### PR TITLE
Feat[#77]: 내 주변 찐빵 API 구현

### DIFF
--- a/src/main/java/JJinBBang/app/domain/map/controller/MapController.java
+++ b/src/main/java/JJinBBang/app/domain/map/controller/MapController.java
@@ -2,7 +2,13 @@ package JJinBBang.app.domain.map.controller;
 
 import java.util.List;
 
+import JJinBBang.app.domain.common.dto.PaginatedResponse;
+import JJinBBang.app.domain.map.dto.request.NearByMapItemRequest;
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.global.common.dto.InfoDto;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,5 +33,14 @@ public class MapController {
 		log.info("지도 마커 조회 성공");
 		List<MarkerInfo> response = mapService.getMapMarkers(request);
 		return new ResTemplate<>(HttpStatus.OK, "지도 마커 조회 성공", response);
+	}
+
+	@PostMapping("/markers/nearby")
+	public ResTemplate<PaginatedResponse<InfoDto>> getNearByMarkers(
+			@AuthenticationPrincipal Users user,
+			@Valid @RequestBody NearByMapItemRequest request
+	) {
+		PaginatedResponse<InfoDto> response = mapService.nearByMapItems(request, user);
+		return new ResTemplate<>(HttpStatus.OK, "내 주변 찐빵 조회 성공", response);
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/map/dto/request/NearByMapItemRequest.java
+++ b/src/main/java/JJinBBang/app/domain/map/dto/request/NearByMapItemRequest.java
@@ -20,11 +20,11 @@ public record NearByMapItemRequest(
 	Integer page,  // 페이지 번호
 
 	@NotNull(message = "{filter.viewType.notNull}")
-	@Pattern(regexp = "^(ALL|BUILDING|REVIEW)$", message = "{filter.viewType.invalid}")
+//	@Pattern(regexp = "^(ALL|BUILDING|REVIEW)$", message = "{filter.viewType.invalid}")
 	ViewType type, // 보기 유형
 
 	@NotNull(message = "{sortType.notNull}")
-	@Pattern(regexp = "^(LATEST|LIKES|STARS|RCMND)$", message = "{sortType.invalid}")
+//	@Pattern(regexp = "^(LATEST|LIKES|STARS|RCMND)$", message = "{sortType.invalid}")
 	SortType sortBy, // 정렬 기준
 
 	@NotNull(message = "{idList.notNull}")

--- a/src/main/java/JJinBBang/app/domain/map/exception/MapNoContentException.java
+++ b/src/main/java/JJinBBang/app/domain/map/exception/MapNoContentException.java
@@ -18,4 +18,8 @@ public class MapNoContentException extends NoContentGroupException {
 	public static MapNoContentException searchFailed() {
 		return new MapNoContentException("검색 결과가 존재하지 않습니다.");
 	}
+
+	public static MapNoContentException emptyIdList() {
+		return new MapNoContentException("id 리스트가 비어 있습니다.");
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/map/service/MapService.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapService.java
@@ -2,10 +2,13 @@ package JJinBBang.app.domain.map.service;
 
 import java.util.List;
 
+import JJinBBang.app.domain.common.dto.PaginatedResponse;
 import JJinBBang.app.domain.map.dto.request.MapMarkerRequest;
 import JJinBBang.app.domain.map.dto.request.SearchMarkerRequest;
 import JJinBBang.app.domain.map.dto.request.NearByMapItemRequest;
 import JJinBBang.app.domain.map.dto.response.MapItemDetailResponse;
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.global.common.dto.InfoDto;
 import JJinBBang.app.global.common.dto.MarkerInfo;
 
 public interface MapService {
@@ -29,7 +32,8 @@ public interface MapService {
 	 * 주변 건물, 리뷰들을 상세 조회하는 서비스
 	 *
 	 * @param request 페이지네이션, 보기유형, 정렬, idList
+	 * @param user 유저 id 및 정보
 	 * @return 마커 목록
 	 */
-	MapItemDetailResponse nearByMapItems(NearByMapItemRequest request);
+	PaginatedResponse<InfoDto> nearByMapItems(NearByMapItemRequest request, Users user);
 }

--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -1,9 +1,22 @@
 package JJinBBang.app.domain.map.service;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import JJinBBang.app.domain.building.enums.ContractType;
+import JJinBBang.app.domain.building.repository.BuildingLikesRepository;
 import JJinBBang.app.domain.building.repository.BuildingsRepository;
+import JJinBBang.app.domain.building.repository.ReviewLikesRepository;
+import JJinBBang.app.domain.building.repository.ReviewsRepository;
+import JJinBBang.app.domain.building.service.SearchInfo;
+import JJinBBang.app.domain.common.dto.PaginatedResponse;
+import JJinBBang.app.domain.common.enums.SortType;
+import JJinBBang.app.domain.map.exception.MapNotFoundException;
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.global.common.dto.InfoDto;
 import org.springframework.stereotype.Service;
 
 import JJinBBang.app.domain.building.entity.Buildings;
@@ -27,7 +40,10 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MapServiceImpl implements MapService{
 	private final BuildingsRepository buildingsRepository;
-
+	private final ReviewsRepository reviewsRepository;
+	private final BuildingLikesRepository buildingLikesRepository;
+	private final ReviewLikesRepository reviewLikesRepository;
+	private final SearchInfo searchInfo;
 
 	@Override
 	public List<MarkerInfo> getMapMarkers(MapMarkerRequest request) {
@@ -82,10 +98,113 @@ public class MapServiceImpl implements MapService{
 	}
 
 	@Override
-	public MapItemDetailResponse nearByMapItems(NearByMapItemRequest request) {
-		// TODO Auto-generated method stub
-		return null;
+	public PaginatedResponse<InfoDto> nearByMapItems(NearByMapItemRequest request, Users user) {
+		List<Long> ids = request.idList();
+
+		// id가 존재하지 않는 경우 예외처리
+		if (ids == null || ids.isEmpty()) {
+			throw MapNoContentException.emptyIdList();
+		}
+
+		List<InfoDto> items = new ArrayList<>();
+		// View 타입에 따른 리뷰, 건물별 조회
+		for (Long id : ids) {
+			if (request.type() == ViewType.REVIEW) {
+				boolean liked = user != null && reviewLikesRepository
+						.findByReviewIdAndUserUserId(id, user.getUserId())
+						.isPresent();
+				try {
+					items.add(searchInfo.reviewSearch(id, liked));
+				} catch (Exception e) {
+					throw MapNotFoundException.notFoundReview();
+				}
+			} else {
+				Buildings building = buildingsRepository.findById(id)
+						.orElseThrow(MapNotFoundException::notFoundBuilding);
+				boolean liked = user != null && buildingLikesRepository
+						.findByBuildingAndUser(building, user)
+						.isPresent();
+				items.add(searchInfo.buildingSearch(id, liked));
+			}
+		}
+
+		// 정렬
+		Comparator<InfoDto> comparator = getComparator(request.sortBy(), request.type());
+		if (comparator != null) {
+			items.sort(comparator);
+		}
+
+		// 페이징 처리 (page는 1부터 시작)
+		int from = Math.max(0, (request.page() - 1) * request.num());
+		int to = Math.min(items.size(), from + request.num());
+		if (from > to) {
+			from = to;
+		}
+		List<InfoDto> paged = items.subList(from, to);
+
+		return PaginatedResponse.<InfoDto>builder()
+				.num(paged.size())
+				.page(request.page())
+				.itemNum((long) items.size())
+				.items(paged)
+				.build();
 	}
+
+	private Comparator<InfoDto> getComparator(SortType sort, ViewType type) {
+		return switch (sort) {
+			case LIKES -> Comparator.comparing(this::extractLikeCount).reversed();
+			case STARS -> Comparator.comparing(this::extractRating, Comparator.nullsLast(BigDecimal::compareTo)).reversed();
+			case LATEST -> Comparator.comparing(this::extractUpdatedAt, Comparator.nullsLast(LocalDateTime::compareTo)).reversed();
+			case RCMND -> {
+				if (type == ViewType.BUILDING) {
+					yield Comparator.comparing(this::extractReviewCount).reversed();
+				} else {
+					yield null; // 리뷰 추천순은 요청 순서 유지
+				}
+			}
+		};
+	}
+
+	private Integer extractReviewCount(InfoDto dto) {
+		if (dto.generalBuildingInfo() != null) {
+			return dto.generalBuildingInfo().reviewCount();
+		}
+		if (dto.agencyBuildingInfo() != null) {
+			return dto.agencyBuildingInfo().reviewCount();
+		}
+		return 0;
+	}
+
+	private Integer extractLikeCount(InfoDto dto) {
+		return dto.reviewInfo() != null ? dto.reviewInfo().likeCount() : 0;
+	}
+
+	private BigDecimal extractRating(InfoDto dto) {
+		if (dto.generalReviewInfo() != null) {
+			return dto.generalReviewInfo().rating();
+		}
+		if (dto.dormitoryReviewInfo() != null) {
+			return dto.dormitoryReviewInfo().rating();
+		}
+		if (dto.agencyReviewInfo() != null) {
+			return dto.agencyReviewInfo().rating();
+		}
+		if (dto.generalBuildingInfo() != null) {
+			return dto.generalBuildingInfo().rating();
+		}
+		if (dto.dormitoryBuildingInfo() != null) {
+			return dto.dormitoryBuildingInfo().rating();
+		}
+		if (dto.agencyBuildingInfo() != null) {
+			return dto.agencyBuildingInfo().rating();
+		}
+		return BigDecimal.ZERO;
+	}
+
+	private LocalDateTime extractUpdatedAt(InfoDto dto) {
+		return dto.reviewInfo() != null ? dto.reviewInfo().updateAt() : null;
+	}
+
 
 
 	// Validation 메서드


### PR DESCRIPTION
## 📌 이슈 번호
>#77

## 💬 리뷰 포인트
> 내 주변 찐빵 API 구현 및 테스트 

## 🚀 상세 설명
- MapController
- MapService, MapServiceImpl
- MapNoContentException
- NearByMapItemRequest

요청이 비어 있을 때를 처리하기 위해 MapNoContentException에 emptyIdList 추가해 두었고, MapServiceImpl에서는 사용자의 좋아요 여부를 포함해 조회 결과를 정렬/페이징하여  범용성 있게 PaginatedResponse로 반환하도록 했어요..! 
다음 PR때 이전에 만들어둔 범용성 떨어지는 Dto는 제거해두도록 할게요

## 📸 스크린샷
> 200, 성공
<img width="533" height="894" alt="image" src="https://github.com/user-attachments/assets/c6383b79-30bb-4735-8118-96660d4320d4" />


> 404 - 없는 id로 요청한 경우
<img width="537" height="729" alt="image" src="https://github.com/user-attachments/assets/5ecf98b6-4bbe-4afa-92c2-64ead0399113" />


## 📢 노트
해당 API가 이미 develop에 올라간줄 알았는데.. 코드 확인하다가 보니 제가 안올렸더라구요
현재 검색쪽은 먹통이라 수정해서 추가로 검색 API도 올리도록 하겠습니닷..!