### PR TITLE
:hammer: Refactor[#109] 이메일 인증 로직 업데이트

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/entity/Universities.java
+++ b/src/main/java/JJinBBang/app/domain/common/entity/Universities.java
@@ -30,6 +30,9 @@ public class Universities {
 	@Column(nullable = false)
 	private String universityLogo; // 대학교 로고
 
+	@Column(length = 50)
+	private String universityDomain;
+
 	// 연관관계 매핑
 	// 대학교 -> 캠퍼스
 	@OneToMany(mappedBy = "university", cascade = CascadeType.ALL)

--- a/src/main/java/JJinBBang/app/domain/user/entity/Users.java
+++ b/src/main/java/JJinBBang/app/domain/user/entity/Users.java
@@ -102,4 +102,8 @@ public class Users extends BaseEntity {
 	public void updateVerificationStatus(VerificationStatus verificationStatus) {
 		this.verificationStatus = verificationStatus;
 	}
+
+	public void updateUniversity(Universities university) {
+		this.university = university;
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/user/exception/UniversityNotFoundException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/UniversityNotFoundException.java
@@ -7,5 +7,12 @@ public class UniversityNotFoundException extends NotFoundGroupException {
     public UniversityNotFoundException() {
         super("대학교 데이터 없음");
     }
+    public UniversityNotFoundException(String message) {
+        super(message);
+    }
+
+    public static UniversityNotFoundException universityNotFound(String universityName) {
+        return new UniversityNotFoundException("해당 도메인에 대한 대학교 데이터 없음: " + universityName);
+    }
 
 }

--- a/src/main/java/JJinBBang/app/domain/user/repository/UniversityRepository.java
+++ b/src/main/java/JJinBBang/app/domain/user/repository/UniversityRepository.java
@@ -4,14 +4,15 @@ import JJinBBang.app.domain.common.entity.Universities;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UniversityRepository extends JpaRepository<Universities, Long> {
 
     Page<Universities> findAll(Pageable pageable);
+
+    Optional<Universities> findUniversitiesByUniversityDomain(String universityDomain);
+    boolean existsByUniversityDomain(String universityDomain);
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -4,10 +4,12 @@ import JJinBBang.app.domain.building.dto.PageRequest;
 import JJinBBang.app.domain.building.dto.UserReviewListResponse;
 import JJinBBang.app.domain.building.dto.UserReviewResponse;
 import JJinBBang.app.domain.building.repository.*;
+import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.domain.user.dto.UserInfoResponseDto;
+import JJinBBang.app.domain.user.exception.UniversityNotFoundException;
+import JJinBBang.app.domain.user.repository.UniversityRepository;
 import org.springframework.data.domain.Pageable;
 import JJinBBang.app.global.common.enums.VerificationStatus;
-import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import JJinBBang.app.domain.user.entity.Users;
@@ -31,6 +33,7 @@ public class UsersServiceImpl implements UsersService {
 	private final AgencyReviewsRepository agencyReviewsRepository;
 	private final ReviewLikesRepository reviewLikesRepository;
 	private final ReviewDetailsRepository reviewDetailsRepository;
+	private final UniversityRepository universityRepository;
 
 	@Override
 	public boolean existsByProviderId(String providerId) {
@@ -122,9 +125,19 @@ public class UsersServiceImpl implements UsersService {
 		return "http://localhost:8080/image/" + id + ".jpg";
 	}
 
+	@Override
 	public Users verifyUniversityEmail(Users user, String universityEmail) {
+		// 유저의 학교 이메일 업데이트
 		user.updateUniversityEmail(universityEmail);
+		// 유저의 인증 상태 업데이트
 		user.updateVerificationStatus(VerificationStatus.EMAIL_VERIFIED);
+
+		// 유저의 학교 정보 업데이트
+		String domain = extractDomain(universityEmail);
+		Universities authenticatedUniversity = universityRepository.findUniversitiesByUniversityDomain(domain)
+				.orElseThrow(() -> UniversityNotFoundException.universityNotFound(domain));
+		user.updateUniversity(authenticatedUniversity);
+
 		return usersRepository.save(user);
 	}
 
@@ -132,5 +145,13 @@ public class UsersServiceImpl implements UsersService {
 	public Users findWithUniversity(String providerId) {
 		return usersRepository.findWithUniversityByProviderId(providerId)
 				.orElseThrow(UserNotFoundException::notFound);
+	}
+
+
+	private String extractDomain(String email) {
+		int atIdx = email.lastIndexOf("@");
+		return (atIdx != -1 && atIdx < email.length() - 1)
+				? email.substring(atIdx + 1)
+				: "";
 	}
 }

--- a/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.global.mail.service.impl;
 
+import JJinBBang.app.domain.user.repository.UniversityRepository;
 import JJinBBang.app.global.mail.dto.EmailAuthInfo;
 import JJinBBang.app.global.mail.exception.MailInvalidException;
 import JJinBBang.app.global.mail.exception.MailNotFoundException;
@@ -21,6 +22,7 @@ public class MailAuthServiceImpl implements MailAuthService {
     private final Random random = new Random();
     private final MailSendService mailSendService;
     private final EmailAuthCodeRepository emailAuthCodeRepository;
+    private final UniversityRepository universityRepository;
 
     @Override
     public void sendAuthCode(Long userId, String toEmail) {
@@ -70,7 +72,11 @@ public class MailAuthServiceImpl implements MailAuthService {
         if (!isValidFormat(email)) {
             throw MailInvalidException.invalidEmailFormat();
         }
-        if (!properties.getAllowedDomain().contains(extractDomain(email))) {
+
+        // 이메일 도메인 검증
+        // DB에 저장되어있는 이메일 도메인인지 or 환경변수에 설정된 도메인인지 검사
+        if (!universityRepository.existsByUniversityDomain(extractDomain(email)) &&
+                !properties.getAllowedDomain().contains(extractDomain(email))) {
             throw MailInvalidException.invalidEmailDomain();
         }
     }


### PR DESCRIPTION
## 📌 이슈 번호
> ex) #1

Issue #109 

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요

베타 버전으로 개발하였습니다.

변경사항
1. Universities 엔티티에 universityDomain 필드 추가 (nullable, length 50)
2. 이메일 인증코드 요청 시 도메인을 환경변수로만 비교 => 환경변수 + db에 저장되어있는 대학교의 도메인과 함께 비교
3. 인증 완료 시 유저의 대학 정보를 해당 도메인을 기준으로 업데이트

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

수정된 서비스 로직 설명입니다.
1. 기존 방식대로 재학생 인증 클릭
2. 아이디 + 도메인 전부 입력 후 메일 전송
3. 서버에서 도메인과 대학교를 매칭한 후 유효하지 않은 도메인이면 인증 취소
4. 유효한 도메인이라면 인증 이후 유저의 대학교 정보 업데이트

대학교 별 도메인 정보는 추후 업데이트 예정입니다.

## 📸 스크린샷

1. Universities 엔티티
<img width="581" height="128" alt="image" src="https://github.com/user-attachments/assets/4cd46110-693b-4174-8b3c-ad8f490ecd6c" />

2. 인증 완료 시 유저 정보 조회 결과
<img width="399" height="251" alt="image" src="https://github.com/user-attachments/assets/16ddbe04-1974-4b62-af9f-fcda5ba084a5" />

## 📢 노트