### PR TITLE
[Feat #41] 건물에 대한 리뷰 목록 조회 API 구현

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/controller/BuildingController.java
+++ b/src/main/java/JJinBBang/app/domain/building/controller/BuildingController.java
@@ -20,7 +20,7 @@ import JJinBBang.app.global.template.ResTemplate;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/building")
+@RequestMapping("/api/v1/building")
 @RequiredArgsConstructor
 public class BuildingController {
 	private final BuildingService buildingService;

--- a/src/main/java/JJinBBang/app/domain/building/controller/BuildingController.java
+++ b/src/main/java/JJinBBang/app/domain/building/controller/BuildingController.java
@@ -1,14 +1,21 @@
 package JJinBBang.app.domain.building.controller;
 
 import JJinBBang.app.domain.building.service.AgencyService;
-import lombok.NonNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import JJinBBang.app.domain.building.dto.BuildingDetailResponse;
+import JJinBBang.app.domain.building.dto.PageRequest;
+import JJinBBang.app.domain.building.dto.ReviewSummaryResponse;
 import JJinBBang.app.domain.building.service.BuildingService;
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.building.service.ReviewService;
+import JJinBBang.app.domain.common.dto.PaginatedResponse;
 import JJinBBang.app.global.template.ResTemplate;
 import lombok.RequiredArgsConstructor;
 
@@ -18,11 +25,12 @@ import lombok.RequiredArgsConstructor;
 public class BuildingController {
 	private final BuildingService buildingService;
 	private final AgencyService agencyService;
+	private final ReviewService reviewService;
 
 	@GetMapping("/{buildingId}")
 	public ResTemplate<BuildingDetailResponse> getBuildingDetail(
 			@PathVariable Long buildingId,
-			@NonNull @RequestParam Boolean isAgency,
+			@RequestParam(defaultValue = "false") Boolean isAgency,
 			@AuthenticationPrincipal Users user
 			) {
 
@@ -33,5 +41,17 @@ public class BuildingController {
 			data = buildingService.getBuildingDetail(buildingId, user);
 		}
 		return new ResTemplate<>(HttpStatus.OK, "건물 상세 불러오기 성공", data);
+	}
+
+	@GetMapping("/{buildingId}/review")
+	public ResTemplate<PaginatedResponse<ReviewSummaryResponse>> getBuildingReview(
+		@PathVariable Long buildingId,
+		@AuthenticationPrincipal Users user,
+		PageRequest pageRequest,
+		@RequestParam(defaultValue = "false") Boolean isAgency
+	) {
+
+		PaginatedResponse<ReviewSummaryResponse> data = reviewService.getReviewList(buildingId, isAgency, user, pageRequest);
+		return new ResTemplate<>(HttpStatus.OK, "조회 성공", data);
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/dto/PageRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/PageRequest.java
@@ -1,0 +1,56 @@
+package JJinBBang.app.domain.building.dto;
+
+import org.springframework.data.domain.AbstractPageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import JJinBBang.app.domain.common.enums.SortType;
+import lombok.Getter;
+
+@Getter
+public class PageRequest extends AbstractPageRequest {
+	private final Integer num;
+	private final Integer page;
+	private final SortType sortBy;
+
+	public PageRequest(Integer page,
+		Integer num,
+		SortType sortBy) {
+		super(
+			page != null ? page : 0,
+			num   != null ? num   : 10
+		);
+		this.page   = page   != null ? page   : 0;
+		this.num    = num    != null ? num    : 10;
+		this.sortBy = sortBy != null ? sortBy : SortType.LATEST;
+	}
+
+	@Override
+	public Sort getSort() {
+		return switch (sortBy) {
+			case LATEST -> Sort.by("createdAt").descending();
+			case LIKES -> Sort.by("likesCount").descending();
+			case STARS -> Sort.by("rating").descending();
+		};
+	}
+
+	@Override
+	public Pageable withPage(int pageNumber) {
+		return new PageRequest(pageNumber, this.num, this.sortBy);
+	}
+
+	@Override
+	public Pageable next() {
+		return withPage(getPage() + 1);
+	}
+
+	@Override
+	public Pageable previous() {
+		return withPage(getPage() - 1);
+	}
+
+	@Override
+	public Pageable first() {
+		return withPage(0);
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/ReviewSummaryResponse.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/ReviewSummaryResponse.java
@@ -1,0 +1,56 @@
+package JJinBBang.app.domain.building.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import JJinBBang.app.domain.building.entity.AgencyReviews;
+import JJinBBang.app.domain.building.entity.DormReviews;
+import JJinBBang.app.domain.building.entity.GeneralReviews;
+import JJinBBang.app.domain.building.entity.ReviewDetails;
+import JJinBBang.app.domain.building.entity.Reviews;
+import JJinBBang.app.domain.building.exception.ReviewInternalException;
+import JJinBBang.app.global.common.dto.AgencyReviewInfo;
+import JJinBBang.app.global.common.dto.DormitoryReviewInfo;
+import JJinBBang.app.global.common.dto.GeneralReviewInfo;
+import JJinBBang.app.global.common.dto.ReviewInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewSummaryResponse {
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		private final GeneralReviewInfo generalReviewInfo;
+
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		private final DormitoryReviewInfo dormitoryReviewInfo;
+
+		@JsonInclude(JsonInclude.Include.NON_NULL)
+		private final AgencyReviewInfo agencyReviewInfo;
+
+		private final ReviewInfo reviewInfo;
+		private final String image;
+
+		public static ReviewSummaryResponse of(Reviews review, Boolean like, ReviewDetails reviewDetail) {
+			GeneralReviewInfo generalReviewInfo = null;
+			DormitoryReviewInfo dormitoryReviewInfo = null;
+			AgencyReviewInfo agencyReviewInfo = null;
+
+			if (review instanceof GeneralReviews generalReview) {
+				generalReviewInfo = GeneralReviewInfo.of(generalReview, reviewDetail, like);
+			} else if (review instanceof DormReviews dormitoryReview) {
+				dormitoryReviewInfo = DormitoryReviewInfo.of(dormitoryReview, like);
+			} else if (review instanceof AgencyReviews agencyReview) {
+				agencyReviewInfo = AgencyReviewInfo.of(agencyReview, like);
+			} else {
+				throw new ReviewInternalException();
+			}
+
+			return ReviewSummaryResponse.builder()
+				.generalReviewInfo(generalReviewInfo)
+				.dormitoryReviewInfo(dormitoryReviewInfo)
+				.agencyReviewInfo(agencyReviewInfo)
+				.reviewInfo(ReviewInfo.of(review))
+				.image(review.getThumbnailImage())
+				.build();
+		}
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/ReviewDetails.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/ReviewDetails.java
@@ -1,0 +1,37 @@
+package JJinBBang.app.domain.building.entity;
+
+import java.util.List;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import JJinBBang.app.domain.building.enums.BuildingType;
+import JJinBBang.app.global.common.dto.Keywords;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Document(collection = "review_details")
+public class ReviewDetails {
+	@Id
+	private ObjectId id;
+
+	@Field(name = "review_id")
+	private Long reviewId;
+
+	@Field(name = "building_id")
+	private Long buildingId;
+
+	@Field(name = "building_type")
+	private BuildingType buildingType;
+
+	private List<String> images;
+
+	@Field(name = "image_count")
+	private Integer imageCount;
+
+	private Keywords keywords;
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
@@ -2,12 +2,14 @@ package JJinBBang.app.domain.building.entity;
 
 import JJinBBang.app.domain.building.enums.ReviewType;
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.global.common.enums.KeywordType;
 import JJinBBang.app.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Entity
@@ -61,4 +63,9 @@ public class Reviews extends BaseEntity {
     // 리뷰 -> 리뷰 좋아요
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
     private List<ReviewLikes> reviewLikes = new ArrayList<>();
+
+    public List<KeywordType> getTags() {
+        return Arrays.stream(tags.split(","))
+            .map(x->KeywordType.valueOf(x.trim())).toList();
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/building/exception/ReviewDetailInternalException.java
+++ b/src/main/java/JJinBBang/app/domain/building/exception/ReviewDetailInternalException.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.domain.building.exception;
+
+import JJinBBang.app.global.error.exception.InternalServerErrorGroupException;
+
+public class ReviewDetailInternalException extends InternalServerErrorGroupException {
+	public ReviewDetailInternalException(String message) {
+		super(message);
+	}
+
+	public ReviewDetailInternalException(long reviewId) {
+		super("등록된 리뷰 상세 정보가 없습니다. reviewId=" + reviewId);
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/exception/ReviewInternalException.java
+++ b/src/main/java/JJinBBang/app/domain/building/exception/ReviewInternalException.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.domain.building.exception;
+
+import JJinBBang.app.global.error.exception.InternalServerErrorGroupException;
+
+public class ReviewInternalException extends InternalServerErrorGroupException {
+	public ReviewInternalException(String message) {
+		super(message);
+	}
+
+	public ReviewInternalException() {
+		super("잘못된 리뷰 유형입니다.");
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/repository/ReviewDetailRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/ReviewDetailRepository.java
@@ -1,0 +1,15 @@
+package JJinBBang.app.domain.building.repository;
+
+import java.util.Optional;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import JJinBBang.app.domain.building.entity.ReviewDetails;
+
+@Repository
+public interface ReviewDetailRepository extends MongoRepository<ReviewDetails, ObjectId> {
+
+	Optional<ReviewDetails> findByReviewId(Long reviewId);
+}

--- a/src/main/java/JJinBBang/app/domain/building/repository/ReviewRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/ReviewRepository.java
@@ -1,0 +1,16 @@
+package JJinBBang.app.domain.building.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import JJinBBang.app.domain.building.entity.Agencies;
+import JJinBBang.app.domain.building.entity.Buildings;
+import JJinBBang.app.domain.building.entity.Reviews;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Reviews, Long> {
+	Page<Reviews> findAllByBuilding(Buildings building, Pageable pageable);
+	Page<Reviews> findAllByAgency(Agencies agency, Pageable pageable);
+}

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewService.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewService.java
@@ -1,0 +1,10 @@
+package JJinBBang.app.domain.building.service;
+
+import JJinBBang.app.domain.building.dto.PageRequest;
+import JJinBBang.app.domain.building.dto.ReviewSummaryResponse;
+import JJinBBang.app.domain.common.dto.PaginatedResponse;
+import JJinBBang.app.domain.user.entity.Users;
+
+public interface ReviewService {
+	PaginatedResponse<ReviewSummaryResponse> getReviewList(Long buildingId, Boolean isAgency, Users user, PageRequest pageRequest);
+}

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -1,0 +1,56 @@
+package JJinBBang.app.domain.building.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import JJinBBang.app.domain.building.dto.PageRequest;
+import JJinBBang.app.domain.building.dto.ReviewSummaryResponse;
+import JJinBBang.app.domain.building.entity.Agencies;
+import JJinBBang.app.domain.building.entity.Buildings;
+import JJinBBang.app.domain.building.entity.ReviewDetails;
+import JJinBBang.app.domain.building.entity.Reviews;
+import JJinBBang.app.domain.building.exception.BuildingNullException;
+import JJinBBang.app.domain.building.exception.ReviewDetailInternalException;
+import JJinBBang.app.domain.building.repository.AgencyRepository;
+import JJinBBang.app.domain.building.repository.BuildingRepository;
+import JJinBBang.app.domain.building.repository.ReviewDetailRepository;
+import JJinBBang.app.domain.building.repository.ReviewRepository;
+import JJinBBang.app.domain.common.dto.PaginatedResponse;
+import JJinBBang.app.domain.user.entity.Users;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService{
+	private final ReviewRepository reviewRepository;
+	private final ReviewDetailRepository reviewDetailRepository;
+	private final AgencyRepository agencyRepository;
+	private final BuildingRepository buildingRepository;
+
+	@Override
+	@Transactional(readOnly = true)
+	public PaginatedResponse<ReviewSummaryResponse> getReviewList(Long buildingId, Boolean isAgency, Users user, PageRequest pageRequest) {
+
+		Page<Reviews> reviewPage;
+		if(isAgency) {
+			Agencies agency = agencyRepository.findById(buildingId).orElseThrow(BuildingNullException::new);
+			reviewPage = reviewRepository.findAllByAgency(agency, pageRequest);
+		} else {
+			Buildings building = buildingRepository.findById(buildingId).orElseThrow(BuildingNullException::new);
+			reviewPage = reviewRepository.findAllByBuilding(building, pageRequest);
+		}
+
+		return PaginatedResponse.of(
+			reviewPage,
+			(review -> {
+				Boolean liked = review.getReviewLikes().stream().anyMatch(reviewLike -> reviewLike.getUser().equals(user));
+				return ReviewSummaryResponse.of(review, liked, getReviewDetail(review.getId()));
+			})
+		);
+	}
+
+	private ReviewDetails getReviewDetail(Long reviewId) {
+		return reviewDetailRepository.findByReviewId(reviewId).orElseThrow(() -> new ReviewDetailInternalException(reviewId));
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/common/dto/PaginatedResponse.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/PaginatedResponse.java
@@ -1,0 +1,44 @@
+package JJinBBang.app.domain.common.dto;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+
+import lombok.Builder;
+
+@Builder
+public record PaginatedResponse<T>(
+	int num,		// 불러온 개수
+	int page,		// 현재 페이지
+	Long itemNum,	// 전체 검색 결과 수
+	List<T> items	// 제네릭 타입 리스트
+) {
+
+	public static <T> PaginatedResponse<T> of(Page<T> page) {
+		return PaginatedResponse.<T>builder()
+			.num(page.getNumberOfElements())
+			.page(page.getNumber())
+			.itemNum(page.getTotalElements())
+			.items(page.getContent())
+			.build();
+	}
+
+	public static <E, T> PaginatedResponse<T> of(
+		Page<E> page,
+		Function<? super E, ? extends T> mapper
+	) {
+		List<T> mapped = page.getContent()
+			.stream()
+			.map(mapper)
+			.collect(Collectors.toList());
+
+		return PaginatedResponse.<T>builder()
+			.num(mapped.size())
+			.page(page.getNumber())
+			.itemNum(page.getTotalElements())
+			.items(mapped)
+			.build();
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/common/enums/SortType.java
+++ b/src/main/java/JJinBBang/app/domain/common/enums/SortType.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.domain.common.enums;
+
+public enum SortType {
+	LATEST,	// 최신순
+	LIKES,	// 좋아요순
+	STARS	// 별점순
+}

--- a/src/main/java/JJinBBang/app/global/common/dto/AgencyReviewInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/AgencyReviewInfo.java
@@ -2,16 +2,17 @@ package JJinBBang.app.global.common.dto;
 
 import JJinBBang.app.domain.building.entity.Agencies;
 import JJinBBang.app.domain.building.entity.Reviews;
+import JJinBBang.app.domain.building.entity.AgencyReviews;
+import JJinBBang.app.domain.building.enums.BuildingType;
 import lombok.Builder;
 
 import java.math.BigDecimal;
-import java.util.List;
 
 @Builder
 public record AgencyReviewInfo(
         Long id,
         String name,
-        List<String> type,
+        BuildingType type,
         BigDecimal rating,
         Boolean liked
 ) {
@@ -19,10 +20,19 @@ public record AgencyReviewInfo(
         return AgencyReviewInfo.builder()
                 .id(reviews.getId())
                 .name(agencies.getName())
-                .type(List.of("공인중개사"))
+                .type(BuildingType.AGENCY)
                 .rating(agencies.getRating())
                 .liked(liked)
                 .build();
 
     }
+	public static AgencyReviewInfo of(AgencyReviews agencyReview, Boolean liked) {
+		return AgencyReviewInfo.builder()
+			.id(agencyReview.getId())
+			.name(agencyReview.getAgency().getName())
+			.type(BuildingType.AGENCY)
+			.rating(agencyReview.getRating())
+			.liked(liked)
+			.build();
+	}
 }

--- a/src/main/java/JJinBBang/app/global/common/dto/DormitoryReviewInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/DormitoryReviewInfo.java
@@ -1,30 +1,30 @@
 package JJinBBang.app.global.common.dto;
 
 import JJinBBang.app.domain.building.entity.Buildings;
+import java.math.BigDecimal;
+
 import JJinBBang.app.domain.building.entity.DormReviews;
+import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.domain.building.enums.Floor;
 import lombok.Builder;
 
-import java.math.BigDecimal;
-import java.util.List;
-
 @Builder
 public record DormitoryReviewInfo(
-        Long id,
-        String name,
-        List<String> type,
-        String universityName,
-        Floor floor,
-        Integer capacity,
-        Integer dormFee,
-        BigDecimal rating,
-        Boolean liked
+		Long id,
+		String name,
+		BuildingType type,
+		String universityName,
+		Floor floor,
+		Integer capacity,
+		Integer dormFee,
+		BigDecimal rating,
+		Boolean liked
 ) {
     public static DormitoryReviewInfo of(DormReviews dormReviews,Buildings building,String universityName, Boolean liked) {
         return DormitoryReviewInfo.builder()
                 .id(dormReviews.getId())
                 .name(building.getBuildingName())
-                .type(List.of("기숙사"))
+                .type(BuildingType.DORMITORY)
                 .universityName(universityName)
                 .floor(dormReviews.getFloor())
                 .capacity(dormReviews.getCapacity())
@@ -33,4 +33,17 @@ public record DormitoryReviewInfo(
                 .liked(liked)
                 .build();
     }
+	public static DormitoryReviewInfo of(DormReviews dormitoryReview, Boolean liked) {
+			return DormitoryReviewInfo.builder()
+				.id(dormitoryReview.getId())
+				.name(dormitoryReview.getBuilding().getBuildingName())
+				.type(BuildingType.DORMITORY)
+				.universityName(dormitoryReview.getBuilding().getCampus().getUniversity().getUniversityName())
+				.floor(dormitoryReview.getFloor())
+				.capacity(dormitoryReview.getCapacity())
+				.dormFee(dormitoryReview.getDormFee())
+				.rating(dormitoryReview.getRating())
+				.liked(liked)
+				.build();
+		}
 }

--- a/src/main/java/JJinBBang/app/global/common/dto/GeneralReviewInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/GeneralReviewInfo.java
@@ -2,44 +2,56 @@ package JJinBBang.app.global.common.dto;
 
 import JJinBBang.app.domain.building.entity.Buildings;
 import JJinBBang.app.domain.building.entity.GeneralReviews;
+import JJinBBang.app.domain.building.entity.ReviewDetails;
 import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.domain.building.enums.ContractType;
-import JJinBBang.app.domain.building.enums.Floor;
-import JJinBBang.app.domain.building.enums.ReviewType;
-import lombok.Builder;
-
 import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
+
+import JJinBBang.app.domain.building.enums.Floor;
+import lombok.Builder;
 
 @Builder
 public record GeneralReviewInfo(
-        Long id,
-        String name,
-        List<BuildingType> type,
-        ContractType contractType,
-        Integer deposit,
-        Integer monthlyRent,
-        Floor floor,
-        Double space,
-        Integer maintenanceCost,
-        BigDecimal rating,
-        Boolean liked
+		Long id,
+		String name,
+		BuildingType type,
+		ContractType contractType,
+		Integer deposit,
+		Integer monthlyRent,
+		Floor floor,
+		Double space,
+		Integer maintenanceCost,
+		BigDecimal rating,
+		Boolean liked
 ) {
-    public static GeneralReviewInfo of(GeneralReviews generalReview, Buildings building, Boolean liked) {
-        return GeneralReviewInfo.builder()
-                .id(generalReview.getId())
-                .name(building.getBuildingName())
-                .type(building.getBuildingType())
-                .contractType(generalReview.getContractType())
-                .deposit(generalReview.getDeposit())
-                .monthlyRent(generalReview.getPrice())
-                .floor(generalReview.getFloor())
-                .space(generalReview.getArea())
-                .maintenanceCost(generalReview.getMaintenanceCost())
-                .rating(generalReview.getRating())
-                .liked(liked)
-                .build();
-    }
+	public static GeneralReviewInfo of(GeneralReviews generalReview, ReviewDetails reviewDetail, Boolean liked) {
+		return GeneralReviewInfo.builder()
+			.id(generalReview.getId())
+			.name(generalReview.getBuilding().getBuildingName())
+			.type(reviewDetail.getBuildingType())
+			.contractType(generalReview.getContractType())
+			.deposit(generalReview.getDeposit())
+			.monthlyRent(generalReview.getPrice())
+			.floor(generalReview.getFloor())
+			.space(generalReview.getArea())
+			.maintenanceCost(generalReview.getMaintenanceCost())
+			.rating(generalReview.getRating())
+			.liked(liked)
+			.build();
+	}
+	public static GeneralReviewInfo of(GeneralReviews generalReview, Buildings building, Boolean liked) {
+		return GeneralReviewInfo.builder()
+			.id(generalReview.getId())
+			.name(building.getBuildingName())
+			.type(building.getBuildingType().getFirst())
+			.contractType(generalReview.getContractType())
+			.deposit(generalReview.getDeposit())
+			.monthlyRent(generalReview.getPrice())
+			.floor(generalReview.getFloor())
+			.space(generalReview.getArea())
+			.maintenanceCost(generalReview.getMaintenanceCost())
+			.rating(generalReview.getRating())
+			.liked(liked)
+			.build();
+	}
 }

--- a/src/main/java/JJinBBang/app/global/common/dto/Keywords.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/Keywords.java
@@ -1,0 +1,11 @@
+package JJinBBang.app.global.common.dto;
+
+import java.util.List;
+
+import JJinBBang.app.global.common.enums.KeywordType;
+
+public record Keywords (
+	List<KeywordType> positive,
+	List<KeywordType> negative
+) {
+}

--- a/src/main/java/JJinBBang/app/global/common/dto/ReviewInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/ReviewInfo.java
@@ -2,7 +2,6 @@ package JJinBBang.app.global.common.dto;
 
 import JJinBBang.app.domain.building.entity.Agencies;
 import JJinBBang.app.domain.building.entity.Buildings;
-import JJinBBang.app.domain.building.entity.GeneralReviews;
 import JJinBBang.app.domain.building.entity.Reviews;
 import lombok.Builder;
 
@@ -10,25 +9,27 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
+import JJinBBang.app.global.common.enums.KeywordType;
+
 @Builder
 public record ReviewInfo(
         String content,
-        List<String> keyword,
+        List<KeywordType> keyword,
         Integer likeCount,
         LocalDateTime updateAt
 ) {
-    public static ReviewInfo of(Reviews review) {
-        return ReviewInfo.builder()
-                .content(review.getContent())
-                .keyword(Arrays.asList("PO_LO_01", "PO_MT_01", "PO_MT_04"))
-                .likeCount(review.getLikesCount())
-                .updateAt(review.getUpdatedAt())
-                .build();
-    }
+	public static ReviewInfo of(Reviews review) {
+		return ReviewInfo.builder()
+			.content(review.getContent())
+			.keyword(review.getTags())
+			.likeCount(review.getLikesCount())
+			.updateAt(review.getUpdatedAt())
+			.build();
+	}
     public static ReviewInfo ofBuilding(Reviews review, Buildings building) {
         return ReviewInfo.builder()
                 .content(review.getContent())
-                .keyword(Arrays.asList("PO_LO_01", "PO_MT_01", "PO_MT_04"))
+                .keyword(Arrays.asList(KeywordType.PO_LO_01, KeywordType.PO_MT_01, KeywordType.PO_MT_04))
                 .likeCount(building.getLikeCount())
                 .updateAt(review.getUpdatedAt())
                 .build();
@@ -37,7 +38,7 @@ public record ReviewInfo(
     public static ReviewInfo ofAgency(Reviews review, Agencies agency) {
         return ReviewInfo.builder()
             .content(review.getContent())
-            .keyword(Arrays.asList("PO_LO_01", "PO_MT_01", "PO_MT_04"))
+            .keyword(Arrays.asList(KeywordType.PO_LO_01, KeywordType.PO_MT_01, KeywordType.PO_MT_04))
             .likeCount(agency.getLikeCount())
             .updateAt(review.getUpdatedAt())
             .build();


### PR DESCRIPTION
## 📌 이슈 번호

\#41

## 💬 리뷰 포인트

* `Reviews` 엔티티에 `getTags()` 추가하여 `tags` 문자열을 `KeywordType` 리스트로 변환
* `GeneralReviewInfo`, `DormitoryReviewInfo`, `AgencyReviewInfo` DTO의 `type` 필드를 `List<String>` 또는 문자열에서 `BuildingType` Enum으로 통일하고, 엔티티 기반의 `of(...)` 팩토리 메서드 오버로드 추가
* `ReviewInfo` DTO의 `keyword` 필드를 `List<String>`에서 `List<KeywordType>`으로 변경하고 동적 태그 매핑 적용
* `Keywords` 컴포넌트 추가로 긍정·부정 키워드 그룹화
* `ReviewDetails` MongoDB 문서 엔티티 및 `ReviewDetailRepository` 추가
* `ReviewRepository`에 건물·공인중개사별 페이징 조회 메서드(`findAllByBuilding`, `findAllByAgency`) 추가
* `ReviewSummaryResponse` DTO로 리뷰 요약 매핑 로직 구현
* `ReviewService` 인터페이스 및 `ReviewServiceImpl` 구현체에서 페이징, 정렬(`SortType`), 유저 좋아요 여부, 리뷰 상세 조회 로직 추가
* `PageRequest`/`PaginatedResponse` DTO 도입으로 페이징 및 정렬 지원
* `BuildingController`에 `/building/{buildingId}/review` 리뷰 조회 API 엔드포인트 추가
* 리뷰 조회 실패(`ReviewDetailInternalException`), 잘못된 리뷰 유형(`ReviewInternalException`) 예외 클래스 추가

## 🚀 상세 설명

1. **엔티티 확장**

   * `Reviews`에 `getTags()` 메서드 추가: 저장된 `tags` 문자열을 `KeywordType` Enum으로 파싱
2. **DTO 리팩토링**

   * `GeneralReviewInfo`, `DormitoryReviewInfo`, `AgencyReviewInfo` 타입 필드를 `BuildingType` Enum으로 변경
   * 각 DTO에 `ReviewDetails` 또는 JPA 엔티티 기반 `of(...)` 메서드 오버로드 추가
3. **키워드 관리**

   * `ReviewInfo` DTO에서 하드코딩된 키워드를 제거하고, `review.getTags()`를 사용하도록 변경
   * `Keywords` 레코드 추가로 긍정(`positive`)·부정(`negative`) 키워드 그룹화
4. **페이징·정렬 지원**

   * `SortType` Enum(`LATEST`/`LIKES`/`STARS`) 정의
   * `PageRequest`(extends `AbstractPageRequest`)로 `page`/`num`/`sortBy` 파라미터 처리
   * `PaginatedResponse` 제네릭 DTO로 `Page<E>` → `{ num, page, itemNum, items }` 매핑
5. **리뷰 상세(MongoDB) 연동**

   * `ReviewDetails` 문서 엔티티 및 `ReviewDetailRepository.findByReviewId(...)` 추가
   * `ReviewDetailInternalException` 예외로 없을 땐 500 에러 처리
6. **리뷰 목록 조회 서비스**

   * `ReviewService.getReviewList(...)`: `isAgency` 플래그에 따라 `ReviewRepository.findAllByBuilding` 혹은 `findAllByAgency` 호출
   * 각 리뷰별 유저 좋아요 여부 계산 및 리뷰 상세(`ReviewDetails`) 조회 후 `ReviewSummaryResponse.of(...)` 반환
7. **컨트롤러 확장**

   * `BuildingController`에 `GET /building/{buildingId}/review` 엔드포인트 추가
   * `ReviewService` 주입하여 페이징·정렬된 `PaginatedResponse<ReviewSummaryResponse>` 반환

## 📸 스크린샷
![일반 건물 리뷰 조회 화면](https://github.com/user-attachments/assets/31dd6938-e6fa-4fbd-aace-fdbe4ec6cc80)  
일반 건물 리뷰 리스트 조회 화면

![기숙사 리뷰 조회 화면](https://github.com/user-attachments/assets/cd8a12a1-f5b3-4047-aa88-c28dac1c5ed6)  
기숙사 리뷰 리스트 조회 화면

![공인중개사 리뷰 조회 화면](https://github.com/user-attachments/assets/f8c2afbd-677b-432d-bc44-1d7034f86e8c)  
공인중개사 리뷰 리스트 조회 화면

![모든 필터 적용된 조회 화면](https://github.com/user-attachments/assets/fefd2506-19a7-4066-8a19-6cd014554117)  
페이지·개수·정렬·isAgency 플래그가 모두 적용된 조회 화면



## 📢 노트
* 기존 DTO 사용부 호환성 검토 권장
