### PR TITLE
🐛 Fix[#96]: getUserInfo의 University 정보 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
@@ -27,8 +27,9 @@ public class UsersController {
 			throw InvalidTokenException.unauthorized();
 		}
 		log.info("유저 조회 성공 : {}", user.getUserId());
+		Users withUniversity =  usersService.findWithUniversity(user.getProviderId());
 
-		UserInfoResponseDto response = usersService.getUserInfo(user);
+		UserInfoResponseDto response = usersService.getUserInfo(withUniversity);
 		return new ResTemplate<>(HttpStatus.OK, "유저 정보조회 성공", response);
 	}
 


### PR DESCRIPTION
## 📌 이슈 번호
> 

## 💬 리뷰 포인트
> getUserInfo의 user가 @AuthenticationPrincipal로 사용해서 FetchType.LAZY때문에 University 정보가 없었음

## 🚀 상세 설명
> @EntityGraph를 사용하는 findWithUniversity로 user 재생성

## 📸 스크린샷

## 📢 노트