### PR TITLE
[FIX] 서비스 Entity 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
@@ -38,11 +38,8 @@ public class Buildings {
 	@Column(nullable = false)
 	private BuildingType buildingType; // 건물 유형
 
-	@Column(nullable = false, length = 100)
-	private String addressRoadName; // 건물 도로명 주소
-
-	@Column(nullable = false, length = 100)
-	private String addressNumber; // 건물 지번 주소
+	@Column(nullable = false, length = 255)
+	private String buildingAddress; // 건물 주소
 
 	@Column(nullable = false)
 	private Point2D.Double buildingCoordinate; // 건물 좌표

--- a/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
@@ -1,6 +1,7 @@
 package JJinBBang.app.domain.building.entity;
 
 import JJinBBang.app.domain.building.enums.ContractType;
+import JJinBBang.app.domain.building.enums.Floor;
 import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.domain.user.entity.Users;
 import jakarta.persistence.*;
@@ -22,12 +23,8 @@ public class Reviews {
     @Column(name="review_id")
     private Long id; // 리뷰 id
 
-    @Column(length = 100)
-    private String block; // 동
-
-    private Integer unit; // 호
-
-    private Integer floor; // 층
+    @Enumerated(EnumType.STRING)
+    private Floor floor; // 층
 
     @Column(nullable = false)
     private ContractType contractType; // 계약 형태
@@ -57,6 +54,9 @@ public class Reviews {
 
     @Column(length = 30)
     private  String tags; // 태그
+
+    @Column(nullable = false)
+    private Double reviewRating; // 후기 평점
 
     // 연관관계 매핑
     // 유저 -> 리뷰

--- a/src/main/java/JJinBBang/app/domain/building/enums/Floor.java
+++ b/src/main/java/JJinBBang/app/domain/building/enums/Floor.java
@@ -1,0 +1,9 @@
+package JJinBBang.app.domain.building.enums;
+
+public enum Floor {
+	BASEMENT, // 반지하
+	LOW,      // 저층
+	MID,      // 중층
+	HIGH,     // 고층
+	ATTIC    // 옥탑
+}


### PR DESCRIPTION
## 📌 이슈 번호
> #17 

## 💬 리뷰 포인트
Review Entity 필드 삭제, 필드 타입 변경, 필드 추가
Building Entity의 두 주소 필드를 하나로 통합

## 🚀 상세 설명
Reviews Entity에서 block(동) 및 unit(호) 필드를 제거하고, 대신 floor(층) 필드를 enum으로 변경하였습니다. 
floor 필드의 타입은 Floor라는 enum 타입으로 정의하였고 가능한 값은 BASEMENT, LOW, MID, HIGH, ATTIC이 있습니다.
Reviews Entity에 reviewRating(후기 평점) 필드를 추가했습니다.
Buildings Entity에 addressRoadName과 addressNumber 두 필드를 하나의 buildingAddress로 통합하였습니다.
buildingAddress는 String 타입이며, db에는 VARCHAR(255)  타입으로 저장됩니다.
## 📸 스크린샷

## 📢 노트

