### PR TITLE
🎨 Chore[#18]: Point2D.Double 이슈로 인한 위도, 경도 컬럼 나누기

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
@@ -42,7 +42,10 @@ public class Buildings {
 	private String buildingAddress; // 건물 주소
 
 	@Column(nullable = false)
-	private Point2D.Double buildingCoordinate; // 건물 좌표
+	private Double buildingLat; // 건물 위도
+
+	@Column(nullable = false)
+	private Double buildingLot; // 건물 경도
 
 	private Double area; // 건물 면적
 

--- a/src/main/java/JJinBBang/app/domain/common/entity/Campuses.java
+++ b/src/main/java/JJinBBang/app/domain/common/entity/Campuses.java
@@ -35,7 +35,10 @@ public class Campuses {
 	private String campusAddress; // 캠퍼스 주소
 
 	@Column(nullable = false)
-	private Point2D.Double campusCoordinate; // 캠퍼스 좌표
+	private Double campusLat; // 캠퍼스 위도
+
+	@Column(nullable = false)
+	private Double campusLot; // 캠퍼스 경도
 
 	private String image; // 캠퍼스 이미지
 


### PR DESCRIPTION
## 📌 이슈 번호
> #18

## 💬 리뷰 포인트
> 기존 좌표를 Point2D.Double 이슈로 인한 위도, 경도 컬럼 분리

## 🚀 상세 설명
기존 좌표를 location으로 두기 위해  Point2D.Double로 선언을 하였으나
JPA 호환성 문제로 위도,경도로 분리하거나 컨버터를 작성해야하는 상황이였습니다.
회의 결과 컨버터 작성시 레이턴시와 자원이 소모될 것 같아 
위도, 경로 컬럼으로 나누기로 결정하였습니다.

## 📸 스크린샷
<img width="334" alt="image" src="https://github.com/user-attachments/assets/9e768d2b-d586-49a8-b4f4-cd438020f4f5" />
<img width="308" alt="image" src="https://github.com/user-attachments/assets/fdecd76a-e344-4dcf-889a-774b38563a02" />



## 📢 노트