### PR TITLE
BaseEntity를 통한 등록 및 수정 시간 추가

### DIFF
--- a/src/main/java/JJinBBang/app/AppApplication.java
+++ b/src/main/java/JJinBBang/app/AppApplication.java
@@ -2,8 +2,10 @@ package JJinBBang.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing // 엔티티 객체가 생성이 되거나 변경이 되었을 때 자동으로 날짜를 매핑
 public class AppApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.domain.common.entity.Campuses;
+import JJinBBang.app.global.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Buildings {
+public class Buildings extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "building_id")

--- a/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
@@ -4,6 +4,7 @@ import JJinBBang.app.domain.building.enums.ContractType;
 import JJinBBang.app.domain.building.enums.Floor;
 import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -16,7 +17,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Reviews {
+public class Reviews extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,14 +35,6 @@ public class Reviews {
     private Integer price; // 월세
 
     private Integer maintenanceCost; // 관리비
-
-    @CreationTimestamp
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt; // 작성일
-
-    @UpdateTimestamp
-    @Column(nullable = false)
-    private LocalDateTime updatedAt; // 수정일
 
     @Column(nullable = false, columnDefinition = "integer default 0")
     private Integer likesCount; // 좋아요 수

--- a/src/main/java/JJinBBang/app/domain/user/entity/Users.java
+++ b/src/main/java/JJinBBang/app/domain/user/entity/Users.java
@@ -10,13 +10,14 @@ import JJinBBang.app.domain.building.entity.Reviews;
 import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.global.common.enums.Provider;
 import JJinBBang.app.global.common.enums.VerificationStatus;
+import JJinBBang.app.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Users {
+public class Users extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "user_id")
@@ -42,9 +43,6 @@ public class Users {
 	@Column(name = "verification_status", nullable = false)
 	private VerificationStatus verificationStatus;
 
-	@Column(name = "created_at", nullable = false, updatable = false)
-	private LocalDateTime createdAt;
-
 	@Column(name = "disabled_at")
 	private LocalDateTime disabledAt;
 
@@ -53,7 +51,6 @@ public class Users {
 		this.universityEmail = null;
 		this.admissionCertificate = null;
 		this.admissionCertificateUploadDate = null;
-		this.createdAt = LocalDateTime.now();
 		this.verificationStatus = VerificationStatus.UNVERIFIED;
 		this.disabledAt = null;
 	}
@@ -88,7 +85,6 @@ public class Users {
 		this.universityEmail = null;
 		this.admissionCertificate = null;
 		this.admissionCertificateUploadDate = null;
-		this.createdAt = LocalDateTime.now();
 		this.verificationStatus = VerificationStatus.UNVERIFIED;
 		this.disabledAt = null;
 	}

--- a/src/main/java/JJinBBang/app/global/entity/BaseEntity.java
+++ b/src/main/java/JJinBBang/app/global/entity/BaseEntity.java
@@ -16,7 +16,7 @@ import lombok.Getter;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 	@CreatedDate
-	@Column(nullable = false)
+	@Column(nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
 	@LastModifiedDate

--- a/src/main/java/JJinBBang/app/global/entity/BaseEntity.java
+++ b/src/main/java/JJinBBang/app/global/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package JJinBBang.app.global.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+	@CreatedDate
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(nullable = false)
+	private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 📌 이슈 번호
> #35

## 💬 리뷰 포인트
> 등록 및 수정시간 추가를 위한 BaseEntity 구현과 각 Entity의 적용

## 🚀 상세 설명
Building 엔티티의 경우 좋아요 수, 후기 수, 이미지 수 등과 도로명 주소를 통해
사용자가 Building 정보를 입력할 가능성이 생겼기에 Building 엔티티에 등록 및 수정 시간 컬럼을 추가를 결정하며
기존 User, Review도 등록, 수정 시간을 가지고 있었기에 BaseEntity을 통해 
전체적으로 구조적 안정을 가지면 좋을 것 같아 구현을 하였습니다.

EnableJpaAuditing 어노테이션을 이용하여 수정이 이뤄질떄마다 업데이트가 되도록 하였고,
각 User, Review, Building Entity에 적용을 완료하였습니다.

## 📸 스크린샷
> User Entity
<img width="304" alt="image" src="https://github.com/user-attachments/assets/0a807705-5682-4bc0-8ea0-da3285eb75f4" />

> Review Entity
<img width="303" alt="image" src="https://github.com/user-attachments/assets/f99f2dd2-47f0-4cae-af67-ccb335d6d112" />

> Building Entity
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a2ade644-9bc1-4736-aff8-287ffaeb383d" />


## 📢 노트