### PR TITLE
:sparkles: Feat[#134]: 토큰 재발급 시 리프레시 토큰도 함께 생성

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -2,10 +2,8 @@ package JJinBBang.app.domain.user.controller;
 
 import JJinBBang.app.domain.user.dto.request.IssueEmailCodeRequest;
 import JJinBBang.app.domain.user.dto.request.LoginRequest;
-import JJinBBang.app.domain.user.dto.request.SignupRequest;
 import JJinBBang.app.domain.user.dto.request.VerifyEmailCodeRequest;
-import JJinBBang.app.domain.user.dto.response.LoginResponse;
-import JJinBBang.app.domain.user.dto.response.ReissueAccessTokenResponse;
+import JJinBBang.app.domain.user.dto.response.TokenResponse;
 import JJinBBang.app.domain.user.dto.response.SignupRequiredResponse;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.domain.user.service.OAuthService;
@@ -52,21 +50,21 @@ public class AuthController {
             String accessToken = jwtUtils.generateAccessToken(user);
             String refreshToken = jwtUtils.generateRefreshToken(user);
 
-            LoginResponse loginResponse = LoginResponse.of(accessToken, refreshToken);
-            return new ResTemplate<>(HttpStatus.OK, "로그인 성공", loginResponse);
+            TokenResponse response = TokenResponse.of(accessToken, refreshToken);
+            return new ResTemplate<>(HttpStatus.OK, "로그인 성공", response);
         }
     }
 
     @PostMapping("/signup")
-    public ResTemplate<LoginResponse> signUp(@AuthenticationPrincipal Users user) {
+    public ResTemplate<TokenResponse> signUp(@AuthenticationPrincipal Users user) {
         // 로그인 한 유저에 대해 약관 동의를 수행하는 API 입니다.
 
         user = oAuthService.signup(user);
         String accessToken = jwtUtils.generateAccessToken(user);
         String refreshToken = jwtUtils.generateRefreshToken(user);
 
-        LoginResponse loginResponse = LoginResponse.of(accessToken, refreshToken);
-        return new ResTemplate<>(HttpStatus.OK, "회원가입 성공", loginResponse);
+        TokenResponse response = TokenResponse.of(accessToken, refreshToken);
+        return new ResTemplate<>(HttpStatus.OK, "회원가입 성공", response);
     }
 
     @PostMapping("/emailCode")
@@ -103,22 +101,22 @@ public class AuthController {
     }
 
     @PutMapping("/tokenRefresh")
-    public ResTemplate<ReissueAccessTokenResponse> reissueAccessToken(
+    public ResTemplate<TokenResponse> reissueAccessToken(
             HttpServletRequest request,
             @AuthenticationPrincipal Users user
     ){
         String refreshToken = jwtUtils.extractToken(request);
         String accessToken = jwtUtils.reissueAccessToken(user, refreshToken);
+        String newRefreshToken = jwtUtils.generateRefreshToken(user);
 
-        ReissueAccessTokenResponse response = ReissueAccessTokenResponse.of(accessToken);
-        return new ResTemplate<>(HttpStatus.OK, "엑세스 토큰 재발급 성공", response);
+        TokenResponse response = TokenResponse.of(accessToken, newRefreshToken);
+        return new ResTemplate<>(HttpStatus.OK, "엑세스 토큰, 리프레시 토큰 재발급 성공", response);
     }
 
     @DeleteMapping("/logout")
     public ResTemplate<?> logout(
             @AuthenticationPrincipal Users user
     ){
-        // TODO : 엑세스, 리프레시 토큰 블랙리스트 처리
         jwtUtils.deleteRefreshToken(user.getUserId());
         return new ResTemplate<>(HttpStatus.OK, "로그아웃 성공", null);
     }

--- a/src/main/java/JJinBBang/app/domain/user/dto/response/TokenResponse.java
+++ b/src/main/java/JJinBBang/app/domain/user/dto/response/TokenResponse.java
@@ -3,12 +3,12 @@ package JJinBBang.app.domain.user.dto.response;
 import lombok.Builder;
 
 @Builder
-public record LoginResponse(
+public record TokenResponse(
         String accessToken,
         String refreshToken
 ) {
-    public static LoginResponse of(String accessToken, String refreshToken) {
-        return LoginResponse.builder()
+    public static TokenResponse of(String accessToken, String refreshToken) {
+        return TokenResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/src/main/java/JJinBBang/app/global/jwt/service/impl/RefreshTokenGenerateServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/jwt/service/impl/RefreshTokenGenerateServiceImpl.java
@@ -36,7 +36,6 @@ public class RefreshTokenGenerateServiceImpl extends AbstractTokenGenerateServic
             return refreshTokenRepository.save(user.getUserId(), refreshToken, super.expirationTime);
         }
         // 기존 리프레시 토큰이 존재하는 경우, 새로운 리프레시 토큰을 저장하고 반환
-        // TODO : 블랙리스트 추가 로직 구현
         refreshTokenRepository.deleteByUserId(user.getUserId());
         return refreshTokenRepository.save(user.getUserId(), refreshToken, super.expirationTime);
     }


### PR DESCRIPTION
## 📌 이슈 번호
> #134

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요

토큰 재발급 시 엑세스토큰과 함께 리프레시 토큰도 생성하고, 이전의 리프레시 토큰은 만료시키도록 로직 수정

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

## 📸 스크린샷

성공 결과
<img width="1011" height="541" alt="image" src="https://github.com/user-attachments/assets/5221a4b0-54a1-47d8-9098-4a8745ad94e9" />

동일한 리프레시 토큰 재사용 시
<img width="1002" height="470" alt="image" src="https://github.com/user-attachments/assets/1908b1ab-0705-408b-8877-e51306deb529" />


## 📢 노트