### PR TITLE
[FEAT] contractType ALL 타입 관련 코드 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/repository/BuildingsRepositoryImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/BuildingsRepositoryImpl.java
@@ -73,9 +73,6 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 			.where(builder);
 
 		// 5. 계약 조건 필터
-		// contractType에 대해 선택 안한경우도 존재하기에 모든 조회가 가능하도록 예외 필요함.
-		// 단, 지금은 배포 테스트 예정이기에 추후 issue에 대해 작성할듯
-		// #수정필요
 		if (contractType != null) {
 			query.where(treated.contractType.eq(contractType));
 		}

--- a/src/main/java/JJinBBang/app/domain/common/dto/item/Filters.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/item/Filters.java
@@ -23,7 +23,7 @@ public record Filters(
 	List<BuildingType> buildType, // 건물 유형
 
 	@NotNull(message = "{filter.contractType.notNull}")
-	ContractType contractType, // 계약 유형
+	String contractType, // 계약 유형 (ALL, MONTHLY_RENT, DEPOSIT_RENT)
 
 	List<String> campus, // 캠퍼스
 

--- a/src/main/java/JJinBBang/app/domain/map/exception/MapUnprocessableException.java
+++ b/src/main/java/JJinBBang/app/domain/map/exception/MapUnprocessableException.java
@@ -16,4 +16,9 @@ public class MapUnprocessableException extends UnprocessableGroupException {
 	public static MapUnprocessableException invalidMonthlyRentRange() {
 		return new MapUnprocessableException("월세 최소값과 최대값을 확인해주세요.");
 	}
+
+	// 위도/경도 범위(bounds)가 올바르지 않을 경우 (예: neLat < swLat 또는 neLng < swLng)
+	public static MapUnprocessableException invalidGeographicBounds() {
+		return new MapUnprocessableException("지도 범위(위도/경도)가 올바르지 않습니다. 북동쪽 좌표가 남서쪽 좌표보다 커야 합니다.");
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -94,7 +94,7 @@ public class MapServiceImpl implements MapService{
 	// 위도/경도 범위 검사
 	private void validateBounds(Bounds bounds) {
 		if (bounds.neLat() < bounds.swLat() || bounds.neLng() < bounds.swLng()) {
-			throw MapUnprocessableException.invalidDepositRange(); // 위도/경도 범위 역전
+			throw MapUnprocessableException.invalidGeographicBounds(); // 위도/경도 범위 역전
 		}
 	}
 

--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -2,6 +2,7 @@ package JJinBBang.app.domain.map.service;
 
 import java.util.List;
 
+import JJinBBang.app.domain.building.enums.ContractType;
 import JJinBBang.app.domain.building.repository.BuildingsRepository;
 import org.springframework.stereotype.Service;
 
@@ -38,11 +39,13 @@ public class MapServiceImpl implements MapService{
 		validateFilterRanges(filters);
 		validateKeywordLimit(filters.reviewKeyword());
 
+		ContractType contractType = parseContractType(filters.contractType());
+
 		// 모든 조건 기반으로 건물 리스트를 먼저 조회
 		List<Buildings> buildings = buildingsRepository.findMarkersWithinBounds(
 			bounds.neLat(), bounds.neLng(),
 			bounds.swLat(), bounds.swLng(),
-			filters.buildType(), filters.contractType(),
+			filters.buildType(), contractType,
 			filters.depositMin(), filters.depositMax(),
 			filters.monthlyRentMin(), filters.monthlyRentMax(),
 			filters.inMaintenanceCost(),
@@ -110,5 +113,17 @@ public class MapServiceImpl implements MapService{
 		if (keywords != null && keywords.size() > 5) {
 			throw MapInvalidException.invalidKeyword();
 		}
+	}
+
+	private ContractType parseContractType(String type) {
+		if (type == null) {
+			return null;
+		}
+		return switch (type) {
+			case "MONTHLY_RENT" -> ContractType.MONTHLY_RENT;
+			case "DEPOSIT_RENT" -> ContractType.DEPOSIT_RENT;
+			case "ALL" -> null;
+			default -> null;
+		};
 	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #68 

## 💬 리뷰 포인트
contractType이 ALL인 경우를 받기 위한 코드 수정

## 🚀 상세 설명
기존에 contractType이 ALL 인 경우가 들어있었으나 
팀원들의 코드들와 contractType은 월세, 전세만 들어 있어야하는데,
ALL이라는 타입을 넣는 것도 상충되기에 빼고 크게 다른 코드 수정 없이 그냥 뒀어서
수정하였습니다..!

추가로 좌표 범위가 잘못된 경우 범위 관련 Exception을 출력시켜야하는데 
해당 Exception이 없어 보증금 Exception으로 던져줬기에 invalidGeographicBounds를 만들어뒀습니당

## 📸 스크린샷

## 📢 노트