### PR TITLE
✨ Feat: buildingSearch 리팩토링 진행

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.domain.building.service;
 
+import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.global.common.dto.InfoDto;
 import JJinBBang.app.domain.building.entity.*;
 import JJinBBang.app.domain.building.enums.ReviewType;
@@ -50,16 +51,32 @@ public class SearchInfo {
     }
 
     public InfoDto buildingSearch(Long itemId, Boolean liked){
-        Buildings building = buildingsRepository.findById(itemId).orElseThrow(() -> new BookmarkNotFoundException("Building"));
-        Reviews reviews= reviewsRepository.findFirstByBuildingOrderByCreatedAtDesc(building);
-        if (building.getBuildingType().equals("DORMITORY")){
-            Campuses campuses = building.getCampus();
-            Universities universities = campuses.getUniversity();
-            String universityName = universities.getUniversityName();
-            return InfoDto.ofDormitoryBuildingInfo(reviews,building,universityName,liked);
+        Buildings building = buildingsRepository.findById(itemId)
+                .orElseThrow(() -> new BookmarkNotFoundException("Building"));
+
+        Reviews reviews = reviewsRepository.findFirstByBuildingOrderByCreatedAtDesc(building);
+
+        BuildingType mainType = BuildingType.ALL;
+        if (building.getBuildingType().contains(BuildingType.DORMITORY)) {
+            mainType = BuildingType.DORMITORY;
+        } else if (building.getBuildingType().contains(BuildingType.AGENCY)) {
+            mainType = BuildingType.AGENCY;
         }
-        else{
-            return InfoDto.ofGeneralBuildingInfo(reviews,building,liked);
+
+        switch (mainType) {
+            case DORMITORY:
+                Campuses campuses = building.getCampus();
+                Universities universities = campuses.getUniversity();
+                String universityName = universities.getUniversityName();
+                return InfoDto.ofDormitoryBuildingInfo(reviews, building, universityName, liked);
+            case AGENCY:
+                Agencies agency = agenciesRepository.findByBuildingCode(building.getBuildingCode())
+                        .orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
+                Reviews agencyReview = reviewsRepository.findFirstByAgencyAndDtypeOrderByCreatedAtDesc(
+                        agency, ReviewType.AGENCY);
+                return InfoDto.ofAgencyBuildingInfo(agencyReview, agency, liked);
+            default:
+                return InfoDto.ofGeneralBuildingInfo(reviews, building, liked);
         }
     }
 


### PR DESCRIPTION
## 📌 이슈 번호
> #139

## 💬 리뷰 포인트
> 기숙사, 공인중개사 등의 구분이 가능하도록 buildingSearch 리팩토링

## 🚀 상세 설명
기존 SearchInfo buildingSearch()에서는 기숙사 유형을 제대로 걸러내지 못했음.
기존에 원래 String 형태로 BuildingType이 왔었지만 배열 형태로 리팩토링 된 이후
building.getBuildingType().equals("DORMITORY") 구문으로는 검출 할 수 없었음

=> 리팩토링 진행
- 기숙사, 공인중개사 분류에 따른 case 구분
- contains을 통한 문자열 검출

## 📸 스크린샷
<img width="1483" height="913" alt="image" src="https://github.com/user-attachments/assets/7bf8ef63-5e3d-4cbc-89aa-42950a1117b6" />


## 📢 노트