### PR TITLE
[FEAT] Security 기초 설정 및 Jwt 토큰 시스템 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	testImplementation 'org.springframework.security:spring-security-test'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.2'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.2'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.2'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.2'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.12.2'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.2'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
@@ -1,0 +1,31 @@
+package JJinBBang.app.domain.user.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.service.UsersService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/user")
+@RequiredArgsConstructor
+public class UsersController {
+
+	private final UsersService usersService;
+
+	@GetMapping("")
+	public String test(@AuthenticationPrincipal Users user) {
+		System.out.println("user.getProviderId() = " + user.getProviderId());
+		return "success";
+	}
+
+	@GetMapping("/all")
+	public String test() {
+		return "success";
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/user/entity/Users.java
+++ b/src/main/java/JJinBBang/app/domain/user/entity/Users.java
@@ -26,7 +26,7 @@ public class Users {
 	@Column(name = "provider", nullable = false)
 	private Provider provider;
 
-	@Column(name = "provider_id", length = 100, nullable = false)
+	@Column(name = "provider_id", length = 100, nullable = false, unique = true)
 	private String providerId;
 
 	@Column(name = "university_email", length = 255)

--- a/src/main/java/JJinBBang/app/domain/user/entity/Users.java
+++ b/src/main/java/JJinBBang/app/domain/user/entity/Users.java
@@ -35,12 +35,12 @@ public class Users {
 	@Column(name = "admission_certificate", length = 225)
 	private String admissionCertificate;
 
+	@Column(name = "admission_certificate_upload_date")
+	private LocalDateTime admissionCertificateUploadDate;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "verification_status", nullable = false)
 	private VerificationStatus verificationStatus;
-
-	@Column(name = "admission_certificate_upload_date")
-	private LocalDateTime admissionCertificateUploadDate;
 
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
@@ -50,8 +50,12 @@ public class Users {
 
 	@PrePersist
 	protected void onCreate() {
+		this.universityEmail = null;
+		this.admissionCertificate = null;
+		this.admissionCertificateUploadDate = null;
 		this.createdAt = LocalDateTime.now();
 		this.verificationStatus = VerificationStatus.UNVERIFIED;
+		this.disabledAt = null;
 	}
 
 	// 연관관계 매핑
@@ -71,4 +75,21 @@ public class Users {
 	// 유저 -> 리뷰-좋아요
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
 	private List<ReviewLikes> reviewLikes = new ArrayList<>();
+
+
+	@Builder
+	private Users(
+		Provider provider,
+		String providerId
+
+	){
+		this.provider = provider;
+		this.providerId = providerId;
+		this.universityEmail = null;
+		this.admissionCertificate = null;
+		this.admissionCertificateUploadDate = null;
+		this.createdAt = LocalDateTime.now();
+		this.verificationStatus = VerificationStatus.UNVERIFIED;
+		this.disabledAt = null;
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/UserNotFoundException.java
@@ -10,4 +10,8 @@ public class UserNotFoundException extends NotFoundGroupException {
 	public static UserNotFoundException notFound(){
 		return new UserNotFoundException("찾으려는 유저가 DB에 존재하지 않습니다.");
 	}
+
+	public static UserNotFoundException searchFailed(){
+		return new UserNotFoundException("유저 조회에 실패하였습니다.");
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.domain.user.exception;
+
+import JJinBBang.app.global.error.exception.NotFoundGroupException;
+
+public class UserNotFoundException extends NotFoundGroupException {
+	public UserNotFoundException(String message) {
+		super(message);
+	}
+
+	public static UserNotFoundException notFound(){
+		return new UserNotFoundException("찾으려는 유저가 DB에 존재하지 않습니다.");
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/user/repository/UsersRepository.java
+++ b/src/main/java/JJinBBang/app/domain/user/repository/UsersRepository.java
@@ -1,0 +1,12 @@
+package JJinBBang.app.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import JJinBBang.app.domain.user.entity.Users;
+
+public interface UsersRepository extends JpaRepository<Users, Long> {
+
+	Optional<Users> findByProviderId(String providerId);
+}

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersService.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersService.java
@@ -1,0 +1,9 @@
+package JJinBBang.app.domain.user.service;
+
+import JJinBBang.app.domain.user.entity.Users;
+
+public interface UsersService {
+	Users findByProviderId(String providerId);
+
+	Users save(Users user);
+}

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -1,0 +1,27 @@
+package JJinBBang.app.domain.user.service;
+
+import org.springframework.stereotype.Service;
+
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UsersServiceImpl implements UsersService {
+
+	private final UsersRepository usersRepository;
+
+	@Override
+	public Users findByProviderId(String providerId) {
+		// 나중에 예외처리 방식 바꿔야 함
+		return usersRepository.findByProviderId(providerId).orElse(null);
+	}
+
+	@Override
+	public Users save(Users user) {
+		return usersRepository.save(user);
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -17,7 +17,14 @@ public class UsersServiceImpl implements UsersService {
 
 	@Override
 	public Users findByProviderId(String providerId) {
-		return usersRepository.findByProviderId(providerId).orElseThrow(UserNotFoundException::notFound);
+		try {
+			return usersRepository.findByProviderId(providerId).orElseThrow(UserNotFoundException::notFound);
+		} catch (UserNotFoundException e) {
+			throw e;
+		} catch (Exception e) {
+			log.error(e.getMessage());
+			throw UserNotFoundException.searchFailed();
+		}
 	}
 
 	@Override

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -3,6 +3,7 @@ package JJinBBang.app.domain.user.service;
 import org.springframework.stereotype.Service;
 
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.exception.UserNotFoundException;
 import JJinBBang.app.domain.user.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,8 +17,7 @@ public class UsersServiceImpl implements UsersService {
 
 	@Override
 	public Users findByProviderId(String providerId) {
-		// 나중에 예외처리 방식 바꿔야 함
-		return usersRepository.findByProviderId(providerId).orElse(null);
+		return usersRepository.findByProviderId(providerId).orElseThrow(UserNotFoundException::notFound);
 	}
 
 	@Override

--- a/src/main/java/JJinBBang/app/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/JJinBBang/app/global/jwt/JwtAuthenticationFilter.java
@@ -2,25 +2,30 @@ package JJinBBang.app.global.jwt;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.common.enums.VerificationStatus;
+import JJinBBang.app.global.error.exception.NotFoundGroupException;
+import JJinBBang.app.global.jwt.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -45,9 +50,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 				// 4. DB에서 유저 정보 조회
 				Users user = usersService.findByProviderId(providerId);
-				if (user == null) {
-					throw new UsernameNotFoundException("해당 사용자를 찾을 수 없습니다.");
-				}
 
 				// 5. SecurityContextHolder에 인증 정보 저장
 				var authentication = new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList());
@@ -56,22 +58,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			// 6. 필터 체인 진행
 			filterChain.doFilter(request, response);
 
-		} catch (Exception e) {
-			// 7. 예외 처리 (필요 시 전역 예외 처리기로 전달 가능)
-			// TODO: 예외 응답 형식 변경해야 함
-			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-			response.setContentType("application/json;charset=UTF-8");
-			response.getWriter().write("{\"error\": \"" + e.getMessage() + "\"}");
+		} catch (InvalidTokenException | NotFoundGroupException e) {
+			makeErrorResponse(e, response);
 		}
 	}
 
+	private void makeErrorResponse(Exception e, HttpServletResponse response) throws IOException {
+		log.error(e.getMessage());
+		response.setContentType("application/json;charset=UTF-8");
+		ObjectMapper mapper = new ObjectMapper();
+		Map<String, Object> errorDetails = new HashMap<>();
 
-	private boolean validateToken(String token) {
-		try {
-			jwtUtils.validateToken(token);
-			return true;
-		} catch (Exception e) {
-			return false;
+		if(e instanceof InvalidTokenException){
+			// 토큰 관련 예외 처리
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+			errorDetails.put("code", HttpServletResponse.SC_UNAUTHORIZED);
+			errorDetails.put("message", e.getMessage());
 		}
+		else if(e instanceof NotFoundGroupException){
+			// 유저 관련 예외 처리
+			response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+
+			errorDetails.put("code", HttpServletResponse.SC_NOT_FOUND);
+			errorDetails.put("message", e.getMessage());
+		}
+
+		response.getWriter().write(mapper.writeValueAsString(errorDetails));
 	}
 }

--- a/src/main/java/JJinBBang/app/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/JJinBBang/app/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,77 @@
+package JJinBBang.app.global.jwt;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.service.UsersService;
+import JJinBBang.app.global.common.enums.VerificationStatus;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtUtils jwtUtils;
+	private final UsersService usersService;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		try {
+			// 1. 토큰 추출
+			String token = jwtUtils.extractToken(request);
+
+			// 2. 토큰 존재 및 검증
+			if (token != null && jwtUtils.validateToken(token)) {
+				// 3. 토큰에서 클레임 추출
+				Claims claims = jwtUtils.parseClaims(token);
+				String providerId = claims.getSubject();
+				VerificationStatus status = VerificationStatus.valueOf(claims.get("verificationStatus", String.class));
+
+				// 4. DB에서 유저 정보 조회
+				Users user = usersService.findByProviderId(providerId);
+				if (user == null) {
+					throw new UsernameNotFoundException("해당 사용자를 찾을 수 없습니다.");
+				}
+
+				// 5. SecurityContextHolder에 인증 정보 저장
+				var authentication = new UsernamePasswordAuthenticationToken(user, null, Collections.emptyList());
+				SecurityContextHolder.getContext().setAuthentication(authentication);
+			}
+			// 6. 필터 체인 진행
+			filterChain.doFilter(request, response);
+
+		} catch (Exception e) {
+			// 7. 예외 처리 (필요 시 전역 예외 처리기로 전달 가능)
+			// TODO: 예외 응답 형식 변경해야 함
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.setContentType("application/json;charset=UTF-8");
+			response.getWriter().write("{\"error\": \"" + e.getMessage() + "\"}");
+		}
+	}
+
+
+	private boolean validateToken(String token) {
+		try {
+			jwtUtils.validateToken(token);
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/JJinBBang/app/global/jwt/JwtUtils.java
+++ b/src/main/java/JJinBBang/app/global/jwt/JwtUtils.java
@@ -1,4 +1,4 @@
-package JJinBBang.app.global.util;
+package JJinBBang.app.global.jwt;
 
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.common.enums.VerificationStatus;
@@ -9,6 +9,7 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -55,10 +56,15 @@ public class JwtUtils {
 	}
 
 
-
-	public String getTokenFromHeader(String authorizationHeader) {
+	public String extractToken(String authorizationHeader) {
 		return authorizationHeader.substring(7);
 	}
+
+	public String extractToken(HttpServletRequest request) {
+		String header = request.getHeader("Authorization");
+		return (header != null && header.startsWith("Bearer ")) ? header.substring(7) : null;
+	}
+
 
 	public String getProviderIdFromToken(String token) {
 		Claims claims = parseClaims(token);
@@ -75,7 +81,7 @@ public class JwtUtils {
 		return parseClaims(token);
 	}
 
-	private Claims parseClaims(String token) {
+	public Claims parseClaims(String token) {
 		return Jwts.parser()
 			.verifyWith(key)
 			.build()
@@ -83,7 +89,7 @@ public class JwtUtils {
 			.getPayload();
 	}
 
-	public void validateToken(String token) {
+	public boolean validateToken(String token) {
 		try {
 			Jwts.parser()
 				.verifyWith(key)
@@ -99,5 +105,6 @@ public class JwtUtils {
 			// throw InvalidTokenException.invalidToken();
 			throw e;
 		}
+		return true;
 	}
 }

--- a/src/main/java/JJinBBang/app/global/jwt/JwtUtils.java
+++ b/src/main/java/JJinBBang/app/global/jwt/JwtUtils.java
@@ -2,13 +2,17 @@ package JJinBBang.app.global.jwt;
 
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.common.enums.VerificationStatus;
+import JJinBBang.app.global.error.exception.AuthGroupException;
+import JJinBBang.app.global.jwt.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -98,12 +102,11 @@ public class JwtUtils {
 				.getPayload();
 		} catch (ExpiredJwtException e) {
 			log.error("JWT expired.");
-			// throw InvalidTokenException.expired();
-			throw e;
-		} catch (UnsupportedJwtException | MalformedJwtException | IllegalArgumentException e) {
+			throw InvalidTokenException.expired();
+		} catch (JwtException | IllegalArgumentException e) {
+			// 토큰 만료 이외의 JWT 오류는 보안상 유효하지 않은 토큰 예외로 통일
 			log.error("Invalid JWT format.");
-			// throw InvalidTokenException.invalidToken();
-			throw e;
+			throw InvalidTokenException.invalidToken();
 		}
 		return true;
 	}

--- a/src/main/java/JJinBBang/app/global/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/JJinBBang/app/global/jwt/exception/InvalidTokenException.java
@@ -1,0 +1,17 @@
+package JJinBBang.app.global.jwt.exception;
+
+import JJinBBang.app.global.error.exception.AuthGroupException;
+
+public class InvalidTokenException extends AuthGroupException {
+	public InvalidTokenException(String message) {
+		super(message);
+	}
+
+	public static InvalidTokenException expired(){
+		return new InvalidTokenException("JWT 토큰이 만료되었습니다.");
+	}
+
+	public static InvalidTokenException invalidToken(){
+		return new InvalidTokenException("유효하지 않은 JWT 토큰입니다.");
+	}
+}

--- a/src/main/java/JJinBBang/app/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/JJinBBang/app/global/security/CustomAccessDeniedHandler.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import JJinBBang.app.global.security.exception.SecurityAuthException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -18,12 +19,15 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 	@Override
 	public void handle(HttpServletRequest request, HttpServletResponse response,
 		AccessDeniedException accessDeniedException) throws IOException {
+
+		SecurityAuthException exception = SecurityAuthException.noPermission(); // 예외 들고오기
+
 		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 		response.setContentType("application/json;charset=UTF-8");
 
 		Map<String, Object> errorDetails = new HashMap<>();
-		errorDetails.put("code", 403);
-		errorDetails.put("message", "해당 요청에 대한 권한이 없습니다."); // TODO : 이메일 관련 메세지로 변경해야 함
+		errorDetails.put("code", HttpServletResponse.SC_FORBIDDEN);
+		errorDetails.put("message", exception.getMessage());
 
 		ObjectMapper mapper = new ObjectMapper();
 		response.getWriter().write(mapper.writeValueAsString(errorDetails));

--- a/src/main/java/JJinBBang/app/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/JJinBBang/app/global/security/CustomAccessDeniedHandler.java
@@ -2,34 +2,101 @@ package JJinBBang.app.global.security;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.security.exception.SecurityAuthException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final SecurityPathProperties securityPathProperties;
+	private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
 	@Override
 	public void handle(HttpServletRequest request, HttpServletResponse response,
 		AccessDeniedException accessDeniedException) throws IOException {
 
-		SecurityAuthException exception = SecurityAuthException.noPermission(); // 예외 들고오기
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		String userVerificationStatus = "UNKNOWN"; // 기본값 설정
+
+		if (authentication != null && authentication.getPrincipal() instanceof Users user) {
+			userVerificationStatus = user.getVerificationStatus().name();
+		}
+
+		String requestURI = request.getRequestURI();
+		String requiredVerificationStatus = getRequiredVerificationStatus(requestURI);
+		String message = getCustomErrorMessage(userVerificationStatus, requiredVerificationStatus);
 
 		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 		response.setContentType("application/json;charset=UTF-8");
 
 		Map<String, Object> errorDetails = new HashMap<>();
 		errorDetails.put("code", HttpServletResponse.SC_FORBIDDEN);
-		errorDetails.put("message", exception.getMessage());
+		errorDetails.put("message", message);
+
+		// 로깅 필요 시 log.error 으로 변경 후 아래 정보 출력?
+		// String username = (authentication != null) ? authentication.getName() : "anonymous";
+		// errorDetails.put("user", username);
+		// errorDetails.put("path", requestURI);
+		// errorDetails.put("verificationStatus", userVerificationStatus);
+		// errorDetails.put("requiredVerificationStatus", requiredVerificationStatus);
 
 		ObjectMapper mapper = new ObjectMapper();
 		response.getWriter().write(mapper.writeValueAsString(errorDetails));
+	}
+
+	/**
+	 * 요청된 URL이 요구하는 verificationStatus 가져오기
+	 */
+	private String getRequiredVerificationStatus(String requestURI) {
+		for (Map.Entry<String, List<String>> entry : securityPathProperties.getVerificationStatusBased().entrySet()) {
+			for (String pattern : entry.getValue()) {
+				if (PATH_MATCHER.match(pattern, requestURI)) {  // ✅ AntPathMatcher 사용하여 와일드카드 패턴 매칭
+					return entry.getKey();
+				}
+			}
+		}
+		return "UNKNOWN";
+	}
+
+	/**
+	 * 현재 verificationStatus와 필요한 verificationStatus를 비교하여 예외 메시지 생성
+	 */
+	private String getCustomErrorMessage(String userStatus, String requiredStatus) {
+		if (!userStatus.equals(requiredStatus)) {
+			switch (requiredStatus) {
+				case "VERIFIED":
+					return SecurityAuthException.universityVerificationRequired().getMessage();
+				case "UNVERIFIED":
+					if ("VERIFIED".equals(userStatus)) {
+						return SecurityAuthException.alreadyUniversityVerified().getMessage();
+					} else if ("PENDING".equals(userStatus)) {
+						return SecurityAuthException.existPendingUnivVerifyRequest().getMessage();
+					}
+				case "PENDING":
+					if ("VERIFIED".equals(userStatus)) {
+						return SecurityAuthException.alreadyUniversityVerified().getMessage();
+					} else if ("UNVERIFIED".equals(userStatus)) {
+						return SecurityAuthException.pendingUnivVerifyRequestNotFound().getMessage();
+					}
+			}
+		}
+		return SecurityAuthException.noPermission().getMessage();
 	}
 }

--- a/src/main/java/JJinBBang/app/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/JJinBBang/app/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package JJinBBang.app.global.security;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException {
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+		response.setContentType("application/json;charset=UTF-8");
+
+		Map<String, Object> errorDetails = new HashMap<>();
+		errorDetails.put("code", 403);
+		errorDetails.put("message", "해당 요청에 대한 권한이 없습니다."); // TODO : 이메일 관련 메세지로 변경해야 함
+
+		ObjectMapper mapper = new ObjectMapper();
+		response.getWriter().write(mapper.writeValueAsString(errorDetails));
+	}
+}

--- a/src/main/java/JJinBBang/app/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/JJinBBang/app/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package JJinBBang.app.global.security;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+		throws IOException {
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType("application/json;charset=UTF-8");
+
+		Map<String, Object> errorDetails = new HashMap<>();
+		errorDetails.put("code", 401);
+		errorDetails.put("message", "인증되지 않은 사용자입니다. 로그인 후 다시 시도하세요.");
+
+		ObjectMapper mapper = new ObjectMapper();
+		response.getWriter().write(mapper.writeValueAsString(errorDetails));
+	}
+
+}

--- a/src/main/java/JJinBBang/app/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/JJinBBang/app/global/security/CustomAuthenticationEntryPoint.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import jakarta.servlet.ServletException;
+import JJinBBang.app.global.security.exception.SecurityAuthException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -20,12 +20,15 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
 		throws IOException {
+
+		SecurityAuthException exception = SecurityAuthException.noAuthentication(); // 예외 들고오기
+
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 		response.setContentType("application/json;charset=UTF-8");
 
 		Map<String, Object> errorDetails = new HashMap<>();
-		errorDetails.put("code", 401);
-		errorDetails.put("message", "인증되지 않은 사용자입니다. 로그인 후 다시 시도하세요.");
+		errorDetails.put("code", HttpServletResponse.SC_UNAUTHORIZED);
+		errorDetails.put("message", exception.getMessage());
 
 		ObjectMapper mapper = new ObjectMapper();
 		response.getWriter().write(mapper.writeValueAsString(errorDetails));

--- a/src/main/java/JJinBBang/app/global/security/SecurityConfig.java
+++ b/src/main/java/JJinBBang/app/global/security/SecurityConfig.java
@@ -1,0 +1,100 @@
+package JJinBBang.app.global.security;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.global.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final SecurityPathProperties securityPathProperties;
+	private final CustomAccessDeniedHandler customAccessDeniedHandler;
+	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+	// CORS 설정
+	CorsConfigurationSource corsConfigurationSource() {
+
+		CorsConfiguration globalConfig = new CorsConfiguration();
+		// globalConfig.setAllowedOrigins(List.of("http://localhost:3000"));
+		globalConfig.setAllowedOrigins(List.of("*")); // 테스트용 TODO: 위에 패턴으로 변경해야 함
+		globalConfig.setAllowedMethods(List.of("GET", "POST", "PATCH", "PUT", "DELETE"));
+		globalConfig.setAllowedHeaders(List.of("Authorization", "Content-Type"));
+		// globalConfig.setAllowedHeaders(List.of("*"));
+		globalConfig.setAllowCredentials(true);
+
+		CorsConfiguration swaggerConfig = new CorsConfiguration();
+		swaggerConfig.addAllowedOriginPattern("*");
+		swaggerConfig.setAllowedMethods(List.of("GET", "POST", "OPTIONS"));
+		swaggerConfig.setAllowedHeaders(List.of("*"));
+		swaggerConfig.setAllowCredentials(true);
+
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", globalConfig);                  // 기본 API 설정
+		source.registerCorsConfiguration("/swagger-ui/**", swaggerConfig);       // Swagger UI 전용 설정
+		source.registerCorsConfiguration("/v3/api-docs/**", swaggerConfig);      // OpenAPI docs 설정
+		return source;
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+		httpSecurity.
+			httpBasic(HttpBasicConfigurer::disable)
+			.cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource())) // CORS 설정 추가
+			.csrf(AbstractHttpConfigurer::disable)
+			.exceptionHandling(ex -> ex
+				.authenticationEntryPoint(customAuthenticationEntryPoint)
+				.accessDeniedHandler(customAccessDeniedHandler)
+			)
+			.authorizeHttpRequests(authorize -> {
+				authorize
+					.requestMatchers(securityPathProperties.getPermitAll().toArray(new String[0])).permitAll()
+					.requestMatchers(securityPathProperties.getAuthenticated().toArray(new String[0])).authenticated()
+					.requestMatchers(securityPathProperties.getAnonymous().toArray(new String[0])).anonymous();
+
+				securityPathProperties.getVerificationStatusBased().forEach((status, paths) ->
+					authorize.requestMatchers(paths.toArray(new String[0]))
+						.access((authentication, context) -> {
+							if (authentication.get().getPrincipal() instanceof Users user) {
+								return new AuthorizationDecision(user.getVerificationStatus().name().equals(status));
+							}
+							return new AuthorizationDecision(false);
+						})
+				);
+
+				switch (securityPathProperties.getAnyRequest()) {
+					case "permit-all":
+						authorize.anyRequest().permitAll();
+						break;
+					case "anonymous":
+						authorize.anyRequest().anonymous();
+						break;
+					case "authenticated":
+					default:
+						authorize.anyRequest().authenticated();
+						break;
+				}
+			})
+			.addFilterAfter(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+		return httpSecurity.build();
+	}
+}

--- a/src/main/java/JJinBBang/app/global/security/SecurityPathProperties.java
+++ b/src/main/java/JJinBBang/app/global/security/SecurityPathProperties.java
@@ -1,0 +1,22 @@
+package JJinBBang.app.global.security;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "security.path")
+public class SecurityPathProperties {
+	private List<String> permitAll;
+	private List<String> authenticated;
+	private List<String> anonymous;
+	private Map<String, List<String>> verificationStatusBased;
+	private String anyRequest;
+}

--- a/src/main/java/JJinBBang/app/global/security/exception/SecurityAuthException.java
+++ b/src/main/java/JJinBBang/app/global/security/exception/SecurityAuthException.java
@@ -14,4 +14,21 @@ public class SecurityAuthException extends AuthGroupException {
 	public static SecurityAuthException noAuthentication() {
 		return new SecurityAuthException("인증되지 않은 사용자입니다. 로그인 후 다시 시도하세요.");
 	}
+
+	public static SecurityAuthException alreadyUniversityVerified(){
+		return new SecurityAuthException("이미 학교 인증이 완료되었습니다.");
+	}
+
+	public static SecurityAuthException universityVerificationRequired() {
+		return new SecurityAuthException("학교 인증이 필요합니다.");
+	}
+
+	public static SecurityAuthException existPendingUnivVerifyRequest() {
+		return new SecurityAuthException("대기 중인 학교 인증 요청이 존재합니다.");
+	}
+
+	public static SecurityAuthException pendingUnivVerifyRequestNotFound() {
+		return new SecurityAuthException("학교 인증 요청이 없습니다.");
+	}
+
 }

--- a/src/main/java/JJinBBang/app/global/security/exception/SecurityAuthException.java
+++ b/src/main/java/JJinBBang/app/global/security/exception/SecurityAuthException.java
@@ -1,0 +1,17 @@
+package JJinBBang.app.global.security.exception;
+
+import JJinBBang.app.global.error.exception.AuthGroupException;
+
+public class SecurityAuthException extends AuthGroupException {
+	public SecurityAuthException(String message) {
+		super(message);
+	}
+
+	public static SecurityAuthException noPermission() {
+		return new SecurityAuthException("해당 요청에 대한 권한이 없습니다.");
+	}
+
+	public static SecurityAuthException noAuthentication() {
+		return new SecurityAuthException("인증되지 않은 사용자입니다. 로그인 후 다시 시도하세요.");
+	}
+}

--- a/src/main/java/JJinBBang/app/global/util/JwtUtils.java
+++ b/src/main/java/JJinBBang/app/global/util/JwtUtils.java
@@ -1,0 +1,103 @@
+package JJinBBang.app.global.util;
+
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.global.common.enums.VerificationStatus;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+@Slf4j
+@Component
+public class JwtUtils {
+
+	private final SecretKey key;
+	private final long accessTokenExpiration;
+	private final long refreshTokenExpiration;
+
+	public JwtUtils(
+		@Value("${jwt.secret}") String secretKey,
+		@Value("${jwt.expiration-time.access-token}") long accessTokenExpiration,
+		@Value("${jwt.expiration-time.refresh-token}") long refreshTokenExpiration
+	) {
+		this.key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+		this.accessTokenExpiration = accessTokenExpiration;
+		this.refreshTokenExpiration = refreshTokenExpiration;
+	}
+
+	public String generateAccessToken(Users user) {
+		return generateToken(user, accessTokenExpiration);
+	}
+
+	public String generateRefreshToken(Users user) {
+		return generateToken(user, refreshTokenExpiration);
+	}
+
+	private String generateToken(Users user, long expirationTime) {
+		return Jwts.builder()
+			.subject(user.getProviderId())
+			.claim("verificationStatus", user.getVerificationStatus().name())
+			.issuedAt(new Date())
+			.expiration(new Date(System.currentTimeMillis() + expirationTime))
+			.signWith(key)
+			.compact();
+	}
+
+
+
+	public String getTokenFromHeader(String authorizationHeader) {
+		return authorizationHeader.substring(7);
+	}
+
+	public String getProviderIdFromToken(String token) {
+		Claims claims = parseClaims(token);
+		return claims.getSubject();
+	}
+
+	public VerificationStatus getVerificationStatus(String token) {
+		String status = parseClaims(token).get("verificationStatus", String.class);
+		return VerificationStatus.valueOf(status);
+	}
+
+
+	public Map<String, Object> extractAllClaimsAsMap(String token) {
+		return parseClaims(token);
+	}
+
+	private Claims parseClaims(String token) {
+		return Jwts.parser()
+			.verifyWith(key)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+
+	public void validateToken(String token) {
+		try {
+			Jwts.parser()
+				.verifyWith(key)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+		} catch (ExpiredJwtException e) {
+			log.error("JWT expired.");
+			// throw InvalidTokenException.expired();
+			throw e;
+		} catch (UnsupportedJwtException | MalformedJwtException | IllegalArgumentException e) {
+			log.error("Invalid JWT format.");
+			// throw InvalidTokenException.invalidToken();
+			throw e;
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,7 +53,7 @@ security:
     permit-all:
       - "/swagger-ui/**"
       - "/v3/api-docs/**"
-      - "/api/v1/user/**"
+#      - "/api/v1/user/**"
 #      - "/api/v1/map/**"
     authenticated:
       - "/api/v1/auth/emailCode"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,3 +47,33 @@ logging:
   level:
     org.hibernate.sql: debug
     org.hibernate.typ e: trace
+
+security:
+  path:
+    permit-all:
+      - "/swagger-ui/**"
+      - "/v3/api-docs/**"
+      - "/api/v1/user/**"
+#      - "/api/v1/map/**"
+    authenticated:
+      - "/api/v1/auth/emailCode"
+      - "/api/v1/auth/emailCode/verify"
+      - "/api/v1/auth/tokenRefresh"
+      - "/api/v1/auth/logout"
+#      - "/api/v1/certificates/**"
+#      - "/api/v1/user/**"
+#      - "/api/v1/building/**"
+#      - "/api/v1/review/**"
+#      - "/api/v1/notification/**"
+    anonymous:
+      - "/api/v1/auth"
+      - "/api/v1/auth/signup"
+    verification-status-based:
+      VERIFIED:
+        - "/api/v1/verifiedTest"
+      UNVERIFIED:
+        - "/api/v1/unverifiedTest"
+      PENDING:
+        - "/api/v1/pendingTest"
+    any-request: "permit-all"  # 'authenticated', 'permit-all', 'anonymous' 중 하나
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,32 @@ spring:
         format_sql: true
     open-in-view: false
 
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${spring.security.oauth2.client.registration.kakao.client-id}
+            client-secret: ${spring.security.oauth2.client.registration.kakao.client-secret}
+            client-authentication-method: ${spring.security.oauth2.client.registration.kakao.client-authentication-method}
+            authorization-grant-type: ${spring.security.oauth2.client.registration.kakao.authorization-grant-type}
+            redirect-uri: ${spring.security.oauth2.client.registration.kakao.redirect-uri}
+            client-name: ${spring.security.oauth2.client.registration.kakao.client-name}
+#            scope: ${spring.security.oauth2.client.registration.kakao.scope} # 필요 시 활성화
+
+        provider:
+          kakao:
+            authorization-uri: ${spring.security.oauth2.client.provider.kakao.authorization-uri}
+            token-uri: ${spring.security.oauth2.client.provider.kakao.token-uri}
+            user-info-uri: ${spring.security.oauth2.client.provider.kakao.user-info-uri}
+            user-name-attribute: ${spring.security.oauth2.client.provider.kakao.user-name-attribute}
+
+jwt:
+  secret: ${jwt.secret}
+  expiration-time:
+    access-token: ${jwt.expiration-time.access-token}
+    refresh-token: ${jwt.expiration-time.refresh-token}
+
 logging:
   level:
     org.hibernate.sql: debug

--- a/src/test/java/JJinBBang/app/global/util/JwtUtilsTest.java
+++ b/src/test/java/JJinBBang/app/global/util/JwtUtilsTest.java
@@ -26,7 +26,7 @@ public class JwtUtilsTest {
 
 	@BeforeEach
 	public void setUp() {
-		long accessTokenExpiration = 1;//1000 * 60 * 60; // 1시간
+		long accessTokenExpiration = 1000 * 60 * 60; // 1시간
 		long refreshTokenExpiration = 1000 * 60 * 60 * 24 * 7; // 7일
 
 		jwtUtils = new JwtUtils(secretKey, accessTokenExpiration, refreshTokenExpiration);
@@ -96,7 +96,7 @@ public class JwtUtilsTest {
 	@Test
 	void validateExpiredTokenTest() throws InterruptedException {
 		JwtUtils shortLivedJwtUtils = new JwtUtils(
-			"b2qzzeohY7dsOBjKDxFDpVb4oXy0KNHVPEZoujByTBSHTpjyjX15jxqZ82ELXX95WTMhVZARzNxcC4ePd49hJg==",
+			secretKey,
 			1000,
 			1000);
 		String token = shortLivedJwtUtils.generateAccessToken(testUser);

--- a/src/test/java/JJinBBang/app/global/util/JwtUtilsTest.java
+++ b/src/test/java/JJinBBang/app/global/util/JwtUtilsTest.java
@@ -4,23 +4,29 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.common.enums.Provider;
-import JJinBBang.app.global.common.enums.VerificationStatus;
+import JJinBBang.app.global.jwt.JwtUtils;
 import io.jsonwebtoken.ExpiredJwtException;
 
 @SpringBootTest
 public class JwtUtilsTest {
+	@Value("${jwt.secret}")
+	private String secretKey;
 
 	private JwtUtils jwtUtils;
 	private Users testUser;
+	@Autowired
+	private UsersService usersService;
 
 	@BeforeEach
 	public void setUp() {
-		String secretKey = "b2qzzeohY7dsOBjKDxFDpVb4oXy0KNHVPEZoujByTBSHTpjyjX15jxqZ82ELXX95WTMhVZARzNxcC4ePd49hJg"; // Base64 encoded key
-		long accessTokenExpiration = 1000 * 60 * 60; // 1시간
+		long accessTokenExpiration = 1;//1000 * 60 * 60; // 1시간
 		long refreshTokenExpiration = 1000 * 60 * 60 * 24 * 7; // 7일
 
 		jwtUtils = new JwtUtils(secretKey, accessTokenExpiration, refreshTokenExpiration);
@@ -28,6 +34,12 @@ public class JwtUtilsTest {
 			.provider(Provider.kakao)
 			.providerId("123541" + Provider.kakao.name())
 			.build();
+		try {
+			testUser = usersService.save(testUser);
+		} catch (Exception e) {
+			System.out.println("e.getMessage() = " + e.getMessage());
+			System.out.println("User already exists");
+		}
 	}
 
 	@Test

--- a/src/test/java/JJinBBang/app/global/util/JwtUtilsTest.java
+++ b/src/test/java/JJinBBang/app/global/util/JwtUtilsTest.java
@@ -1,0 +1,94 @@
+package JJinBBang.app.global.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.global.common.enums.Provider;
+import JJinBBang.app.global.common.enums.VerificationStatus;
+import io.jsonwebtoken.ExpiredJwtException;
+
+@SpringBootTest
+public class JwtUtilsTest {
+
+	private JwtUtils jwtUtils;
+	private Users testUser;
+
+	@BeforeEach
+	public void setUp() {
+		String secretKey = "b2qzzeohY7dsOBjKDxFDpVb4oXy0KNHVPEZoujByTBSHTpjyjX15jxqZ82ELXX95WTMhVZARzNxcC4ePd49hJg"; // Base64 encoded key
+		long accessTokenExpiration = 1000 * 60 * 60; // 1시간
+		long refreshTokenExpiration = 1000 * 60 * 60 * 24 * 7; // 7일
+
+		jwtUtils = new JwtUtils(secretKey, accessTokenExpiration, refreshTokenExpiration);
+		testUser = Users.builder()
+			.provider(Provider.kakao)
+			.providerId("123541" + Provider.kakao.name())
+			.build();
+	}
+
+	@Test
+	public void generateUserTest() {
+		System.out.println(testUser.getProvider());
+		System.out.println(testUser.getProviderId());
+		System.out.println(testUser.getAdmissionCertificate());
+		System.out.println(testUser.getCreatedAt());
+		System.out.println(testUser.getVerificationStatus().name());
+	}
+
+	@Test
+	void generateAccessTokenTest() {
+		String token = jwtUtils.generateAccessToken(testUser);
+		assertNotNull(token);
+		assertFalse(token.isEmpty());
+		System.out.println("token = " + token);
+	}
+
+	@Test
+	void generateRefreshTokenTest() {
+		String token = jwtUtils.generateRefreshToken(testUser);
+		assertNotNull(token);
+		assertFalse(token.isEmpty());
+		System.out.println("token = " + token);
+	}
+
+	@Test
+	void getProviderIdFromTokenTest() {
+		String token = jwtUtils.generateAccessToken(testUser);
+		String providerId = jwtUtils.getProviderIdFromToken(token);
+		assertEquals(testUser.getProviderId(), providerId);
+		System.out.println("providerId = " + providerId);
+	}
+
+	@Test
+	void validateValidTokenTest() {
+		String token = jwtUtils.generateAccessToken(testUser);
+		assertDoesNotThrow(() -> jwtUtils.validateToken(token));
+	}
+
+	@Test
+	void validateInvalidTokenTest() {
+		String invalidToken = "invalid.token.string";
+		assertThrows(RuntimeException.class, () -> jwtUtils.validateToken(invalidToken));
+	}
+
+	@Test
+	void getAuthenticationTest() {
+		String token = jwtUtils.generateAccessToken(testUser);
+		assertEquals(testUser.getVerificationStatus(), jwtUtils.getVerificationStatus(token));
+	}
+
+	@Test
+	void validateExpiredTokenTest() throws InterruptedException {
+		JwtUtils shortLivedJwtUtils = new JwtUtils(
+			"b2qzzeohY7dsOBjKDxFDpVb4oXy0KNHVPEZoujByTBSHTpjyjX15jxqZ82ELXX95WTMhVZARzNxcC4ePd49hJg==",
+			1000,
+			1000);
+		String token = shortLivedJwtUtils.generateAccessToken(testUser);
+		Thread.sleep(1500); // 토큰 만료 대기
+		assertThrows(ExpiredJwtException.class, () -> shortLivedJwtUtils.validateToken(token));
+	}
+}

--- a/src/test/java/JJinBBang/app/global/util/JwtUtilsTest.java
+++ b/src/test/java/JJinBBang/app/global/util/JwtUtilsTest.java
@@ -12,6 +12,7 @@ import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.common.enums.Provider;
 import JJinBBang.app.global.jwt.JwtUtils;
+import JJinBBang.app.global.jwt.exception.InvalidTokenException;
 import io.jsonwebtoken.ExpiredJwtException;
 
 @SpringBootTest
@@ -101,6 +102,6 @@ public class JwtUtilsTest {
 			1000);
 		String token = shortLivedJwtUtils.generateAccessToken(testUser);
 		Thread.sleep(1500); // 토큰 만료 대기
-		assertThrows(ExpiredJwtException.class, () -> shortLivedJwtUtils.validateToken(token));
+		assertThrows(InvalidTokenException.class, () -> shortLivedJwtUtils.validateToken(token));
 	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #13

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요
- 시큐리티 기초 설정과 Jwt 토큰 발급 시스템 개발입니다.
- 유저 생성과 관련해서 현재 작성된 방식으로 생성을 하면 될지 검토 부탁드립니다.
- 또한 각자 기능들을 개발하면서 application.yml에 작성된 security.path 내용의 url 패턴들을 기능에 맞게 설정 부탁드립니다. (추가 개선사항 의견주시면 감사합니다.)
- application-prod.yml에 jwt와 kakao api 관련 필드들을 추가하였습니다.

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요
1. SecurityConfig 기초 세팅
cors 설정 관련
- 현재 개발단계이기 때문에 모든 origin을 허용하도록 설정하였습니다. 추후 프로덕션 시 변경 예정입니다.
- 허용 메소드는 "GET", "POST", "PATCH", "PUT", "DELETE" 으로 설정하였습니다.
- 추가로 swagger 관련해서도 모든 origin을 허용하도록 작성하였습니다.
filter 설정 관련
- url 패턴 작성은 SecurityConfig에서 진행하는것이 아닌 application.yml에서 작성할 수 있도록 구현하였습니다.
- application.yml에서 security.path 필드를 통해 설정이 가능하며 각자 기능 구현 시 적절하게 구현할 수 있도록 하였습니다.
- verification-status-based 필드의 url들은 전부 authenticated가 기본 옵션입니다. 이메일 인증 상태에 따라 다양한 예외 응답을 반환할 수 있도록 구현하였습니다.

url이 요구하는 인증 상태에 따라 유저의 인증 상태가
- VERIFIED가 아닌 경우 → "학교 인증이 필요합니다."
- UNVERIFIED가 아닌 경우 →
    - VERIFIED인 경우 → "이미 학교 인증이 완료되었습니다."
    - PENDING인 경우 → "대기 중인 학교 인증 요청이 존재합니다.”
- PENDING이 아닌 경우 →
    - VERIFIED인 경우 → "이미 학교 인증이 완료되었습니다."
    - UNVERIFIED인 경우 → "학교 인증 요청이 없습니다."

2. Jwt 시스템 기초 세팅
JwtUtil을 통해 엑세스/리프레시 토큰 생성, 검증 등을 수행할 수 있도록 구현하였습니다.
현재 별도로 토큰을 발급받을 수 있는 url은 소셜 로그인 기능이 미구현 상태라 따로 없습니다.
토큰 생성이 필요한 경우 모듈 테스트 디렉토리에서 global.util.JwtUtilsTest.java 객체의
generateAccessTokenTest 함수 실행을 통해 임시 유저객체 생성 및 DB저장 후 토큰 생성을 진행할 수 있습니다.
![image](https://github.com/user-attachments/assets/9830d71f-976b-4f67-b391-e54f560bbc55)

3. Users 엔티티 관련 기초 세팅
UserService, Repository, Controller 생성
!!Users 필드의 providerId 컬럼을 unique 필드로 변경하였습니다!! 초기 엔티티 생성 시 고려를 못했습니다. 죄송합니다.
DB의 Users 테이블을 Drop 후 새로 생성 부탁드립니다 ㅠㅠ

컨트롤러 개발 시 유저 정보를 가져오는 예제를 UsersController에 구현해두었습니다.
해당 예제는 추후 삭제 예정입니다.
![image](https://github.com/user-attachments/assets/f2519899-1391-496d-8021-e7e1fd8a85a6)

4. JwtUtils 관련 모듈 테스트
- generateAccessTokenTest
- generateRefreshTokenTest
- getProviderIdFromTokenTest
- validateValidTokenTest
- validateInvalidTokenTest
- getAuthenticationTest
- validateExpiredTokenTest

5. application-prod.yml
변경 사항들을 노션->백엔드->문서->application-prod.yml 페이지에 추가하였습니다. merge된 후 적용 부탁드립니다.

## 📸 스크린샷

토큰이 정상인 경우 (예제 url)
![image](https://github.com/user-attachments/assets/a47aa87f-b18a-4a18-a703-e4497cedd120)

시큐리티 관련 필터 수행 중 유저 조회 오류 발생
![image](https://github.com/user-attachments/assets/db069f75-6324-48bc-9ada-db9cb9637057)
![image](https://github.com/user-attachments/assets/4b2df996-8689-4ec4-8eb6-63fb09bc6a23)

엑세스 토큰이 만료된 경우
![image](https://github.com/user-attachments/assets/4b869832-6444-4366-bb4d-c99dd3610226)

토큰 포멧 오류
토큰 일부를 지우거나 서명 키 오류 등 각종 토큰 오류 발생 시 해당 예외 반환
![image](https://github.com/user-attachments/assets/9cc242bf-fe9e-4dd7-ba67-4435238a5d1b)

인증이 필요한데 토큰이 없는 경우
![image](https://github.com/user-attachments/assets/1a86bd6d-39d4-4d41-9d8f-498c948852d4)


학교 인증 상태에 따른 오류 반환
url이 요구하는 인증 상태에 따라 유저의 인증 상태가
- VERIFIED가 아닌 경우 → "학교 인증이 필요합니다."
- UNVERIFIED가 아닌 경우 →
    - VERIFIED인 경우 → "이미 학교 인증이 완료되었습니다."
    - PENDING인 경우 → "대기 중인 학교 인증 요청이 존재합니다.”
- PENDING이 아닌 경우 →
    - VERIFIED인 경우 → "이미 학교 인증이 완료되었습니다."
    - UNVERIFIED인 경우 → "학교 인증 요청이 없습니다."
![image](https://github.com/user-attachments/assets/e7c7cf26-806f-4389-b5d5-3ffea5425c05)
![image](https://github.com/user-attachments/assets/48b081dd-df1b-4a84-ac25-1fc35105a599)


JwtUtils 모듈테스트 결과
![image](https://github.com/user-attachments/assets/80892cdc-40d0-4d7a-ab22-0466828bd876)


## 📢 노트
1. Users 필드의 providerId 컬럼을 unique 필드로 변경하게 되어 DB의 Users 테이블을 Drop 후 새로 생성 부탁드립니다 ㅠㅠ
2. application-prod.yml 변경 사항들을 노션->백엔드->문서->application-prod.yml 페이지에 추가하였습니다. merge된 후 적용 부탁드립니다.
3. 엑세스 토큰은 모듈 테스트 객체에서 발급 가능합니다.