### PR TITLE
[Feat #51] 이메일 인증 기반 시스템 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/JJinBBang/app/global/error/ControllerAdvice.java
+++ b/src/main/java/JJinBBang/app/global/error/ControllerAdvice.java
@@ -2,6 +2,7 @@ package JJinBBang.app.global.error;
 
 import java.util.Objects;
 
+import JJinBBang.app.global.error.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -10,15 +11,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import JJinBBang.app.global.error.dto.ErrorResponse;
-import JJinBBang.app.global.error.exception.AccessDeniedGroupException;
-import JJinBBang.app.global.error.exception.AuthGroupException;
-import JJinBBang.app.global.error.exception.ConflictGroupException;
-import JJinBBang.app.global.error.exception.InvalidGroupException;
-import JJinBBang.app.global.error.exception.ManyRequestsGroupException;
-import JJinBBang.app.global.error.exception.NotFoundGroupException;
-import JJinBBang.app.global.error.exception.TeapotGroupException;
-import JJinBBang.app.global.error.exception.TimeoutGroupException;
-import JJinBBang.app.global.error.exception.UnprocessableGroupException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -76,6 +68,12 @@ public class ControllerAdvice {
 	@ExceptionHandler({ManyRequestsGroupException.class})
 	public ResponseEntity<ErrorResponse> handleManyRequest(RuntimeException e) {
 		return createErrorResponse(e, HttpStatus.TOO_MANY_REQUESTS);
+	}
+
+	// 500, InternalServerError (이메일 전송 과정에서 발생하는 오류를 위해 추가)
+	@ExceptionHandler({InternalServerErrorGroupException.class})
+	public ResponseEntity<ErrorResponse> handleInternalServerDate(RuntimeException e) {
+		return createErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
 	// 메서드 인자 문제 생겼을 때

--- a/src/main/java/JJinBBang/app/global/error/ControllerAdvice.java
+++ b/src/main/java/JJinBBang/app/global/error/ControllerAdvice.java
@@ -72,7 +72,7 @@ public class ControllerAdvice {
 
 	// 500, InternalServerError (이메일 전송 과정에서 발생하는 오류를 위해 추가)
 	@ExceptionHandler({InternalServerErrorGroupException.class})
-	public ResponseEntity<ErrorResponse> handleInternalServerErrorHandler(RuntimeException e) {
+	public ResponseEntity<ErrorResponse> handleInternalServerError(RuntimeException e) {
 		return createErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 

--- a/src/main/java/JJinBBang/app/global/error/ControllerAdvice.java
+++ b/src/main/java/JJinBBang/app/global/error/ControllerAdvice.java
@@ -72,7 +72,7 @@ public class ControllerAdvice {
 
 	// 500, InternalServerError (이메일 전송 과정에서 발생하는 오류를 위해 추가)
 	@ExceptionHandler({InternalServerErrorGroupException.class})
-	public ResponseEntity<ErrorResponse> handleInternalServerDate(RuntimeException e) {
+	public ResponseEntity<ErrorResponse> handleInternalServerErrorHandler(RuntimeException e) {
 		return createErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 

--- a/src/main/java/JJinBBang/app/global/error/exception/InternalServerErrorGroupException.java
+++ b/src/main/java/JJinBBang/app/global/error/exception/InternalServerErrorGroupException.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.global.error.exception;
+
+public abstract class InternalServerErrorGroupException extends RuntimeException {
+    public InternalServerErrorGroupException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/JJinBBang/app/global/mail/exception/MailAuthException.java
+++ b/src/main/java/JJinBBang/app/global/mail/exception/MailAuthException.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.global.mail.exception;
+
+import JJinBBang.app.global.error.exception.AuthGroupException;
+
+public class MailAuthException extends AuthGroupException {
+    public MailAuthException(String message) {
+        super(message);
+    }
+
+    public static MailAuthException notMatchAuthCode() {
+        return new MailAuthException("인증 코드가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/JJinBBang/app/global/mail/exception/MailInternalException.java
+++ b/src/main/java/JJinBBang/app/global/mail/exception/MailInternalException.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.global.mail.exception;
+
+import JJinBBang.app.global.error.exception.InternalServerErrorGroupException;
+
+public class MailInternalException extends InternalServerErrorGroupException {
+    public MailInternalException(String message) {
+        super(message);
+    }
+
+    public static MailInternalException sendFail(){
+        return new MailInternalException("메일 전송에 실패하였습니다.");
+    }
+}

--- a/src/main/java/JJinBBang/app/global/mail/exception/MailInvalidException.java
+++ b/src/main/java/JJinBBang/app/global/mail/exception/MailInvalidException.java
@@ -1,0 +1,21 @@
+package JJinBBang.app.global.mail.exception;
+
+import JJinBBang.app.global.error.exception.InvalidGroupException;
+
+public class MailInvalidException extends InvalidGroupException {
+    public MailInvalidException(String message) {
+        super(message);
+    }
+
+    public static MailInvalidException invalidEmailFormat() {
+        return new MailInvalidException("유효하지 않은 이메일 형식 입니다.");
+    }
+
+    public static MailInvalidException invalidEmailDomain() {
+        return new MailInvalidException("유효하지 않은 이메일 도메인 입니다.");
+    }
+
+    public static RuntimeException notFoundAuthCode() {
+        return new MailInvalidException("인증 코드가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/JJinBBang/app/global/mail/properties/MailAuthProperties.java
+++ b/src/main/java/JJinBBang/app/global/mail/properties/MailAuthProperties.java
@@ -1,0 +1,29 @@
+package JJinBBang.app.global.mail.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "mail-auth")
+public class MailAuthProperties {
+    //mail-auth.expiration-time
+    private long expirationTime;
+
+    //mail-auth.auth-code-length
+    private int authCodeLength;
+
+    //mail-auth.allowed-domain
+    private List<String> allowedDomain;
+
+    //mail-auth.subject-text
+    private String subjectText;
+
+    //mail-auth.body-text
+    private String bodyText;
+}

--- a/src/main/java/JJinBBang/app/global/mail/repository/EmailAuthCodeRepository.java
+++ b/src/main/java/JJinBBang/app/global/mail/repository/EmailAuthCodeRepository.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.global.mail.repository;
+
+import java.util.Optional;
+
+public interface EmailAuthCodeRepository {
+    void save(String email, String authCode);
+
+    boolean isExistByEmail(String email);
+
+    Optional<String> findAuthCodeByEmail(String email);
+
+    void deleteByEmail(String email);
+}

--- a/src/main/java/JJinBBang/app/global/mail/repository/InMemoryEmailAuthCodeRepository.java
+++ b/src/main/java/JJinBBang/app/global/mail/repository/InMemoryEmailAuthCodeRepository.java
@@ -1,0 +1,71 @@
+package JJinBBang.app.global.mail.repository;
+
+import JJinBBang.app.global.mail.properties.MailAuthProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Repository("inMemoryEmailAuthCodeRepository")
+public class InMemoryEmailAuthCodeRepository implements EmailAuthCodeRepository {
+
+    private final long expirationTime;
+    private final Map<String, EmailAuthInfo> emailAuthCodeMap = new ConcurrentHashMap<>();
+
+    public InMemoryEmailAuthCodeRepository(MailAuthProperties props) {
+        this.expirationTime = props.getExpirationTime() * 60_000;
+    }
+
+    @Override
+    public void save(String email, String authCode) {
+        EmailAuthInfo info = new EmailAuthInfo(authCode, System.currentTimeMillis());
+        EmailAuthInfo prev = emailAuthCodeMap.putIfAbsent(email, info);
+        if (prev != null) {
+            throw new DuplicateKeyException("Duplicate key: " + email);
+        }
+    }
+
+    @Override
+    public boolean isExistByEmail(String email) {
+        EmailAuthInfo info = emailAuthCodeMap.get(email);
+        return info != null && !isExpired(info.timestamp);
+    }
+
+    @Override
+    public Optional<String> findAuthCodeByEmail(String email) {
+        EmailAuthInfo info = emailAuthCodeMap.get(email);
+        if (info == null) {
+            return Optional.empty();
+        }
+        if (isExpired(info.timestamp)) {
+            emailAuthCodeMap.remove(email);
+            return Optional.empty();
+        }
+        return Optional.of(info.code);
+    }
+
+    @Override
+    public void deleteByEmail(String email) {
+        emailAuthCodeMap.remove(email);
+    }
+
+    private boolean isExpired(long timestamp) {
+        return System.currentTimeMillis() - timestamp >= expirationTime;
+    }
+
+    // 주기적으로 만료된 인증 코드 정리 (예: 1분마다)
+    @Scheduled(fixedDelay = 60 * 1000) // 1분 간격
+    public void cleanUpExpiredCodes() {
+        emailAuthCodeMap.entrySet().removeIf(entry ->
+                isExpired(entry.getValue().timestamp)
+        );
+    }
+
+    // 내부 저장용 클래스
+    private record EmailAuthInfo(String code, long timestamp) { }
+}

--- a/src/main/java/JJinBBang/app/global/mail/service/MailAuthService.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/MailAuthService.java
@@ -1,0 +1,26 @@
+package JJinBBang.app.global.mail.service;
+
+import JJinBBang.app.global.mail.exception.MailInternalException;
+import JJinBBang.app.global.mail.exception.MailInvalidException;
+
+public interface MailAuthService {
+
+    /**
+     * 주어진 이메일로 인증 코드를 생성해서 전송합니다.
+     *
+     * @param email 인증 코드를 받을 이메일 주소
+     * @throws MailInternalException  메일 발송 실패 등의 내부 오류
+     * @throws MailInvalidException  이메일 형식 또는 도메인 검증 실패
+     */
+    void sendAuthCode(String email);
+
+    /**
+     * 사용자가 제출한 인증 코드가 저장된 코드와 일치하는지 검증합니다.
+     *
+     * @param email    인증 대상 이메일
+     * @param authCode 사용자 입력 코드
+     * @return 검증 성공 시 true, 실패 또는 만료 시 false
+     * @throws MailInvalidException  코드 미발급·만료
+     */
+    boolean verifyAuthCode(String email, String authCode);
+}

--- a/src/main/java/JJinBBang/app/global/mail/service/MailSendService.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/MailSendService.java
@@ -1,0 +1,5 @@
+package JJinBBang.app.global.mail.service;
+
+public interface MailSendService {
+    void sendMail(String toEmail, String subject, String body);
+}

--- a/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
@@ -1,0 +1,87 @@
+package JJinBBang.app.global.mail.service.impl;
+
+import JJinBBang.app.global.mail.exception.MailInvalidException;
+import JJinBBang.app.global.mail.properties.MailAuthProperties;
+import JJinBBang.app.global.mail.repository.EmailAuthCodeRepository;
+import JJinBBang.app.global.mail.service.MailAuthService;
+import JJinBBang.app.global.mail.service.MailSendService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailAuthServiceImpl implements MailAuthService {
+    private final MailAuthProperties properties;
+    private final Random random = new Random();
+    private final MailSendService mailSendService;
+    private final EmailAuthCodeRepository emailAuthCodeRepository;
+
+    @Override
+    public void sendAuthCode(String toEmail) {
+        validateEmail(toEmail);
+
+        String authCode = generateAuthCode();
+        saveAuthCode(toEmail, authCode);
+
+        mailSendService.sendMail(toEmail, properties.getSubjectText(), buildEmailBody(authCode));
+    }
+
+    @Override
+    public boolean verifyAuthCode(String email, String authCode) {
+        String savedAuthCode = emailAuthCodeRepository.findAuthCodeByEmail(email)
+                .orElseThrow(MailInvalidException::notFoundAuthCode);
+        return savedAuthCode.equals(authCode);
+    }
+
+
+    // utility --------------------------------------------------------------------------------------------------------
+    public String generateAuthCode() {
+        // emailAuthCodeLength 자리 숫자로 구성된 인증 코드 생성
+        // 앞자리 0이 있어도 텍스트로 생성
+        StringBuilder code = new StringBuilder();
+        for (int i = 0; i < properties.getAuthCodeLength(); i++) {
+            code.append(random.nextInt(10));
+        }
+        return code.toString();
+    }
+
+    public void saveAuthCode(String email, String authCode) {
+        if(emailAuthCodeRepository.isExistByEmail(email)) {
+            // 이미 인증 코드가 발급된 이메일인 경우
+            log.info("이미 인증 코드가 발급된 이메일입니다. [email: {}]. 기존 인증 코드를 삭제합니다.", email);
+            emailAuthCodeRepository.deleteByEmail(email);
+        }
+        emailAuthCodeRepository.save(email, authCode);
+    }
+
+    private String buildEmailBody(String code) {
+        return String.format(properties.getBodyText(), code, properties.getExpirationTime());
+    }
+    // ----------------------------------------------------------------------------------------------------------------
+
+    // validator ------------------------------------------------------------------------------------------------------
+    private void validateEmail(String email) {
+        if (!isValidFormat(email)) {
+            throw MailInvalidException.invalidEmailFormat();
+        }
+        if (!properties.getAllowedDomain().contains(extractDomain(email))) {
+            throw MailInvalidException.invalidEmailDomain();
+        }
+    }
+
+    private boolean isValidFormat(String email) {
+        return email != null && email.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+    }
+
+    private String extractDomain(String email) {
+        int atIdx = email.lastIndexOf("@");
+        return (atIdx != -1 && atIdx < email.length() - 1)
+                ? email.substring(atIdx + 1)
+                : "";
+    }
+    // ----------------------------------------------------------------------------------------------------------------
+}

--- a/src/main/java/JJinBBang/app/global/mail/service/impl/MailSendServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/impl/MailSendServiceImpl.java
@@ -1,0 +1,31 @@
+package JJinBBang.app.global.mail.service.impl;
+
+import JJinBBang.app.global.mail.exception.MailInternalException;
+import JJinBBang.app.global.mail.service.MailSendService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailSendServiceImpl implements MailSendService {
+
+    private final JavaMailSender mailSender;
+
+    @Override
+    public void sendMail(String toEmail, String subject, String body) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setSubject(subject);
+        message.setText(body);
+
+        try {
+            mailSender.send(message);
+        } catch (Exception e) {
+            throw MailInternalException.sendFail();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,8 +62,8 @@ jwt:
     signup-token: ${jwt.expiration-time.signup-token}
 
 mail-auth:
-  expiration-time: ${mail-auth.code.expiration-time}
-  auth-code-length: ${mail-auth.code.length}
+  expiration-time: ${mail-auth.expiration-time}
+  auth-code-length: ${mail-auth.auth-code-length}
   allowed-domain:
     - gnu.ac.kr
     - gmail.com

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,12 +37,39 @@ spring:
             user-info-uri: ${spring.security.oauth2.client.provider.kakao.user-info-uri}
             user-name-attribute: ${spring.security.oauth2.client.provider.kakao.user-name-attribute}
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${spring.mail.username}
+    password: ${spring.mail.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          ssl:
+            trust:
+              smtp.gmail.com
+            protocols:
+              TLSv1.2
+
 jwt:
   secret: ${jwt.secret}
   expiration-time:
     access-token: ${jwt.expiration-time.access-token}
     refresh-token: ${jwt.expiration-time.refresh-token}
     signup-token: ${jwt.expiration-time.signup-token}
+
+mail-auth:
+  expiration-time: ${mail-auth.code.expiration-time}
+  auth-code-length: ${mail-auth.code.length}
+  allowed-domain:
+    - gnu.ac.kr
+    - gmail.com
+  # docker-compose.yml에서 관리할 수 있도록 환경변수로 설정함
+  subject-text: "[찐빵] 이메일 인증코드"
+  body-text: "찐빵 이메일 인증 코드입니다.\n\n아래 인증 코드를 입력하여 이메일 인증을 완료해주세요.\n\n인증 코드: %s\n\n이 코드는 %s분간 유효합니다."
 
 logging:
   level:

--- a/src/test/java/JJinBBang/app/global/mail/MailAuthServiceImplTest.java
+++ b/src/test/java/JJinBBang/app/global/mail/MailAuthServiceImplTest.java
@@ -1,0 +1,104 @@
+package JJinBBang.app.global.mail;
+
+import JJinBBang.app.global.mail.exception.MailInvalidException;
+import JJinBBang.app.global.mail.properties.MailAuthProperties;
+import JJinBBang.app.global.mail.repository.EmailAuthCodeRepository;
+import JJinBBang.app.global.mail.service.MailSendService;
+import JJinBBang.app.global.mail.service.impl.MailAuthServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class MailAuthServiceImplTest {
+
+    @Mock
+    MailAuthProperties props;
+    @Mock
+    EmailAuthCodeRepository repo;
+    @Mock
+    MailSendService mailSender;
+
+    @InjectMocks
+    MailAuthServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        // 공통 스텁: 도메인 검사, 코드 길이, 제목·본문 포맷
+        when(props.getAllowedDomain()).thenReturn(List.of("gnu.ac.kr"));
+        when(props.getAuthCodeLength()).thenReturn(4);
+        when(props.getSubjectText()).thenReturn("[찐빵] 인증코드");
+        when(props.getBodyText()).thenReturn("코드: %s (유효:%s분)");
+        when(props.getExpirationTime()).thenReturn(5L);
+    }
+
+    @Test
+    void sendAuthCode_성공() {
+        String email = "user@gnu.ac.kr";
+
+        // isExistByEmail 기본 false → save, sendMail 호출 검증
+        service.sendAuthCode(email);
+
+        verify(repo).save(eq(email), anyString());
+        verify(mailSender).sendMail(
+                eq(email),
+                eq("[찐빵] 인증코드"),
+                contains("코드:")  // 본문에 코드가 포함되어야 함
+        );
+    }
+
+    @Test
+    void sendAuthCode_도메인불일치_예외() {
+        // 허용된 도메인이 아니면
+        String badEmail = "user@naver.com";
+
+        // MailInvalidException 발생해야 함
+        assertThrows(MailInvalidException.class,
+                () -> service.sendAuthCode(badEmail));
+    }
+
+    @Test
+    void verifyAuthCode_일치() {
+        // u@gnu.ac.kr 로 발급된 인증코드가 1234일 때
+        when(repo.findAuthCodeByEmail("u@gnu.ac.kr"))
+                .thenReturn(Optional.of("1234"));
+
+        // 검증할 인증코드가 1234이면 true 리턴
+        assertTrue(service.verifyAuthCode("u@gnu.ac.kr", "1234"));
+    }
+
+    @Test
+    void verifyAuthCode_불일치() {
+        // u@gnu.ac.kr 로 발급된 인증코드가 9999일 때
+        when(repo.findAuthCodeByEmail("u@gnu.ac.kr"))
+                .thenReturn(Optional.of("9999"));
+
+        // 검증할 인증코드가 1234이면 false 리턴
+        assertFalse(service.verifyAuthCode("u@gnu.ac.kr", "1234"));
+    }
+
+    @Test
+    void verifyAuthCode_미발급_예외() {
+        // x@gnu.ac.kr 으로 조회 시 Optional.empty 가 리턴되면
+        when(repo.findAuthCodeByEmail("x@gnu.ac.kr"))
+                .thenReturn(Optional.empty());
+
+        // x@gnu.ac.kr 으로 인증코드 검사 수행 시 MailInvalidException 발생해야 함
+        assertThrows(MailInvalidException.class,
+                () -> service.verifyAuthCode("x@gnu.ac.kr", "0000"));
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
> ex) #1

Close #51

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요

- 이메일 인증 기능을 위한 전체적인 구조 도입
- 인증 코드 저장소 + 인메모리 구현체 적용
- 메일 전송, 인증 관련 예외 처리 추가
- 테스트 코드 작성

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

1. 이메일 인증 기능 전반 구축
- `MailAuthService`와 `MailSendService`를 중심으로 이메일 인증을 위한 서비스 계층을 구성하였습니다.
- 인증 코드는 무작위 숫자로 생성되며, 메일 전송 시 설정된 형식의 텍스트와 함께 발송됩니다.

2. 인증 코드 저장소 인메모리 구현체 도입
- `EmailAuthCodeRepository` 인터페이스와 `InMemoryEmailAuthCodeRepository` 구현체를 통해 인증 코드를 저장하고 만료시간을 기준으로 주기적 정리를 수행합니다.
- 인메모리 구현체는 최대한 Redis 환경과 유사하도록 모방하여 구현하였습니다.

3. 예외 처리 및 에러 그룹 확장
- 인증 코드 불일치, 이메일 형식 오류, 도메인 오류 등의 예외를 위한 `MailAuthException`, `MailInvalidException` 추가
- 메일 전송 실패 시 대응할 `MailInternalException` 및 이를 처리할 `InternalServerErrorGroupException` 도입

4. 설정 파일(application.yml) 변경
- SMTP 설정, 인증 메일 제목·본문 포맷, 유효 시간, 허용 도메인 등 `mail-auth` 관련 설정 추가
- application.yml 환경변수를 통해 인증코드 만료시간, 인증코드 숫자 길이, 허용 이메일 도메인, 이메일 내용 등을 관리할 수 있습니다.

5. 테스트 코드 작성
- `MailAuthServiceImplTest`를 통해 인증 코드 전송 성공/실패, 검증 성공/실패 시나리오를 테스트해보았습니다.

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/ba39da04-bf8e-4a84-9ace-eb9b82cb2840)

Test 객체 실행 시 No matching tests found in any candidate test task. 오류 발생하면 아래 설정에서 Run tests using을 IntelliJ IDEA로 수정하시면 됩니다.
![image](https://github.com/user-attachments/assets/63b36cc9-e2ca-4ae5-84cc-3d726c7f27d6)

다음 이슈에서 실제 API를 구현하도록 하겠습니다.

## 📢 노트