### PR TITLE
[FEAT #48] 기획 수정에 따른 관련 엔티티 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/entity/Agencies.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Agencies.java
@@ -1,0 +1,53 @@
+package JJinBBang.app.domain.building.entity;
+
+import JJinBBang.app.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Agencies extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "agency_id")
+	private Long agencyId;
+
+	@Column(name = "agency_serial")
+	private Long agencySerial;
+
+	@Column(name = "name", length = 255, nullable = false)
+	private String name;
+
+	@Column(name = "address", length = 255, nullable = false)
+	private String address;
+
+	@Column(name = "agency_lat", nullable = false)
+	private Double agencyLat;
+
+	@Column(name = "agency_lot", nullable = false)
+	private Double agencyLot;
+
+	@Column(name = "rating", precision = 3, scale = 2, nullable = false)
+	private BigDecimal rating;
+
+	@Column(name = "like_count", nullable = false)
+	private Integer likeCount;
+
+	@Column(name = "review_count", nullable = false)
+	private Integer reviewCount;
+
+	@Column(name = "images_count", nullable = false)
+	private Integer imagesCount;
+
+	// 공인중개사 -> 공인중개사-좋아요
+	@OneToMany(mappedBy = "agency", cascade = CascadeType.ALL)
+	private List<AgencyLikes> agencyLikes = new ArrayList<>();
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/AgencyLikeId.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/AgencyLikeId.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.domain.building.entity;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+
+@Embeddable
+@EqualsAndHashCode
+public class AgencyLikeId implements Serializable {
+    private Long agencyId;
+    private Long userId;
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/AgencyLikes.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/AgencyLikes.java
@@ -1,0 +1,25 @@
+package JJinBBang.app.domain.building.entity;
+
+import JJinBBang.app.domain.user.entity.Users;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AgencyLikes {
+    @EmbeddedId
+    private AgencyLikeId id;
+
+    @MapsId("agencyId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "agency_id", nullable = false)
+    private Agencies agency;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/AgencyReviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/AgencyReviews.java
@@ -1,0 +1,9 @@
+package JJinBBang.app.domain.building.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "agency_reviews")
+@PrimaryKeyJoinColumn(name = "review_id")
+public class AgencyReviews extends Reviews {
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/AgencyReviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/AgencyReviews.java
@@ -5,5 +5,6 @@ import jakarta.persistence.*;
 @Entity
 @Table(name = "agency_reviews")
 @PrimaryKeyJoinColumn(name = "review_id")
+@DiscriminatorValue("AGENCY")
 public class AgencyReviews extends Reviews {
 }

--- a/src/main/java/JJinBBang/app/domain/building/entity/DormFacility.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/DormFacility.java
@@ -1,0 +1,34 @@
+package JJinBBang.app.domain.building.entity;
+
+import JJinBBang.app.domain.building.enums.UsageType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "dorm_facilities")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DormFacility {
+
+    @EmbeddedId
+    private DormFacilityId id;
+
+    // PK(review_id) → Reviews 엔티티와 N:1
+    @MapsId("reviewId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "review_id")
+    private Reviews review;
+
+    // PK(facility_id) → Facility 엔티티와 N:1
+    @MapsId("facilityId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "facility_id")
+    private Facility facility;
+
+    @Column(name = "available", nullable = false)
+    private Boolean available;      // TINYINT(1) → Boolean
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "usage_type", length = 7)
+    private UsageType usageType;    // ENUM('private','public')
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/DormFacilityId.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/DormFacilityId.java
@@ -1,0 +1,19 @@
+package JJinBBang.app.domain.building.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DormFacilityId implements Serializable {
+    @Column(name = "review_id")
+    private Long reviewId;
+
+    @Column(name = "facility_id")
+    private Long facilityId;
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/DormReviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/DormReviews.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 @Entity
 @Table(name = "dorm_reviews")
 @PrimaryKeyJoinColumn(name = "review_id")
+@DiscriminatorValue("DORM")
 public class DormReviews extends Reviews {
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/JJinBBang/app/domain/building/entity/DormReviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/DormReviews.java
@@ -1,0 +1,26 @@
+package JJinBBang.app.domain.building.entity;
+
+import JJinBBang.app.domain.building.enums.Floor;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "dorm_reviews")
+@PrimaryKeyJoinColumn(name = "review_id")
+public class DormReviews extends Reviews {
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Floor floor;
+
+	@Column(nullable = false)
+	private Integer capacity;
+
+	@Column(name = "dorm_fee", nullable = false)
+	private Integer dormFee;
+
+	@Column(name = "current_region", length = 255)
+	private String currentRegion;
+
+	@Column(name = "current_grade", nullable = true)
+	private Double currentGrade;
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/Facility.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Facility.java
@@ -1,0 +1,24 @@
+package JJinBBang.app.domain.building.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "facilities")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Facility {
+
+    @Id
+    @Column(name = "facility_id")
+    private Long facilityId;                    // 편의시설 종류 고유 식별자
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;                        // 편의시설 이름
+
+    @OneToMany(mappedBy = "facility", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DormFacility> dormFacilities = new ArrayList<>();
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/GeneralReviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/GeneralReviews.java
@@ -1,0 +1,31 @@
+package JJinBBang.app.domain.building.entity;
+
+import JJinBBang.app.domain.building.enums.ContractType;
+import JJinBBang.app.domain.building.enums.Floor;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "general_reviews")
+@PrimaryKeyJoinColumn(name = "review_id")
+public class GeneralReviews extends Reviews {
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private Floor floor;
+
+	@Column(nullable = false)
+	private Double area;            // DECIMAL(5,2) → double OK
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "contract_type", nullable = false)
+	private ContractType contractType;
+
+	@Column(nullable = true)
+	private Integer deposit;
+
+	@Column(nullable = true)
+	private Integer price;
+
+	@Column(name = "maintenance_cost", nullable = true)
+	private Integer maintenanceCost;
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/GeneralReviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/GeneralReviews.java
@@ -7,14 +7,14 @@ import jakarta.persistence.*;
 @Entity
 @Table(name = "general_reviews")
 @PrimaryKeyJoinColumn(name = "review_id")
+@DiscriminatorValue("GENERAL")
 public class GeneralReviews extends Reviews {
-
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private Floor floor;
 
 	@Column(nullable = false)
-	private Double area;            // DECIMAL(5,2) → double OK
+	private Double area;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "contract_type", nullable = false)

--- a/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.domain.building.entity;
 
+import JJinBBang.app.domain.building.enums.ReviewType;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -13,12 +14,18 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "DTYPE", discriminatorType = DiscriminatorType.STRING)
 public class Reviews extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="review_id")
     private Long id; // 리뷰 id
+
+    // DTYPE 컬럼 읽기 전용으로만 맵핑
+    @Enumerated(EnumType.STRING)
+    @Column(name="DTYPE", insertable = false, updatable = false)
+    private ReviewType dtype;
 
     @Column(name = "likes_count", nullable = false, columnDefinition = "integer default 0")
     private Integer likesCount; // 좋아요 수

--- a/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
@@ -1,22 +1,18 @@
 package JJinBBang.app.domain.building.entity;
 
-import JJinBBang.app.domain.building.enums.ContractType;
-import JJinBBang.app.domain.building.enums.Floor;
-import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 
-import java.time.LocalDateTime;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.JOINED)
 public class Reviews extends BaseEntity {
 
     @Id
@@ -24,22 +20,10 @@ public class Reviews extends BaseEntity {
     @Column(name="review_id")
     private Long id; // 리뷰 id
 
-    @Enumerated(EnumType.STRING)
-    private Floor floor; // 층
-
-    @Column(nullable = false)
-    private ContractType contractType; // 계약 형태
-
-    private Integer deposit; // 보증금
-
-    private Integer price; // 월세
-
-    private Integer maintenanceCost; // 관리비
-
-    @Column(nullable = false, columnDefinition = "integer default 0")
+    @Column(name = "likes_count", nullable = false, columnDefinition = "integer default 0")
     private Integer likesCount; // 좋아요 수
 
-    @Column(nullable = false,length = 2083)
+    @Column(name = "thumbnail_image", nullable = false, length = 2083)
     private String thumbnailImage; // 썸네일 이미지
 
     @Column(nullable = false)
@@ -48,8 +32,8 @@ public class Reviews extends BaseEntity {
     @Column(length = 30)
     private  String tags; // 태그
 
-    @Column(nullable = false)
-    private Double reviewRating; // 후기 평점
+    @Column(name = "rating", precision = 3, scale = 2, nullable = false)
+    private BigDecimal rating; // 후기 평점
 
     // 연관관계 매핑
     // 유저 -> 리뷰
@@ -59,16 +43,15 @@ public class Reviews extends BaseEntity {
 
     // 건물 -> 리뷰
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "building_id", nullable = false)
+    @JoinColumn(name = "building_id", nullable = true)
     private Buildings building; // 건물 id
 
-    // 대학교 -> 리뷰
+    // 공인중개사 -> 리뷰
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "university_id", nullable = false)
-    private Universities university; // 대학교 id
+    @JoinColumn(name = "agency_id", nullable = true)
+    private Agencies agency; // 공인중개사 id
 
     // 리뷰 -> 리뷰 좋아요
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
     private List<ReviewLikes> reviewLikes = new ArrayList<>();
-
 }

--- a/src/main/java/JJinBBang/app/domain/building/enums/ReviewType.java
+++ b/src/main/java/JJinBBang/app/domain/building/enums/ReviewType.java
@@ -1,0 +1,10 @@
+package JJinBBang.app.domain.building.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ReviewType {
+    GENERAL,
+    DORM,
+    AGENCY
+}

--- a/src/main/java/JJinBBang/app/domain/building/enums/UsageType.java
+++ b/src/main/java/JJinBBang/app/domain/building/enums/UsageType.java
@@ -1,0 +1,8 @@
+package JJinBBang.app.domain.building.enums;
+
+// UsageType: 사용 타입
+// 기숙사 시설 사용 타입을 명시
+public enum UsageType {
+    PRIVATE, // 개인용
+    PUBLIC // 공용
+}

--- a/src/main/java/JJinBBang/app/domain/user/entity/Users.java
+++ b/src/main/java/JJinBBang/app/domain/user/entity/Users.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import JJinBBang.app.domain.building.entity.AgencyLikes;
 import JJinBBang.app.domain.building.entity.BuildingLikes;
 import JJinBBang.app.domain.building.entity.ReviewLikes;
 import JJinBBang.app.domain.building.entity.Reviews;
@@ -76,6 +77,9 @@ public class Users extends BaseEntity {
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
 	private List<ReviewLikes> reviewLikes = new ArrayList<>();
 
+	// 유저 -> 공인중개사-좋아요
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+	private List<AgencyLikes> agencyLikes = new ArrayList<>();
 
 	@Builder
 	private Users(

--- a/src/main/java/JJinBBang/app/domain/user/entity/Users.java
+++ b/src/main/java/JJinBBang/app/domain/user/entity/Users.java
@@ -30,6 +30,9 @@ public class Users extends BaseEntity {
 	@Column(name = "provider_id", length = 100, nullable = false, unique = true)
 	private String providerId;
 
+	@Column(name = "student_number", length = 50, nullable = true)
+	private String studentNumber;
+
 	@Column(name = "university_email", length = 255)
 	private String universityEmail;
 


### PR DESCRIPTION
## 📌 이슈 번호
> #48

## 💬 리뷰 포인트
- Users에 `studentNumber` 필드 추가  
- Agencies 엔티티 및 AgencyLikes 관계 추가  
- Reviews 상속 구조(JOINED) 도입 및 General/Agency/Dorm 서브클래스 엔티티 추가  
- Facility 엔티티 추가  
- DormFacility/DormFacilityId 및 UsageType(enum) 정의 및 매핑  
- Reviews에 리뷰 유형을 나타내는 dtype 필드 추가

## 🚀 상세 설명
1. **Users**  
   - `studentNumber` 컬럼 추가

2. **Agencies & AgencyLikes**  
   - `Agencies` 엔티티 생성
   - `AgencyLikeId`(@Embeddable 복합키)  생성
   - `AgencyLikes`(@EmbeddedId + @MapsId 매핑) 생성

3. **Reviews 상속 구조 및 서브클래스**  
   - `Reviews ` 엔티티 `@Inheritance(strategy = JOINED)` 적용  
   - `GeneralReviews`, `AgencyReviews`, `DormReviews` 생성
   - 리뷰 유형 나타내는 dtype 필드 추가

4. **Facility, DormFacility**  
   - `Facility` 엔티티 생성
   - `DormFacilityId`(@Embeddable 복합키)  생성
   - `DormFacility`(@EmbeddedId + @MapsId 매핑)  생성
   - `UsageType` enum 정의
