### PR TITLE
:sparkles: Feat[#128] 네이버 로그인 API 개발

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/exception/NaverAuthException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/NaverAuthException.java
@@ -1,0 +1,21 @@
+package JJinBBang.app.domain.user.exception;
+
+public class NaverAuthException extends RuntimeException {
+
+    public NaverAuthException(String message) {
+        super(message);
+    }
+
+    public static NaverAuthException existAccount(){
+        return new NaverAuthException("이미 회원가입된 계정입니다.");
+    }
+
+    public static NaverAuthException accessTokenGenerateError(){
+        return new NaverAuthException("네이버 API 엑세스 토큰 발급에 실패하였습니다.");
+    }
+
+    public static NaverAuthException userInfoFetchFailed(){
+        return new NaverAuthException("네이버 API 엑세스 토큰으로 유저 정보 조회에 실패하였습니다.");
+    }
+
+}

--- a/src/main/java/JJinBBang/app/domain/user/service/login/NaverLoginServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/login/NaverLoginServiceImpl.java
@@ -1,0 +1,119 @@
+package JJinBBang.app.domain.user.service.login;
+
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.exception.NaverAuthException;
+import JJinBBang.app.domain.user.service.UsersService;
+import JJinBBang.app.global.common.enums.Provider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NaverLoginServiceImpl implements LoginService {
+
+    @Value("${spring.security.oauth2.client.provider.naver.token-uri}")
+    private String tokenUrl;
+
+    @Value("${spring.security.oauth2.client.provider.naver.user-info-uri}")
+    private String userInfoUrl;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.naver.redirect-uri}")
+    private String redirectUri;
+
+    private final UsersService usersService;
+
+    @Override
+    public String getProviderName() {
+        return Provider.naver.name();
+    }
+
+    @Override
+    public String makeProviderId(String id) {
+        return Provider.naver.name() + "_" + id;
+    }
+
+    @Override
+    public Users login(String oauthCode) {
+        // 1) 액세스 토큰 발급
+        String accessToken = getAccessToken(oauthCode);
+
+        // 2) 유저 정보 조회
+        Map<String, Object> naverUserInfo = getUserInfo(accessToken);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> response = (Map<String, Object>) naverUserInfo.get("response");
+        String naverId = (String) response.get("id");
+
+        // 3) providerId 조합
+        String providerId = makeProviderId(naverId);
+
+        // 4) DB에 있으면 가져오고, 없으면 회원가입 대기용 DTO 리턴
+        if (usersService.existsByProviderId(providerId)) {
+            return usersService.findByProviderId(providerId);
+        }
+
+        return Users.builder()
+                .provider(Provider.naver)
+                .providerId(providerId)
+                .build();
+    }
+
+    private String getAccessToken(String code) {
+        try {
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("grant_type", "authorization_code");
+            params.add("client_id", clientId);
+            params.add("client_secret", clientSecret);
+            params.add("redirect_uri", redirectUri);
+            params.add("code", code);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+            RestTemplate rt = new RestTemplate();
+            HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+            ResponseEntity<Map> response = rt.postForEntity(tokenUrl, request, Map.class);
+
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                return (String) response.getBody().get("access_token");
+            }
+            throw NaverAuthException.accessTokenGenerateError();
+        } catch (Exception e) {
+            log.error("네이버 AccessToken 발급 실패", e);
+            throw NaverAuthException.accessTokenGenerateError();
+        }
+    }
+
+    private Map<String, Object> getUserInfo(String accessToken) {
+        try {
+            RestTemplate rt = new RestTemplate();
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(accessToken);
+
+            HttpEntity<Void> request = new HttpEntity<>(headers);
+            ResponseEntity<Map> response = rt.exchange(userInfoUrl, HttpMethod.GET, request, Map.class);
+
+            if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+                return response.getBody();
+            }
+            throw NaverAuthException.userInfoFetchFailed();
+        } catch (Exception e) {
+            log.error("네이버 유저 정보 조회 실패", e);
+            throw NaverAuthException.userInfoFetchFailed();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,13 +37,23 @@ spring:
             redirect-uri: ${spring.security.oauth2.client.registration.kakao.redirect-uri}
             client-name: ${spring.security.oauth2.client.registration.kakao.client-name}
 #            scope: ${spring.security.oauth2.client.registration.kakao.scope} # 필요 시 활성화
-
+          naver:
+            client-id: ${spring.security.oauth2.client.registration.naver.client-id}
+            client-secret: ${spring.security.oauth2.client.registration.naver.client-secret}
+            redirect-uri: ${spring.security.oauth2.client.registration.naver.redirect-uri}
+            authorization-grant-type: ${spring.security.oauth2.client.registration.naver.authorization-grant-type}
+            client-authentication-method: ${spring.security.oauth2.client.registration.naver.client-authentication-method}
         provider:
           kakao:
             authorization-uri: ${spring.security.oauth2.client.provider.kakao.authorization-uri}
             token-uri: ${spring.security.oauth2.client.provider.kakao.token-uri}
             user-info-uri: ${spring.security.oauth2.client.provider.kakao.user-info-uri}
             user-name-attribute: ${spring.security.oauth2.client.provider.kakao.user-name-attribute}
+          naver:
+            authorization-uri: ${spring.security.oauth2.client.provider.naver.authorization-uri}
+            token-uri: ${spring.security.oauth2.client.provider.naver.token-uri}
+            user-info-uri: ${spring.security.oauth2.client.provider.naver.user-info-uri}
+            user-name-attribute: ${spring.security.oauth2.client.provider.naver.user-name-attribute}
 
   mail:
     host: smtp.gmail.com


### PR DESCRIPTION
## 📌 이슈 번호
> #128

## 💬 리뷰 포인트
> 네이버 로그인 API 개발 주요 변경 사항

- 네이버 OAuth2 토큰 발급 및 사용자 정보 조회 기능 구현  
- 예외 처리용 `NaverAuthException` 클래스 추가  
- `application.yml`에 네이버 OAuth2 설정 반영  

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

1. `NaverAuthException` 예외 클래스 추가

2. `NaverLoginServiceImpl` 구현
   - `getAccessToken(String code)`  
     - `RestTemplate`와 `HttpEntity`를 사용해 authorization 코드로부터 액세스 토큰 발급  
     - 오류 시 `NaverAuthException.accessTokenGenerateError()` 호출  
   - `getUserInfo(String accessToken)`  
     - Bearer 토큰을 헤더에 실어 네이버 사용자 정보 조회  
     - 2xx 응답이 아니거나 응답 바디가 없으면 `NaverAuthException.userInfoFetchFailed()` 호출  
   - `login(String oauthCode)`  
     - 발급된 토큰으로 사용자 정보 가져와 `providerId` 조합  
     - `usersService.existsByProviderId()`로 기존 회원 검증 후, 없으면 신규 가입용 `Users` 빌더 반환  

3. `application.yml` 설정 추가

## 📸 스크린샷

<img width="433" height="293" alt="image" src="https://github.com/user-attachments/assets/431bec2a-e38c-47a4-9ea3-eb84233e3162" />

네이버 로그인 진행 화면
<img width="562" height="573" alt="image" src="https://github.com/user-attachments/assets/5b90ffe2-97e2-43f0-82ec-3e6568aa70cb" />

로그인 성공 화면
<img width="694" height="458" alt="image" src="https://github.com/user-attachments/assets/af29c91f-9809-496a-ada0-d40b4565201c" />

저장된 유저 정보
<img width="216" height="117" alt="image" src="https://github.com/user-attachments/assets/829a2b18-3f39-4f15-9f48-b7a65caae4d9" />
<img width="90" height="84" alt="image" src="https://github.com/user-attachments/assets/af4e5628-dd2a-4552-9cb7-2364d6baf4c3" />

## 📢 노트

네이버 로그인 API 계정은 제 계정으로 구현하였습니다.