### PR TITLE
[Feat #63] 이메일 인증 API 구현 및 인증 상태 관리 로직 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -63,6 +63,9 @@ public class AuthController {
             @AuthenticationPrincipal Users user,
             @RequestBody IssueEmailCodeRequest request
     ) {
+        // VerificationFilter에서 Users의 VerificationStatus가 UNVERIFIED인 요청만 허용하도록 필터링됨
+        // -> 여기서는 VerificationStatus를 확인할 필요 없음
+        // (기획 요구사항에 따라 학교 이메일 인증이 완료된 후, 다른 이메일로 변경할 수 있어야 한다면 추가 로직 필요함)
         String email = request.emailAddress();
         mailAuthService.sendAuthCode(email);
         return new ResTemplate<>(HttpStatus.OK, "인증코드 전송 완료", null);
@@ -73,6 +76,7 @@ public class AuthController {
             @AuthenticationPrincipal Users user,
             @RequestBody IssueEmailCodeRequest request
     ) {
+        // 여기서도 VerificationFilter에서 Users의 VerificationStatus가 UNVERIFIED인 요청만 허용하도록 필터링됨
         String email = request.emailAddress();
         String code = request.emailAddress();
 

--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -3,6 +3,7 @@ package JJinBBang.app.domain.user.controller;
 import JJinBBang.app.domain.user.dto.request.IssueEmailCodeRequest;
 import JJinBBang.app.domain.user.dto.request.LoginRequest;
 import JJinBBang.app.domain.user.dto.request.SignupRequest;
+import JJinBBang.app.domain.user.dto.request.VerifyEmailCodeRequest;
 import JJinBBang.app.domain.user.dto.response.LoginResponse;
 import JJinBBang.app.domain.user.dto.response.SignupRequiredResponse;
 import JJinBBang.app.domain.user.entity.Users;
@@ -85,11 +86,11 @@ public class AuthController {
     @PostMapping("/emailCode/verify")
     public ResTemplate<?> verifyEmailCode(
             @AuthenticationPrincipal Users user,
-            @RequestBody IssueEmailCodeRequest request
+            @RequestBody VerifyEmailCodeRequest request
     ) {
         // 여기서도 VerificationFilter에서 Users의 VerificationStatus가 UNVERIFIED인 요청만 허용하도록 필터링됨
         String email = request.emailAddress();
-        String code = request.emailAddress();
+        String code = request.authCode();
 
         // 인증코드 검증
         // 인증코드 만료 또는 미발급은 예외 반환

--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -1,12 +1,15 @@
 package JJinBBang.app.domain.user.controller;
 
+import JJinBBang.app.domain.user.dto.request.IssueEmailCodeRequest;
 import JJinBBang.app.domain.user.dto.request.LoginRequest;
 import JJinBBang.app.domain.user.dto.request.SignupRequest;
 import JJinBBang.app.domain.user.dto.response.LoginResponse;
 import JJinBBang.app.domain.user.dto.response.SignupRequiredResponse;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.domain.user.service.OAuthService;
+import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.jwt.JwtUtils;
+import JJinBBang.app.global.mail.service.MailAuthService;
 import JJinBBang.app.global.template.ResTemplate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,19 +26,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
 
+    private final UsersService usersService;
     private final OAuthService oAuthService;
     private final JwtUtils jwtUtils;
+    private final MailAuthService mailAuthService;
 
     @PostMapping
-    public ResTemplate<?> signIn(@RequestBody LoginRequest loginRequest){
+    public ResTemplate<?> signIn(@RequestBody LoginRequest loginRequest) {
         Users user = oAuthService.login(loginRequest.oauthProvider(), loginRequest.oauthCode());
-        if(user.getUserId() == null){
+        if (user.getUserId() == null) {
             String signupToken = jwtUtils.generateSignupToken(user);
 
             SignupRequiredResponse signupRequiredResponse = SignupRequiredResponse.of(signupToken);
             return new ResTemplate<>(HttpStatus.OK, "약관동의가 필요합니다.", signupRequiredResponse);
-        }
-        else {
+        } else {
             String accessToken = jwtUtils.generateAccessToken(user);
             String refreshToken = jwtUtils.generateRefreshToken(user);
 
@@ -45,12 +49,41 @@ public class AuthController {
     }
 
     @PostMapping("/signup")
-    public ResTemplate<LoginResponse> signUp(@AuthenticationPrincipal Users user){
+    public ResTemplate<LoginResponse> signUp(@AuthenticationPrincipal Users user) {
         user = oAuthService.signup(user);
         String accessToken = jwtUtils.generateAccessToken(user);
         String refreshToken = jwtUtils.generateRefreshToken(user);
 
         LoginResponse loginResponse = LoginResponse.of(accessToken, refreshToken);
         return new ResTemplate<>(HttpStatus.OK, "회원가입 성공", loginResponse);
+    }
+
+    @PostMapping("/emailCode")
+    public ResTemplate<?> sendEmailCode(
+            @AuthenticationPrincipal Users user,
+            @RequestBody IssueEmailCodeRequest request
+    ) {
+        String email = request.emailAddress();
+        mailAuthService.sendAuthCode(email);
+        return new ResTemplate<>(HttpStatus.OK, "인증코드 전송 완료", null);
+    }
+
+    @PostMapping("/emailCode/verify")
+    public ResTemplate<?> verifyEmailCode(
+            @AuthenticationPrincipal Users user,
+            @RequestBody IssueEmailCodeRequest request
+    ) {
+        String email = request.emailAddress();
+        String code = request.emailAddress();
+
+        // 인증코드 검증
+        // 인증코드 만료 또는 미발급은 예외 반환
+        boolean verifyResult = mailAuthService.verifyAuthCode(email, code);
+        if(!verifyResult) {
+            usersService.verifyUniversityEmail(user, email);
+            return new ResTemplate<>(HttpStatus.OK, "인증이 완료되었습니다.", null);
+        } else {
+            return new ResTemplate<>(HttpStatus.BAD_REQUEST, "인증코드 검증에 실패하였습니다.", null);
+        }
     }
 }

--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -94,7 +94,7 @@ public class AuthController {
         // 인증코드 검증
         // 인증코드 만료 또는 미발급은 예외 반환
         boolean verifyResult = mailAuthService.verifyAuthCode(user.getUserId(), email, code);
-        if(!verifyResult) {
+        if(verifyResult) {
             usersService.verifyUniversityEmail(user, email);
             return new ResTemplate<>(HttpStatus.OK, "인증이 완료되었습니다.", null);
         } else {

--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -67,7 +67,7 @@ public class AuthController {
         // -> 여기서는 VerificationStatus를 확인할 필요 없음
         // (기획 요구사항에 따라 학교 이메일 인증이 완료된 후, 다른 이메일로 변경할 수 있어야 한다면 추가 로직 필요함)
         String email = request.emailAddress();
-        mailAuthService.sendAuthCode(email);
+        mailAuthService.sendAuthCode(user.getUserId(), email);
         return new ResTemplate<>(HttpStatus.OK, "인증코드 전송 완료", null);
     }
 
@@ -82,7 +82,7 @@ public class AuthController {
 
         // 인증코드 검증
         // 인증코드 만료 또는 미발급은 예외 반환
-        boolean verifyResult = mailAuthService.verifyAuthCode(email, code);
+        boolean verifyResult = mailAuthService.verifyAuthCode(user.getUserId(), email, code);
         if(!verifyResult) {
             usersService.verifyUniversityEmail(user, email);
             return new ResTemplate<>(HttpStatus.OK, "인증이 완료되었습니다.", null);

--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -33,13 +33,22 @@ public class AuthController {
 
     @PostMapping
     public ResTemplate<?> signIn(@RequestBody LoginRequest loginRequest) {
+        // 소셜 로그인 API
+
+        // 전달받은 provider에 따라 매칭되는 LoginService 인터페이스 구현체를 실행하여 소셜 로그인 진행
         Users user = oAuthService.login(loginRequest.oauthProvider(), loginRequest.oauthCode());
+
         if (user.getUserId() == null) {
+            // 약관 동의가 필요한 경우
+            // user 객체는 DB에 저장되지 않은 상태. (provider, providerId 만 존재)
+            // -> 약관동의를 위한 임시 토큰 발급 (토큰에 provider, providerId 포함)
             String signupToken = jwtUtils.generateSignupToken(user);
 
             SignupRequiredResponse signupRequiredResponse = SignupRequiredResponse.of(signupToken);
             return new ResTemplate<>(HttpStatus.PRECONDITION_REQUIRED, "약관동의가 필요합니다.", signupRequiredResponse);
         } else {
+            // 약관 동의가 완료된 유저의 경우
+            // user 객체는 DB에 저장된 상태 -> 엑세스 토큰, 리프레시 토큰 발급
             String accessToken = jwtUtils.generateAccessToken(user);
             String refreshToken = jwtUtils.generateRefreshToken(user);
 
@@ -50,6 +59,8 @@ public class AuthController {
 
     @PostMapping("/signup")
     public ResTemplate<LoginResponse> signUp(@AuthenticationPrincipal Users user) {
+        // 로그인 한 유저에 대해 약관 동의를 수행하는 API 입니다.
+
         user = oAuthService.signup(user);
         String accessToken = jwtUtils.generateAccessToken(user);
         String refreshToken = jwtUtils.generateRefreshToken(user);

--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -38,7 +38,7 @@ public class AuthController {
             String signupToken = jwtUtils.generateSignupToken(user);
 
             SignupRequiredResponse signupRequiredResponse = SignupRequiredResponse.of(signupToken);
-            return new ResTemplate<>(HttpStatus.OK, "약관동의가 필요합니다.", signupRequiredResponse);
+            return new ResTemplate<>(HttpStatus.PRECONDITION_REQUIRED, "약관동의가 필요합니다.", signupRequiredResponse);
         } else {
             String accessToken = jwtUtils.generateAccessToken(user);
             String refreshToken = jwtUtils.generateRefreshToken(user);
@@ -87,7 +87,7 @@ public class AuthController {
             usersService.verifyUniversityEmail(user, email);
             return new ResTemplate<>(HttpStatus.OK, "인증이 완료되었습니다.", null);
         } else {
-            return new ResTemplate<>(HttpStatus.BAD_REQUEST, "인증코드 검증에 실패하였습니다.", null);
+            return new ResTemplate<>(HttpStatus.I_AM_A_TEAPOT, "인증코드 검증에 실패하였습니다.", null);
         }
     }
 }

--- a/src/main/java/JJinBBang/app/domain/user/dto/request/IssueEmailCodeRequest.java
+++ b/src/main/java/JJinBBang/app/domain/user/dto/request/IssueEmailCodeRequest.java
@@ -1,0 +1,6 @@
+package JJinBBang.app.domain.user.dto.request;
+
+public record IssueEmailCodeRequest(
+        String emailAddress
+) {
+}

--- a/src/main/java/JJinBBang/app/domain/user/dto/request/VerifyEmailCodeRequest.java
+++ b/src/main/java/JJinBBang/app/domain/user/dto/request/VerifyEmailCodeRequest.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.domain.user.dto.request;
+
+public record VerifyEmailCodeRequest(
+        String emailAddress,
+        String authCode
+) {
+}

--- a/src/main/java/JJinBBang/app/domain/user/entity/Users.java
+++ b/src/main/java/JJinBBang/app/domain/user/entity/Users.java
@@ -85,7 +85,6 @@ public class Users extends BaseEntity {
 	private Users(
 		Provider provider,
 		String providerId
-
 	){
 		this.provider = provider;
 		this.providerId = providerId;
@@ -94,5 +93,13 @@ public class Users extends BaseEntity {
 		this.admissionCertificateUploadDate = null;
 		this.verificationStatus = VerificationStatus.UNVERIFIED;
 		this.disabledAt = null;
+	}
+
+	public void updateUniversityEmail(String universityEmail) {
+		this.universityEmail = universityEmail;
+	}
+
+	public void updateVerificationStatus(VerificationStatus verificationStatus) {
+		this.verificationStatus = verificationStatus;
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersService.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersService.java
@@ -12,4 +12,12 @@ public interface UsersService {
 	Users save(Users user);
 
 	UserInfoResponseDto getUserInfo(Users user);
+
+	/**
+	 * 이메일 인증 완료 시 유저의 학교 이메일과 인증 상태를 업데이트함
+	 * @param user 유저
+	 * @param universityEmail 인증에 사용한 학교 이메일
+	 * @return 업데이트된 유저
+	 */
+	Users verifyUniversityEmail(Users user, String universityEmail);
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -1,6 +1,8 @@
 package JJinBBang.app.domain.user.service;
 
 import JJinBBang.app.domain.user.dto.UserInfoResponseDto;
+import JJinBBang.app.global.common.enums.VerificationStatus;
+import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import JJinBBang.app.domain.user.entity.Users;
@@ -46,5 +48,12 @@ public class UsersServiceImpl implements UsersService {
 			throw UserNotFoundException.notFound();
 		}
 		return UserInfoResponseDto.of(user);
+	}
+
+	@Override
+	public Users verifyUniversityEmail(Users user, String universityEmail) {
+		user.updateUniversityEmail(universityEmail);
+		user.updateVerificationStatus(VerificationStatus.EMAIL_VERIFIED);
+		return usersRepository.save(user);
 	}
 }

--- a/src/main/java/JJinBBang/app/global/mail/dto/EmailAuthInfo.java
+++ b/src/main/java/JJinBBang/app/global/mail/dto/EmailAuthInfo.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.global.mail.dto;
+
+public record EmailAuthInfo(
+        String email,
+        String code,
+        long timestamp
+) { }

--- a/src/main/java/JJinBBang/app/global/mail/exception/MailInvalidException.java
+++ b/src/main/java/JJinBBang/app/global/mail/exception/MailInvalidException.java
@@ -14,8 +14,4 @@ public class MailInvalidException extends InvalidGroupException {
     public static MailInvalidException invalidEmailDomain() {
         return new MailInvalidException("유효하지 않은 이메일 도메인 입니다.");
     }
-
-    public static RuntimeException notFoundAuthCode() {
-        return new MailInvalidException("인증 코드가 존재하지 않습니다.");
-    }
 }

--- a/src/main/java/JJinBBang/app/global/mail/exception/MailNotFoundException.java
+++ b/src/main/java/JJinBBang/app/global/mail/exception/MailNotFoundException.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.global.mail.exception;
+
+import JJinBBang.app.global.error.exception.NotFoundGroupException;
+
+public class MailNotFoundException extends NotFoundGroupException {
+    public MailNotFoundException(String message) {
+        super(message);
+    }
+
+    public static MailNotFoundException notFoundAuthCode() {
+        return new MailNotFoundException("인증 코드가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/JJinBBang/app/global/mail/repository/EmailAuthCodeRepository.java
+++ b/src/main/java/JJinBBang/app/global/mail/repository/EmailAuthCodeRepository.java
@@ -5,11 +5,37 @@ import JJinBBang.app.global.mail.dto.EmailAuthInfo;
 import java.util.Optional;
 
 public interface EmailAuthCodeRepository {
+//     key: userId
+//     value: EmailAuthInfo(email, authCode, timestamp)
+//     key를 userId로 함으로써 인증코드 저장을 유저 단위로 구분함.
+
+    /**
+     * 인증코드를 저장합니다.
+     * @param userId 인증코드를 발급받은 유저의 아이디
+     * @param email 인증코드를 발급받은 유저의 이메일
+     * @param authCode 인증코드
+     */
     void save(Long userId, String email, String authCode);
 
+    /**
+     * 주어진 userId에 대한 인증코드가 존재하는지 확인합니다.
+     * @param userId 인증코드를 발급받은 유저의 아이디
+     * @return 존재하면 true, 만료되었거나 존재하지 않으면 false
+     */
     boolean isExistByUserId(Long userId);
 
+    /**
+     * 주어진 userId에 대한 이메일과 인증코드를 조회합니다.
+     * @param userId 인증코드를 발급받은 유저의 아이디
+     * @return 존재하면 EmailAuthInfo, 만료되었거나 존재하지 않으면 Optional.empty()
+     */
+
     Optional<EmailAuthInfo> findEmailAndAuthCodeByUserId(Long userId);
+
+    /**
+     * 주어진 userId에 대한 인증코드를 삭제합니다.
+     * @param userId 인증코드를 발급받은 유저의 아이디
+     */
 
     void deleteByUserId(Long userId);
 }

--- a/src/main/java/JJinBBang/app/global/mail/repository/EmailAuthCodeRepository.java
+++ b/src/main/java/JJinBBang/app/global/mail/repository/EmailAuthCodeRepository.java
@@ -1,13 +1,15 @@
 package JJinBBang.app.global.mail.repository;
 
+import JJinBBang.app.global.mail.dto.EmailAuthInfo;
+
 import java.util.Optional;
 
 public interface EmailAuthCodeRepository {
-    void save(String email, String authCode);
+    void save(Long userId, String email, String authCode);
 
-    boolean isExistByEmail(String email);
+    boolean isExistByUserId(Long userId);
 
-    Optional<String> findAuthCodeByEmail(String email);
+    Optional<EmailAuthInfo> findEmailAndAuthCodeByUserId(Long userId);
 
-    void deleteByEmail(String email);
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/JJinBBang/app/global/mail/repository/InMemoryEmailAuthCodeRepository.java
+++ b/src/main/java/JJinBBang/app/global/mail/repository/InMemoryEmailAuthCodeRepository.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.global.mail.repository;
 
+import JJinBBang.app.global.mail.dto.EmailAuthInfo;
 import JJinBBang.app.global.mail.properties.MailAuthProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DuplicateKeyException;
@@ -15,43 +16,43 @@ import java.util.concurrent.ConcurrentHashMap;
 public class InMemoryEmailAuthCodeRepository implements EmailAuthCodeRepository {
 
     private final long expirationTime;
-    private final Map<String, EmailAuthInfo> emailAuthCodeMap = new ConcurrentHashMap<>();
+    private final Map<Long, EmailAuthInfo> emailAuthCodeMap = new ConcurrentHashMap<>();
 
     public InMemoryEmailAuthCodeRepository(MailAuthProperties props) {
         this.expirationTime = props.getExpirationTime() * 60_000;
     }
 
     @Override
-    public void save(String email, String authCode) {
-        EmailAuthInfo info = new EmailAuthInfo(authCode, System.currentTimeMillis());
-        EmailAuthInfo prev = emailAuthCodeMap.putIfAbsent(email, info);
+    public void save(Long userId, String email, String authCode) {
+        EmailAuthInfo info = new EmailAuthInfo(email, authCode, System.currentTimeMillis());
+        EmailAuthInfo prev = emailAuthCodeMap.putIfAbsent(userId, info);
         if (prev != null) {
-            throw new DuplicateKeyException("Duplicate key: " + email);
+            throw new DuplicateKeyException("Duplicate key: " + userId);
         }
     }
 
     @Override
-    public boolean isExistByEmail(String email) {
-        EmailAuthInfo info = emailAuthCodeMap.get(email);
-        return info != null && !isExpired(info.timestamp);
+    public boolean isExistByUserId(Long userId) {
+        EmailAuthInfo info = emailAuthCodeMap.get(userId);
+        return info != null && !isExpired(info.timestamp());
     }
 
     @Override
-    public Optional<String> findAuthCodeByEmail(String email) {
-        EmailAuthInfo info = emailAuthCodeMap.get(email);
+    public Optional<EmailAuthInfo> findEmailAndAuthCodeByUserId(Long userId) {
+        EmailAuthInfo info = emailAuthCodeMap.get(userId);
         if (info == null) {
             return Optional.empty();
         }
-        if (isExpired(info.timestamp)) {
-            emailAuthCodeMap.remove(email);
+        if (isExpired(info.timestamp())) {
+            emailAuthCodeMap.remove(userId);
             return Optional.empty();
         }
-        return Optional.of(info.code);
+        return Optional.of(info);
     }
 
     @Override
-    public void deleteByEmail(String email) {
-        emailAuthCodeMap.remove(email);
+    public void deleteByUserId(Long userId) {
+        emailAuthCodeMap.remove(userId);
     }
 
     private boolean isExpired(long timestamp) {
@@ -62,10 +63,7 @@ public class InMemoryEmailAuthCodeRepository implements EmailAuthCodeRepository 
     @Scheduled(fixedDelay = 60 * 1000) // 1분 간격
     public void cleanUpExpiredCodes() {
         emailAuthCodeMap.entrySet().removeIf(entry ->
-                isExpired(entry.getValue().timestamp)
+                isExpired(entry.getValue().timestamp())
         );
     }
-
-    // 내부 저장용 클래스
-    private record EmailAuthInfo(String code, long timestamp) { }
 }

--- a/src/main/java/JJinBBang/app/global/mail/service/MailAuthService.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/MailAuthService.java
@@ -7,6 +7,9 @@ public interface MailAuthService {
 
     /**
      * 주어진 유저 아이디와 이메일로 인증 코드를 생성해서 전송합니다.
+     * 인증 코드는 application.yml -> mail-auth.expiration-time 분간 유효합니다.
+     * 인증 코드는 application.yml -> mail-auth.auth-code-length 길이로 생성됩니다.
+     * 이미 인증 코드가 발급된 경우에는 기존 인증 코드를 삭제하고 새로 발급합니다.
      *
      * @param userId 인증 코드 발급을 요청한 유저의 아이디
      * @param email 인증 코드를 받을 이메일 주소
@@ -17,6 +20,8 @@ public interface MailAuthService {
 
     /**
      * 사용자가 제출한 인증 코드가 저장된 코드와 일치하는지 검증합니다.
+     * userId 키 값에 대한 인증코드가 존재하지 않거나 만료되었으면 예외를 발생시킵니다.
+     * 저장된 인증코드에 대해 이메일과 인증코드가 일치하는지 검증합니다.
      *
      * @param userId  인증 코드 발급을 요청한 유저의 아이디
      * @param email    인증 대상 이메일

--- a/src/main/java/JJinBBang/app/global/mail/service/MailAuthService.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/MailAuthService.java
@@ -6,21 +6,23 @@ import JJinBBang.app.global.mail.exception.MailInvalidException;
 public interface MailAuthService {
 
     /**
-     * 주어진 이메일로 인증 코드를 생성해서 전송합니다.
+     * 주어진 유저 아이디와 이메일로 인증 코드를 생성해서 전송합니다.
      *
+     * @param userId 인증 코드 발급을 요청한 유저의 아이디
      * @param email 인증 코드를 받을 이메일 주소
      * @throws MailInternalException  메일 발송 실패 등의 내부 오류
      * @throws MailInvalidException  이메일 형식 또는 도메인 검증 실패
      */
-    void sendAuthCode(String email);
+    void sendAuthCode(Long userId, String email);
 
     /**
      * 사용자가 제출한 인증 코드가 저장된 코드와 일치하는지 검증합니다.
      *
+     * @param userId  인증 코드 발급을 요청한 유저의 아이디
      * @param email    인증 대상 이메일
      * @param authCode 사용자 입력 코드
      * @return 검증 성공 시 true, 실패 또는 만료 시 false
      * @throws MailInvalidException  코드 미발급·만료
      */
-    boolean verifyAuthCode(String email, String authCode);
+    boolean verifyAuthCode(Long userId, String email, String authCode);
 }

--- a/src/main/java/JJinBBang/app/global/mail/service/MailSendService.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/MailSendService.java
@@ -1,5 +1,12 @@
 package JJinBBang.app.global.mail.service;
 
 public interface MailSendService {
+    /**
+     * 이메일을 전송합니다.
+     *
+     * @param toEmail 수신자 이메일 주소
+     * @param subject 이메일 제목
+     * @param body 이메일 본문
+     */
     void sendMail(String toEmail, String subject, String body);
 }

--- a/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.global.mail.service.impl;
 
+import JJinBBang.app.global.mail.dto.EmailAuthInfo;
 import JJinBBang.app.global.mail.exception.MailInvalidException;
 import JJinBBang.app.global.mail.properties.MailAuthProperties;
 import JJinBBang.app.global.mail.repository.EmailAuthCodeRepository;
@@ -21,20 +22,20 @@ public class MailAuthServiceImpl implements MailAuthService {
     private final EmailAuthCodeRepository emailAuthCodeRepository;
 
     @Override
-    public void sendAuthCode(String toEmail) {
+    public void sendAuthCode(Long userId, String toEmail) {
         validateEmail(toEmail);
 
         String authCode = generateAuthCode();
-        saveAuthCode(toEmail, authCode);
+        saveAuthCode(userId, toEmail, authCode);
 
         mailSendService.sendMail(toEmail, properties.getSubjectText(), buildEmailBody(authCode));
     }
 
     @Override
-    public boolean verifyAuthCode(String email, String authCode) {
-        String savedAuthCode = emailAuthCodeRepository.findAuthCodeByEmail(email)
+    public boolean verifyAuthCode(Long userId, String email, String authCode) {
+        EmailAuthInfo savedAuthCode = emailAuthCodeRepository.findEmailAndAuthCodeByUserId(userId)
                 .orElseThrow(MailInvalidException::notFoundAuthCode);
-        return savedAuthCode.equals(authCode);
+        return savedAuthCode.email().equals(email) && savedAuthCode.code().equals(authCode);
     }
 
 
@@ -49,13 +50,13 @@ public class MailAuthServiceImpl implements MailAuthService {
         return code.toString();
     }
 
-    public void saveAuthCode(String email, String authCode) {
-        if(emailAuthCodeRepository.isExistByEmail(email)) {
+    public void saveAuthCode(Long userId, String email, String authCode) {
+        if(emailAuthCodeRepository.isExistByUserId(userId)) {
             // 이미 인증 코드가 발급된 이메일인 경우
-            log.info("이미 인증 코드가 발급된 이메일입니다. [email: {}]. 기존 인증 코드를 삭제합니다.", email);
-            emailAuthCodeRepository.deleteByEmail(email);
+            log.info("이미 인증 코드가 발급된 이메일입니다. [userId: {}]. 기존 인증 코드를 삭제합니다.", userId);
+            emailAuthCodeRepository.deleteByUserId(userId);
         }
-        emailAuthCodeRepository.save(email, authCode);
+        emailAuthCodeRepository.save(userId, email, authCode);
     }
 
     private String buildEmailBody(String code) {

--- a/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
@@ -40,7 +40,7 @@ public class MailAuthServiceImpl implements MailAuthService {
 
 
     // utility --------------------------------------------------------------------------------------------------------
-    public String generateAuthCode() {
+    private String generateAuthCode() {
         // emailAuthCodeLength 자리 숫자로 구성된 인증 코드 생성
         // 앞자리 0이 있어도 텍스트로 생성
         StringBuilder code = new StringBuilder();
@@ -50,7 +50,7 @@ public class MailAuthServiceImpl implements MailAuthService {
         return code.toString();
     }
 
-    public void saveAuthCode(Long userId, String email, String authCode) {
+    private void saveAuthCode(Long userId, String email, String authCode) {
         if(emailAuthCodeRepository.isExistByUserId(userId)) {
             // 이미 인증 코드가 발급된 이메일인 경우
             log.info("이미 인증 코드가 발급된 이메일입니다. [userId: {}]. 기존 인증 코드를 삭제합니다.", userId);

--- a/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
@@ -2,6 +2,7 @@ package JJinBBang.app.global.mail.service.impl;
 
 import JJinBBang.app.global.mail.dto.EmailAuthInfo;
 import JJinBBang.app.global.mail.exception.MailInvalidException;
+import JJinBBang.app.global.mail.exception.MailNotFoundException;
 import JJinBBang.app.global.mail.properties.MailAuthProperties;
 import JJinBBang.app.global.mail.repository.EmailAuthCodeRepository;
 import JJinBBang.app.global.mail.service.MailAuthService;
@@ -34,7 +35,7 @@ public class MailAuthServiceImpl implements MailAuthService {
     @Override
     public boolean verifyAuthCode(Long userId, String email, String authCode) {
         EmailAuthInfo savedAuthCode = emailAuthCodeRepository.findEmailAndAuthCodeByUserId(userId)
-                .orElseThrow(MailInvalidException::notFoundAuthCode);
+                .orElseThrow(MailNotFoundException::notFoundAuthCode);
         return savedAuthCode.email().equals(email) && savedAuthCode.code().equals(authCode);
     }
 

--- a/src/main/java/JJinBBang/app/global/security/filter/VerificationStatusFilter.java
+++ b/src/main/java/JJinBBang/app/global/security/filter/VerificationStatusFilter.java
@@ -75,17 +75,22 @@ public class VerificationStatusFilter extends OncePerRequestFilter {
      */
     private AuthenticationException getCustomSecurityAuthException(String userStatus, String requiredStatus) {
         if (!userStatus.equals(requiredStatus)) {
+            boolean univVerified = "EMAIL_VERIFIED".equals(userStatus) ||
+                    "ENROLL_STUDENT_VERIFIED".equals(userStatus) ||
+                    "NEW_STUDENT_VERIFIED".equals(userStatus);
             switch (requiredStatus) {
-                case "VERIFIED":
+                case "EMAIL_VERIFIED":
+                case "ENROLL_STUDENT_VERIFIED":
+                case "NEW_STUDENT_VERIFIED":
                     return SecurityAccessDeniedException.universityVerificationRequired();
                 case "UNVERIFIED":
-                    if ("VERIFIED".equals(userStatus)) {
+                    if (univVerified) {
                         return SecurityAccessDeniedException.alreadyUniversityVerified();
                     } else if ("PENDING".equals(userStatus)) {
                         return SecurityAccessDeniedException.existPendingUnivVerifyRequest();
                     }
                 case "PENDING":
-                    if ("VERIFIED".equals(userStatus)) {
+                    if (univVerified) {
                         return SecurityAccessDeniedException.alreadyUniversityVerified();
                     } else if ("UNVERIFIED".equals(userStatus)) {
                         return SecurityAccessDeniedException.pendingUnivVerifyRequestNotFound();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,16 +10,16 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true
         format_sql: true
     open-in-view: false
 
-#  data:
-#    mongodb:
-#      uri: ${spring.data.mongodb.uri}
+  data:
+    mongodb:
+      uri: ${spring.data.mongodb.uri}
 
   security:
     oauth2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,16 +10,16 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true
         format_sql: true
     open-in-view: false
 
-  data:
-    mongodb:
-      uri: ${spring.data.mongodb.uri}
+#  data:
+#    mongodb:
+#      uri: ${spring.data.mongodb.uri}
 
   security:
     oauth2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,8 +89,6 @@ security:
 #      - "/api/v1/user/**"
 #      - "/api/v1/map/**"
     authenticated:
-      - "/api/v1/auth/emailCode"
-      - "/api/v1/auth/emailCode/verify"
       - "/api/v1/auth/tokenRefresh"
       - "/api/v1/auth/logout"
 #      - "/api/v1/user"
@@ -102,10 +100,16 @@ security:
     anonymous:
       - "/api/v1/auth"
     verification-status-based:
-      VERIFIED:
+      EMAIL_VERIFIED:
         - "/api/v1/verifiedTest"
+      ENROLL_STUDENT_VERIFIED:
+        - "/api/v1/enrollStudentVerifiedTest"
+      NEW_STUDENT_VERIFIED:
+        - "/api/v1/newStudentVerifiedTest"
       UNVERIFIED:
         - "/api/v1/unverifiedTest"
+        - "/api/v1/auth/emailCode"
+        - "/api/v1/auth/emailCode/verify"
       PENDING:
         - "/api/v1/pendingTest"
     pending-user:

--- a/src/test/java/JJinBBang/app/global/mail/MailAuthServiceImplTest.java
+++ b/src/test/java/JJinBBang/app/global/mail/MailAuthServiceImplTest.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.global.mail;
 
+import JJinBBang.app.global.mail.dto.EmailAuthInfo;
 import JJinBBang.app.global.mail.exception.MailInvalidException;
 import JJinBBang.app.global.mail.properties.MailAuthProperties;
 import JJinBBang.app.global.mail.repository.EmailAuthCodeRepository;
@@ -48,12 +49,13 @@ class MailAuthServiceImplTest {
 
     @Test
     void sendAuthCode_성공() {
+        Long userId = 1L;
         String email = "user@gnu.ac.kr";
 
         // isExistByEmail 기본 false → save, sendMail 호출 검증
-        service.sendAuthCode(email);
+        service.sendAuthCode(userId, email);
 
-        verify(repo).save(eq(email), anyString());
+        verify(repo).save(eq(userId), eq(email), anyString());
         verify(mailSender).sendMail(
                 eq(email),
                 eq("[찐빵] 인증코드"),
@@ -64,41 +66,55 @@ class MailAuthServiceImplTest {
     @Test
     void sendAuthCode_도메인불일치_예외() {
         // 허용된 도메인이 아니면
+        Long userId = 1L;
         String badEmail = "user@naver.com";
 
         // MailInvalidException 발생해야 함
         assertThrows(MailInvalidException.class,
-                () -> service.sendAuthCode(badEmail));
+                () -> service.sendAuthCode(userId, badEmail));
     }
 
     @Test
     void verifyAuthCode_일치() {
         // u@gnu.ac.kr 로 발급된 인증코드가 1234일 때
-        when(repo.findAuthCodeByEmail("u@gnu.ac.kr"))
-                .thenReturn(Optional.of("1234"));
+        Long userId = 1L;
+        EmailAuthInfo info = new EmailAuthInfo(
+                "u@gnu.ac.kr",
+                "1234",
+                System.currentTimeMillis()
+        );
+        when(repo.findEmailAndAuthCodeByUserId(userId))
+                .thenReturn(Optional.of(info));
 
         // 검증할 인증코드가 1234이면 true 리턴
-        assertTrue(service.verifyAuthCode("u@gnu.ac.kr", "1234"));
+        assertTrue(service.verifyAuthCode(userId, "u@gnu.ac.kr", "1234"));
     }
 
     @Test
     void verifyAuthCode_불일치() {
         // u@gnu.ac.kr 로 발급된 인증코드가 9999일 때
-        when(repo.findAuthCodeByEmail("u@gnu.ac.kr"))
-                .thenReturn(Optional.of("9999"));
+        Long userId = 1L;
+        EmailAuthInfo info = new EmailAuthInfo(
+                "u@gnu.ac.kr",
+                "9999",
+                System.currentTimeMillis()
+        );
+        when(repo.findEmailAndAuthCodeByUserId(userId))
+                .thenReturn(Optional.of(info));
 
         // 검증할 인증코드가 1234이면 false 리턴
-        assertFalse(service.verifyAuthCode("u@gnu.ac.kr", "1234"));
+        assertFalse(service.verifyAuthCode(userId, "u@gnu.ac.kr", "1234"));
     }
 
     @Test
     void verifyAuthCode_미발급_예외() {
         // x@gnu.ac.kr 으로 조회 시 Optional.empty 가 리턴되면
-        when(repo.findAuthCodeByEmail("x@gnu.ac.kr"))
+        Long userId = 1L;
+        when(repo.findEmailAndAuthCodeByUserId(userId))
                 .thenReturn(Optional.empty());
 
         // x@gnu.ac.kr 으로 인증코드 검사 수행 시 MailInvalidException 발생해야 함
         assertThrows(MailInvalidException.class,
-                () -> service.verifyAuthCode("x@gnu.ac.kr", "0000"));
+                () -> service.verifyAuthCode(userId, "x@gnu.ac.kr", "0000"));
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #63

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요

- 이메일 인증 코드 발급 및 검증 API 추가
- 인증 상태 관리 개선 및 관련 필터 로직 수정
- 인증 정보 저장 방식 변경: 이메일 기준 → userId 기준
- 인증 실패/성공 및 예외 처리를 위한 응답 및 검증 로직 추가
- 테스트 코드 추가 및 기존 테스트 코드 개선
- 기존 코드들에 주석 추가

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

1. 이메일 인증 코드 발급 및 검증 API 추가
- `AuthController`에 `/emailCode`, `/emailCode/verify` API가 추가되었습니다.
- 사용자는 로그인 후 이메일 인증을 진행할 수 있습니다.
- 인증 상태가 UNVERIFIED인 사용자만 해당 API를 사용할 수 있도록 작성하였습니다.

2. 인증 상태 관리 로직
- `Users` 엔티티에 `updateUniversityEmail`과 `updateVerificationStatus` 메서드 추가
- 이메일 인증 후 `UsersService.verifyUniversityEmail`을 통해 상태를 `EMAIL_VERIFIED`로 변경하고, 학교 이메일을 인증에 사용한 이메일로 업데이트 합니다.

3. 인증 정보 저장 방식 변경
- 인증 코드를 저장하는 기준이 기존 이메일에서 `userId`로 변경되었습니다. (이메일이 겹치는 문제 예방)

4. 필터 및 보안 설정 변경
- `VerificationStatusFilter`의 조건 로직 리펙토링 (추가된 상태(`EMAIL_VERIFIED`, `PENDING` 등)를 처리할 수 있도록 로직 수정)
- application.yml에서 verification-status-based 접근 제어 경로 수정

5. 테스트 코드 수정
- 3번 변경사항으로 인해 테스트 코드를 수정하였습니다.

## 📸 스크린샷

1. 인증코드 발급
![image](https://github.com/user-attachments/assets/fba75749-512c-4880-9dde-a60160e7e14b)

2. 인증코드 오류
![image](https://github.com/user-attachments/assets/640d3306-c5a8-4db1-aa57-3fa7bbc710e7)

3. 인증코드 검증 성공
![image](https://github.com/user-attachments/assets/b10197a9-f949-4317-86d7-d869e3840b97)

4. 이미 학교 인증이 완료된 경우
![image](https://github.com/user-attachments/assets/ad6b1a78-8782-4684-993f-454510d4ed09)

5. 인증코드가 만료되었거나, 발급받지 않은 경우
![image](https://github.com/user-attachments/assets/bc9dd2e7-2bd7-4790-aac8-04c161ad6485)


## 📢 노트

- 현재 방식은 한번 학교 이메일을 인증한 이후에는, 학교 이메일을 변경할 수 없도록 구현되어 있습니다.
- 기획 요구사항에 따라 학교 이메일 인증이 완료된 후, 다른 이메일로 변경할 수 있어야 한다면 추가 로직을 구현해야 합니다.

- 같은 이메일을 여러 유저가 가질 수 있을지, 막아야 할지 의견 부탁드립니다.