### PR TITLE
🐛 Fix[#95]: 빌딩info의 빌딩타입 리스트->스트링 변경, 빌딩타입 판별 리스트로 픽스

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.domain.building.service;
 
+import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.global.common.dto.InfoDto;
 import JJinBBang.app.domain.building.entity.*;
 import JJinBBang.app.domain.building.enums.ReviewType;
@@ -10,6 +11,8 @@ import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.global.error.exception.UnprocessableGroupException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -52,7 +55,9 @@ public class SearchInfo {
     public InfoDto buildingSearch(Long itemId, Boolean liked){
         Buildings building = buildingsRepository.findById(itemId).orElseThrow(() -> new BookmarkNotFoundException("Building"));
         Reviews reviews= reviewsRepository.findFirstByBuildingOrderByCreatedAtDesc(building);
-        if (building.getBuildingType().equals("DORMITORY")){
+        List<BuildingType> typeList = building.getBuildingType();
+
+        if (typeList.equals(List.of(BuildingType.DORMITORY))) {
             Campuses campuses = building.getCampus();
             Universities universities = campuses.getUniversity();
             String universityName = universities.getUniversityName();

--- a/src/main/java/JJinBBang/app/global/common/dto/AgencyBuildingInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/AgencyBuildingInfo.java
@@ -11,7 +11,7 @@ import java.util.List;
 public record AgencyBuildingInfo(
         Long id,
         String name,
-        List<BuildingType> type,
+        BuildingType type,
         String address,
         BigDecimal rating,
         Boolean liked,
@@ -21,7 +21,7 @@ public record AgencyBuildingInfo(
         return AgencyBuildingInfo.builder()
                 .id(agencies.getAgencyId())
                 .name(agencies.getName())
-                .type(List.of(BuildingType.AGENCY))
+                .type(BuildingType.AGENCY)
                 .address(agencies.getAddress())
                 .rating(agencies.getRating())
                 .liked(liked)

--- a/src/main/java/JJinBBang/app/global/common/dto/DormitoryBuildingInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/DormitoryBuildingInfo.java
@@ -11,7 +11,7 @@ import java.util.List;
 public record DormitoryBuildingInfo(
         Long id,
         String name,
-        List<BuildingType> type,
+        BuildingType type,
         String universityName,
         String address,
         BigDecimal rating,
@@ -22,7 +22,7 @@ public record DormitoryBuildingInfo(
         return DormitoryBuildingInfo.builder()
                 .id(building.getId())
                 .liked(liked)
-                .type(List.of(BuildingType.DORMITORY))
+                .type(BuildingType.DORMITORY)
                 .name(building.getBuildingName())
                 .universityName(universityName)
                 .address(building.getBuildingAddress())


### PR DESCRIPTION
## 📌 이슈 번호
> ex) #1

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

## 📸 스크린샷
<img width="1364" height="237" alt="image" src="https://github.com/user-attachments/assets/98f1c9a4-7748-4b05-ad99-427a0b3ba60f" />
공인중개사 기숙사 info 빌딩타입 리스트 제거

<img width="1424" height="96" alt="image" src="https://github.com/user-attachments/assets/bc7fd4d7-2d0c-430c-a679-1525cb371770" />
빌딩 엔티티의 getBuildingType()의 반환값이 리스트여서 값비교 리스트로 변경

## 📢 노트