### PR TITLE
[FIX #103] 건물 상세 조회 응답 중 DormitoryBuildingInfo에 리뷰 개수 포함 

### DIFF
--- a/src/main/java/JJinBBang/app/global/common/dto/DormitoryBuildingInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/DormitoryBuildingInfo.java
@@ -15,7 +15,8 @@ public record DormitoryBuildingInfo(
         String universityName,
         String address,
         BigDecimal rating,
-        Boolean liked
+        Boolean liked,
+        Integer reviewCount
 ) {
     public static DormitoryBuildingInfo of(Buildings building, String universityName, Boolean liked) {
         return DormitoryBuildingInfo.builder()
@@ -26,6 +27,7 @@ public record DormitoryBuildingInfo(
                 .universityName(universityName)
                 .address(building.getBuildingAddress())
                 .rating(building.getBuildingRating())
+                .reviewCount(building.getReviewCount())
                 .liked(liked)
                 .build();
     }


### PR DESCRIPTION
## 📌 이슈 번호
- #103

## 💬 리뷰 포인트
- DormitoryBuildingInfo에 reviewCount 필드를 추가했습니다.

## 🚀 상세 설명
- #103 를 해결하기 위해서 
- DormitoryBuildingInfo에 reviewCount 필드를 추가해서 
- 건물 상세 조회 API로 기숙사 정보를 응답 받을 떄 리뷰 수가 나오도록 수정했습니다.
 
## 📸 스크린샷
<img width="553" height="752" alt="image" src="https://github.com/user-attachments/assets/dc2ff624-5722-47ea-b31b-a3e4c074bc69" />

## 📢 노트