### PR TITLE
:sparkles: Feat[#128] 구글 로그인 API 개발

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/exception/GoogleAuthException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/GoogleAuthException.java
@@ -1,0 +1,21 @@
+package JJinBBang.app.domain.user.exception;
+
+import JJinBBang.app.global.error.exception.AuthGroupException;
+
+public class GoogleAuthException extends AuthGroupException {
+    public GoogleAuthException(String message) {
+        super(message);
+    }
+
+    public static GoogleAuthException existAccount(){
+        return new GoogleAuthException("이미 회원가입된 계정입니다.");
+    }
+
+    public static GoogleAuthException accessTokenGenerateError(){
+        return new GoogleAuthException("구글 API 엑세스 토큰 발급에 실패하였습니다.");
+    }
+
+    public static GoogleAuthException userInfoFetchFailed(){
+        return new GoogleAuthException("구글 API 엑세스 토큰으로 유저 정보 조회에 실패하였습니다.");
+    }
+}

--- a/src/main/java/JJinBBang/app/domain/user/service/login/GoogleLoginServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/login/GoogleLoginServiceImpl.java
@@ -1,0 +1,101 @@
+package JJinBBang.app.domain.user.service.login;
+
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.exception.GoogleAuthException;
+import JJinBBang.app.domain.user.service.UsersService;
+import JJinBBang.app.global.common.enums.Provider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleLoginServiceImpl implements LoginService {
+
+    @Value("${spring.security.oauth2.client.provider.google.token-uri}")
+    private String tokenUri;
+
+    @Value("${spring.security.oauth2.client.provider.google.user-info-uri}")
+    private String userInfoUri;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
+    private String redirectUri;
+
+    private final UsersService usersService;
+
+    @Override
+    public String getProviderName() {
+        return Provider.google.name();
+    }
+
+    @Override
+    public String makeProviderId(String id) {
+        return Provider.google.name() + "_" + id;
+    }
+
+    @Override
+    public Users login(String oauthCode) {
+        String accessToken = requestAccessToken(oauthCode);
+        Map<String, Object> profile = requestUserInfo(accessToken);
+
+        String googleId = (String) profile.get("sub");
+        String providerId = makeProviderId(googleId);
+
+        if (usersService.existsByProviderId(providerId)) {
+            return usersService.findByProviderId(providerId);
+        }
+
+        // 신규 가입 flow
+        return Users.builder()
+                .provider(Provider.google)
+                .providerId(providerId)
+                .build();
+    }
+
+    private String requestAccessToken(String code) {
+        RestTemplate rt = new RestTemplate();
+        MultiValueMap<String,String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        HttpEntity<MultiValueMap<String,String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<Map> resp = rt.postForEntity(tokenUri, request, Map.class);
+        if (!resp.getStatusCode().is2xxSuccessful() || resp.getBody()==null) {
+            throw GoogleAuthException.accessTokenGenerateError();
+        }
+        return (String) resp.getBody().get("access_token");
+    }
+
+    private Map<String,Object> requestUserInfo(String accessToken) {
+        RestTemplate rt = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<Void> req = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> resp = rt.exchange(userInfoUri, HttpMethod.GET, req, Map.class);
+        if (!resp.getStatusCode().is2xxSuccessful() || resp.getBody()==null) {
+            throw GoogleAuthException.userInfoFetchFailed();
+        }
+        return resp.getBody();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,13 @@ spring:
             redirect-uri: ${spring.security.oauth2.client.registration.kakao.redirect-uri}
             client-name: ${spring.security.oauth2.client.registration.kakao.client-name}
 #            scope: ${spring.security.oauth2.client.registration.kakao.scope} # 필요 시 활성화
+          google:
+            client-id: ${spring.security.oauth2.client.registration.google.client-id}
+            client-secret: ${spring.security.oauth2.client.registration.google.client-secret}
+            client-authentication-method: ${spring.security.oauth2.client.registration.google.client-authentication-method}
+            authorization-grant-type: ${spring.security.oauth2.client.registration.google.authorization-grant-type}
+            redirect-uri: ${spring.security.oauth2.client.registration.google.redirect-uri}
+            client-name: ${spring.security.oauth2.client.registration.google.client-name}
 
         provider:
           kakao:
@@ -44,6 +51,11 @@ spring:
             token-uri: ${spring.security.oauth2.client.provider.kakao.token-uri}
             user-info-uri: ${spring.security.oauth2.client.provider.kakao.user-info-uri}
             user-name-attribute: ${spring.security.oauth2.client.provider.kakao.user-name-attribute}
+          google:
+            authorization-uri: ${spring.security.oauth2.client.provider.google.authorization-uri}
+            token-uri: ${spring.security.oauth2.client.provider.google.token-uri}
+            user-info-uri: ${spring.security.oauth2.client.provider.google.user-info-uri}
+            user-name-attribute: ${spring.security.oauth2.client.provider.google.user-name-attribute}
 
   mail:
     host: smtp.gmail.com


### PR DESCRIPTION
## 📌 이슈 번호
> #129

## 💬 리뷰 포인트
> 구글 로그인 API 개발 주요 변경 사항

- 구글 OAuth2 토큰 발급 및 사용자 정보 조회 기능 구현  
- 예외 처리용 `GoogleAuthException` 클래스 추가  
- `application.yml`에 구글 OAuth2 설정 반영  

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

1. `GoogleAuthException` 예외 클래스 추가

2. `GoogleLoginServiceImpl` 구현
   - `getAccessToken(String code)`  
     - `RestTemplate`와 `HttpEntity`를 사용해 authorization 코드로부터 액세스 토큰 발급  
     - 오류 시 `GoogleAuthException.accessTokenGenerateError()` 호출  
   - `getUserInfo(String accessToken)`  
     - Bearer 토큰을 헤더에 실어 네이버 사용자 정보 조회  
     - 2xx 응답이 아니거나 응답 바디가 없으면 `GoogleAuthException.userInfoFetchFailed()` 호출  
   - `login(String oauthCode)`  
     - 발급된 토큰으로 사용자 정보 가져와 `providerId` 조합  
     - `usersService.existsByProviderId()`로 기존 회원 검증 후, 없으면 신규 가입용 `Users` 빌더 반환  

3. `application.yml` 설정 추가

## 📸 스크린샷

<img width="433" height="293" alt="image" src="https://github.com/user-attachments/assets/431bec2a-e38c-47a4-9ea3-eb84233e3162" />

구글 로그인 진행 화면
<img width="909" height="516" alt="image" src="https://github.com/user-attachments/assets/62ae2f07-8cca-4f7e-9e28-a83d2874ff2d" />
<img width="881" height="459" alt="image" src="https://github.com/user-attachments/assets/bda3b2c9-0a9b-4cac-b467-80a5b72178ff" />


로그인 성공 화면
<img width="707" height="356" alt="image" src="https://github.com/user-attachments/assets/aa3e80b8-ae48-45b7-9304-0f29cd1a1ecc" />

저장된 유저 정보
<img width="209" height="104" alt="image" src="https://github.com/user-attachments/assets/1994bc38-9723-4c62-af48-cc16ab2dc2fa" />
<img width="114" height="88" alt="image" src="https://github.com/user-attachments/assets/2317ded5-5064-4df8-85e2-7ceeb1305915" />

## 📢 노트

구글 로그인 API 계정은 Univ 공용 계정으로 개발하였습니다.
추가로 프론트 베포 시 도메인을 적용하지 않은 경우 redirect uri이 정상적으로 작동하지 않을 수 있습니다!