### PR TITLE
[Feat #132] 공인중개사, 건물, 리뷰 관련 좋아요 수 관리 메서드 구현

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/entity/Agencies.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Agencies.java
@@ -163,4 +163,17 @@ public class Agencies extends BaseEntity {
 			this.imagesCount--;
 		}
 	}
+
+	public void incrementLikeCount() {
+		if (this.likeCount == null) {
+			this.likeCount = 0;
+		}
+		this.likeCount++;
+	}
+
+	public void decrementLikeCount() {
+		if (this.likeCount > 0) {
+			this.likeCount--;
+		}
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
@@ -209,4 +209,17 @@ public class Buildings extends BaseEntity {
 			this.imagesCount--;
 		}
 	}
+
+    public void decrementLikeCount() {
+		if (this.likeCount > 0) {
+			this.likeCount--;
+		}
+	}
+
+	public void incrementLikeCount() {
+		if (this.likeCount == null) {
+			this.likeCount = 0;
+		}
+		this.likeCount++;
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
@@ -96,4 +96,17 @@ public class Reviews extends BaseEntity {
         this.agency         = agency;
         this.reviewLikes    = (reviewLikes == null) ? new ArrayList<>() : reviewLikes;
     }
+
+    public void incrementLikeCount() {
+        if (this.likesCount == null) {
+            this.likesCount = 0;
+        }
+        this.likesCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likesCount > 0) {
+            this.likesCount--;
+        }
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/AgencyLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/AgencyLikesRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface AgencyLikesRepository extends CrudRepository<AgencyLikes, Long> {
     Optional<AgencyLikes> findByAgencyAndUser(Agencies agency, Users user);
 
+    Boolean existsByAgencyAndUser(Agencies agencies, Users users);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/BuildingLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/BuildingLikesRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 
 public interface BuildingLikesRepository extends CrudRepository<BuildingLikes, BuildingLikeId> {
     Optional<BuildingLikes> findByBuildingAndUser(Buildings building, Users user);
+
+    Boolean existsByBuildingAndUser(Buildings buildings, Users users);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/ReviewLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/ReviewLikesRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface ReviewLikesRepository extends CrudRepository<ReviewLikes, Long> {
     Optional<ReviewLikes> findByReviewAndUser(Reviews reviews, Users user);
     Optional<ReviewLikes> findByReviewIdAndUserUserId(Long reviewId, Long userId);
+    Boolean existsByReviewAndUser(Reviews reviews, Users user);
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/BookmarkServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BookmarkServiceImpl.java
@@ -36,49 +36,84 @@ public class BookmarkServiceImpl implements BookmarkService{
     @Transactional
     public void buildingBookmark(Long buildingId, Users users, boolean liked){
         Buildings buildings = buildingsRepository.findById(buildingId).orElseThrow(() -> new BookmarkNotFoundException("Building"));
-        if(liked){
+
+        Boolean isLiked = buildingLikesRepository.existsByBuildingAndUser(buildings, users);
+
+        // 원래 좋아요가 없고, 현재 좋아요를 누른 경우
+        if(!isLiked && liked){
             BuildingLikes newLike = BuildingLikes.create(buildings, users);
             buildings.incrementLikeCount();
             buildingLikesRepository.save(newLike);
         }
-        else{
+
+        // 원래 좋아요가 있고, 현재 좋아요를 취소한 경우
+        if (isLiked && !liked){
             BuildingLikes savedLike = buildingLikesRepository.findByBuildingAndUser(buildings,users).orElseThrow(() -> new BookmarkNotFoundException("BuildingLikes"));
             buildings.decrementLikeCount();
             buildingLikesRepository.delete(savedLike);
         }
+
+        // 원래 좋아요가 있고, 현재 좋아요를 누른 경우
+        // (변경 없음)
+
+        // 원래 좋아요가 없고, 현재 좋아요를 취소한 경우
+        // (변경 없음)
     }
 
     @Override
     @Transactional
     public void reviewBookmark(Long reviewId, Users users, boolean liked) {
         Reviews reviews = reviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("Review"));
-        if(liked){
+
+        Boolean isLiked = reviewLikesRepository.existsByReviewAndUser(reviews, users);
+
+        // 원래 좋아요가 없고, 현재 좋아요 누른 경우
+        if(!isLiked && liked) {
             ReviewLikes newLike = ReviewLikes.create(reviews, users);
             reviews.incrementLikeCount();
             reviewLikesRepository.save(newLike);
         }
-        else{
+
+        // 원래 좋아요가 있고, 현재 좋아요 취소를 누른 경우
+        if(isLiked && !liked) {
             ReviewLikes savedLike = reviewLikesRepository.findByReviewAndUser(reviews,users).orElseThrow(() -> new BookmarkNotFoundException("ReviewLikes"));
             reviews.decrementLikeCount();
             reviewLikesRepository.delete(savedLike);
         }
 
+        // 원래 좋아요가 있고, 현재 좋아요를 누른 경우
+        // (변경 없음)
+
+        // 원래 좋아요가 없고, 현재 좋아요 취소를 누른 경우
+        // (변경 없음)
     }
 
     @Override
     @Transactional
     public void agencyBookmark(Long agencyId, Users users, boolean liked) {
         Agencies agencies = agenciesRepository.findById(agencyId).orElseThrow(()->new BookmarkNotFoundException("Agencies"));
-        if(liked){
+
+        Boolean isLiked = agencyLikesRepository.existsByAgencyAndUser(agencies, users);
+
+        // 원래 좋아요가 없고, 현재 좋아요를 누른 경우
+        if(!isLiked && liked){
             AgencyLikes newLike = AgencyLikes.create(agencies, users);
             agencies.incrementLikeCount();
             agencyLikesRepository.save(newLike);
         }
-        else{
+
+        // 원래 좋아요가 있고, 현재 좋아요 취소를 누른 경우
+        if(isLiked && !liked){
             AgencyLikes saveLike = agencyLikesRepository.findByAgencyAndUser(agencies,users).orElseThrow(() -> new BookmarkNotFoundException("AgencyLikes"));
             agencies.decrementLikeCount();
             agencyLikesRepository.delete(saveLike);
         }
+
+        // 원래 좋아요가 있고, 현재 좋아요를 누른 경우
+        // (변경 없음)
+
+        // 원래 좋아요가 없고, 현재 좋아요 취소를 누른 경우
+        // (변경 없음)
     }
 
     @Override

--- a/src/main/java/JJinBBang/app/domain/building/service/BookmarkServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BookmarkServiceImpl.java
@@ -7,7 +7,6 @@ import JJinBBang.app.domain.building.exception.*;
 import JJinBBang.app.domain.building.repository.*;
 import JJinBBang.app.domain.user.entity.Users;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -39,10 +38,12 @@ public class BookmarkServiceImpl implements BookmarkService{
         Buildings buildings = buildingsRepository.findById(buildingId).orElseThrow(() -> new BookmarkNotFoundException("Building"));
         if(liked){
             BuildingLikes newLike = BuildingLikes.create(buildings, users);
+            buildings.incrementLikeCount();
             buildingLikesRepository.save(newLike);
         }
         else{
             BuildingLikes savedLike = buildingLikesRepository.findByBuildingAndUser(buildings,users).orElseThrow(() -> new BookmarkNotFoundException("BuildingLikes"));
+            buildings.decrementLikeCount();
             buildingLikesRepository.delete(savedLike);
         }
     }
@@ -53,10 +54,12 @@ public class BookmarkServiceImpl implements BookmarkService{
         Reviews reviews = reviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("Review"));
         if(liked){
             ReviewLikes newLike = ReviewLikes.create(reviews, users);
+            reviews.incrementLikeCount();
             reviewLikesRepository.save(newLike);
         }
         else{
             ReviewLikes savedLike = reviewLikesRepository.findByReviewAndUser(reviews,users).orElseThrow(() -> new BookmarkNotFoundException("ReviewLikes"));
+            reviews.decrementLikeCount();
             reviewLikesRepository.delete(savedLike);
         }
 
@@ -68,10 +71,12 @@ public class BookmarkServiceImpl implements BookmarkService{
         Agencies agencies = agenciesRepository.findById(agencyId).orElseThrow(()->new BookmarkNotFoundException("Agencies"));
         if(liked){
             AgencyLikes newLike = AgencyLikes.create(agencies, users);
+            agencies.incrementLikeCount();
             agencyLikesRepository.save(newLike);
         }
         else{
             AgencyLikes saveLike = agencyLikesRepository.findByAgencyAndUser(agencies,users).orElseThrow(() -> new BookmarkNotFoundException("AgencyLikes"));
+            agencies.decrementLikeCount();
             agencyLikesRepository.delete(saveLike);
         }
     }


### PR DESCRIPTION
## 📌 이슈 번호
\#132

## 💬 리뷰 포인트
- 엔티티(`Agencies`, `Buildings`, `Reviews`)에 **좋아요 수 증감 메서드**(`incrementLikeCount`, `decrementLikeCount`) 추가  
- 각 도메인별 좋아요 존재 여부 조회용 **Repository 메서드**(`existsBy…AndUser`) 추가  
- `BookmarkServiceImpl`에서 좋아요 토글 로직에 **엔티티 좋아요 수 업데이트** 기능 통합

## 🚀 상세 설명
1. **엔티티 변경**  
   - `Agencies`, `Buildings`, `Reviews` 클래스에 `incrementLikeCount()`/`decrementLikeCount()` 메서드를 구현하여, 좋아요 생성·삭제 시 카운트를 안전하게 조정하도록 했습니다.  
   - `likeCount`가 `null`일 때 초기화하고, 0보다 큰 경우에만 감소하도록 방어 로직을 포함했습니다.

2. **Repository 확장**  
   - `AgencyLikesRepository`, `BuildingLikesRepository`, `ReviewLikesRepository`에 `existsBy…AndUser(...)` 메서드를 선언해, 특정 사용자·대상간 좋아요 존재 여부를 빠르게 조회할 수 있게 했습니다.

3. **서비스 로직 개선** (`BookmarkServiceImpl`)  
   - **건물**, **리뷰**, **공인중개사** 즐겨찾기 메서드(`buildingBookmark`, `reviewBookmark`, `agencyBookmark`)에서  
     1. `existsBy…AndUser`로 현재 좋아요 상태 확인  
     2. “좋아요 누름 → 없던 좋아요 생성 + `incrementLikeCount()`”  
     3. “좋아요 취소 → 있던 좋아요 삭제 + `decrementLikeCount()`”  
     순서로 처리하도록 변경했습니다.  
   - 기존에는 좋아요 생성/삭제만 처리했지만, 이제 엔티티의 `likeCount` 필드도 관리됩니다.

## 📸 스크린샷
해당 없음

## 📢 노트
