### PR TITLE
:bug: Fix[#78] 엑세스 토큰 생성 테스트 코드 수정

### DIFF
--- a/src/test/java/JJinBBang/app/global/util/AccessTokenGeneratorTest.java
+++ b/src/test/java/JJinBBang/app/global/util/AccessTokenGeneratorTest.java
@@ -5,6 +5,7 @@ import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.common.enums.Provider;
 import JJinBBang.app.global.common.enums.VerificationStatus;
 import JJinBBang.app.global.jwt.JwtUtils;
+import JJinBBang.app.global.jwt.enums.TokenType;
 import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ public class AccessTokenGeneratorTest {
                 claims.get("verificationStatus", String.class)
         );
         assertEquals(
-                "auth",
+                TokenType.ACCESS.getType(),
                 claims.get("tokenType", String.class)
         );
         System.out.println("access token = " + token);
@@ -77,7 +78,7 @@ public class AccessTokenGeneratorTest {
                 VerificationStatus.UNVERIFIED.name(),
                 claims.get("verificationStatus", String.class)
         );
-        assertEquals("auth", claims.get("tokenType", String.class));
+        assertEquals(TokenType.ACCESS.getType(), claims.get("tokenType", String.class));
         System.out.println("access token = " + token);
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
> ex) #1

Close #78

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요

1. AccessTokenGeneratorTest 객체의 테스트 코드 오류 수정

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

생성된 토큰의 타입을 검사할 때 TokenType enum의 값으로 비교하도록 수정하였습니다.

## 📸 스크린샷

## 📢 노트