### PR TITLE
[Feat #136] 유저 인증상태(VERIFIED) 추가 및 인증상태 예외반환 로직 간소화

### DIFF
--- a/src/main/java/JJinBBang/app/global/common/enums/VerificationStatus.java
+++ b/src/main/java/JJinBBang/app/global/common/enums/VerificationStatus.java
@@ -1,6 +1,7 @@
 package JJinBBang.app.global.common.enums;
 
 public enum VerificationStatus {
+	VERIFIED("인증완료"), // 포괄적 인증 완료
 	NEW_STUDENT_VERIFIED("인증완료"), // 합격증명서 인증
 	ENROLL_STUDENT_VERIFIED("인증완료"), // 재학증명서 인증
 	EMAIL_VERIFIED("인증완료"), // 학교 웹메일 인증

--- a/src/main/java/JJinBBang/app/global/security/exception/SecurityAccessDeniedException.java
+++ b/src/main/java/JJinBBang/app/global/security/exception/SecurityAccessDeniedException.java
@@ -17,6 +17,26 @@ public class SecurityAccessDeniedException extends AuthenticationException {
         return new SecurityAccessDeniedException("학교 인증이 필요합니다.");
     }
 
+    public static SecurityAccessDeniedException emailVerificationRequired() {
+        return new SecurityAccessDeniedException("이메일 인증이 필요합니다.");
+    }
+
+    public static AuthenticationException enrollStudentVerificationRequired() {
+        return new SecurityAccessDeniedException("재학생 인증이 필요합니다.");
+    }
+
+    public static AuthenticationException newStudentVerificationRequired() {
+        return new SecurityAccessDeniedException("신입생 인증이 필요합니다.");
+    }
+
+    public static AuthenticationException pendingUnivVerifyRequestRequired() {
+        return new SecurityAccessDeniedException("학교 인증 요청 대기가 필요합니다.");
+    }
+
+    public static AuthenticationException unverifiedStatusRequired() {
+        return new SecurityAccessDeniedException("미인증 상태여야 합니다.");
+    }
+
     public static SecurityAccessDeniedException existPendingUnivVerifyRequest() {
         return new SecurityAccessDeniedException("대기 중인 학교 인증 요청이 존재합니다.");
     }

--- a/src/main/java/JJinBBang/app/global/security/filter/VerificationStatusFilter.java
+++ b/src/main/java/JJinBBang/app/global/security/filter/VerificationStatusFilter.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.global.security.filter;
 
+import JJinBBang.app.global.common.enums.VerificationStatus;
 import JJinBBang.app.global.security.SecurityPathProperties;
 import JJinBBang.app.global.security.exception.SecurityAccessDeniedException;
 import JJinBBang.app.global.security.exception.SecurityAuthException;
@@ -21,6 +22,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * 특정 경로에서 사용자의 verificationStatus(이메일 인증 상태)를 확인하는 필터
@@ -41,13 +43,12 @@ public class VerificationStatusFilter extends OncePerRequestFilter {
         String requestURI = request.getRequestURI();
 
 
-
         // verificationStatus 확인
         for (Map.Entry<String, List<String>> entry : verificationStatusPaths.entrySet()) {
-            String requiredStatus = entry.getKey();
-            List<String> paths = entry.getValue();
+            VerificationStatus requiredStatus = VerificationStatus.valueOf(entry.getKey());
 
-            boolean isMatch = paths.stream().anyMatch(pattern -> PATH_MATCHER.match(pattern, requestURI));
+            boolean isMatch = entry.getValue().stream()
+                .anyMatch(pattern -> PATH_MATCHER.match(pattern, requestURI));
 
             if (isMatch) {
                 Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -58,9 +59,9 @@ public class VerificationStatusFilter extends OncePerRequestFilter {
                     return;
                 }
 
-                if(!user.getVerificationStatus().name().equals(requiredStatus)) {
+                if(!isValidVerificationStatus(user.getVerificationStatus(), requiredStatus)) {
                     makeErrorResponse(response, HttpServletResponse.SC_FORBIDDEN,
-                            getCustomSecurityAuthException(user.getVerificationStatus().name(), requiredStatus));
+                            getCustomSecurityAuthException(requiredStatus));
                     return;
                 }
             }
@@ -70,34 +71,51 @@ public class VerificationStatusFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    private boolean isValidVerificationStatus(VerificationStatus userStatus, VerificationStatus requiredStatus) {
+		if (requiredStatus.equals(VerificationStatus.VERIFIED)) {
+			return userStatus.equals(VerificationStatus.EMAIL_VERIFIED) ||
+				userStatus.equals(VerificationStatus.ENROLL_STUDENT_VERIFIED) ||
+				userStatus.equals(VerificationStatus.NEW_STUDENT_VERIFIED);
+		}
+		return userStatus.equals(requiredStatus);
+	}
+
+
     /**
      * 현재 verificationStatus와 필요한 verificationStatus를 비교하여 예외 메시지 생성
      */
-    private AuthenticationException getCustomSecurityAuthException(String userStatus, String requiredStatus) {
-        if (!userStatus.equals(requiredStatus)) {
-            boolean univVerified = "EMAIL_VERIFIED".equals(userStatus) ||
-                    "ENROLL_STUDENT_VERIFIED".equals(userStatus) ||
-                    "NEW_STUDENT_VERIFIED".equals(userStatus);
-            switch (requiredStatus) {
-                case "EMAIL_VERIFIED":
-                case "ENROLL_STUDENT_VERIFIED":
-                case "NEW_STUDENT_VERIFIED":
-                    return SecurityAccessDeniedException.universityVerificationRequired();
-                case "UNVERIFIED":
-                    if (univVerified) {
-                        return SecurityAccessDeniedException.alreadyUniversityVerified();
-                    } else if ("PENDING".equals(userStatus)) {
-                        return SecurityAccessDeniedException.existPendingUnivVerifyRequest();
-                    }
-                case "PENDING":
-                    if (univVerified) {
-                        return SecurityAccessDeniedException.alreadyUniversityVerified();
-                    } else if ("UNVERIFIED".equals(userStatus)) {
-                        return SecurityAccessDeniedException.pendingUnivVerifyRequestNotFound();
-                    }
+    private AuthenticationException getCustomSecurityAuthException(VerificationStatus requiredStatus) {
+        // userStatus와 requiredStatus 매칭이 유효하지 않은 경우에만 함수 실행
+
+        switch (requiredStatus){
+            case VERIFIED -> {
+                // 유저가 미인증 상태인 경우
+                return SecurityAccessDeniedException.universityVerificationRequired();
+            }
+            case EMAIL_VERIFIED -> {
+                // 유저가 이메일 인증을 하지 않은 경우
+                return SecurityAccessDeniedException.emailVerificationRequired();
+            }
+            case ENROLL_STUDENT_VERIFIED -> {
+                // 유저가 재학증명서 인증을 하지 않은 경우
+                return SecurityAccessDeniedException.enrollStudentVerificationRequired();
+            }
+            case NEW_STUDENT_VERIFIED -> {
+                // 유저가 합격증명서 인증을 하지 않은 경우
+                return SecurityAccessDeniedException.newStudentVerificationRequired();
+            }
+            case PENDING -> {
+                // 인증 대기 상태가 필요한 경우
+                return SecurityAccessDeniedException.pendingUnivVerifyRequestRequired();
+            }
+            case UNVERIFIED -> {
+                // 미인증 상태여야만 하는 경우
+                return SecurityAccessDeniedException.unverifiedStatusRequired();
+            }
+            default -> {
+                return SecurityAuthException.noPermission();
             }
         }
-        return SecurityAuthException.noPermission();
     }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,8 +141,10 @@ security:
     anonymous:
       - "/api/v1/auth"
     verification-status-based:
-      EMAIL_VERIFIED:
+      VERIFIED:
         - "/api/v1/verifiedTest"
+      EMAIL_VERIFIED:
+        - "/api/v1/emailVerifiedTest"
       ENROLL_STUDENT_VERIFIED:
         - "/api/v1/enrollStudentVerifiedTest"
       NEW_STUDENT_VERIFIED:


### PR DESCRIPTION
## 📌 이슈 번호
> - #136

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요

- `VERIFIED` 상태를 application.yml 및 인증 Enum에 추가
- VerificationStatusFilter의 인증 로직 리팩토링 및 인증 관련 예외 반환 구조 간소화 

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

1. VERIFIED 인증 상태 추가
   - `VerificationStatus.java`에 `VERIFIED` Enum을 추가하였습니다.  
   - 기존에는 각각의 인증 상태(EMAIL_VERIFIED, ENROLL_STUDENT_VERIFIED, NEW_STUDENT_VERIFIED)만 존재했으나, 포괄적인 '인증완료' 상태를 구분할 수 있도록 개선하였습니다.

2. application.yml에 VERIFIED 경로 추가
   - `application.yml`의 `verification-status-based` 설정에 `VERIFIED` 경로(`/api/v1/verifiedTest`)를 추가하였습니다.
   - 여러 인증이 모두 인정되는 경우를 별도 경로로 처리할 수 있도록 구조를 확장하였습니다.

3. 예외 추가
   - `SecurityAccessDeniedException.java`에 추가 및 간소화된 예외처리에 맞는 예외 메세지 생성 함수를 추가하였습니다.

4. VerificationStatusFilter 로직 정비
   - 기존에 과도하게 복잡했던 예외 반환 로직을 간소화하였습니다
     - 필요상태 != 유저상태 일 시 => '필요상태' 가 필요합니다. 와 같이 간소화하였습니다.


## 📸 스크린샷

<img width="367" height="160" alt="image" src="https://github.com/user-attachments/assets/0e7eabb0-4dfd-4c7c-b9e8-ebb936515feb" />


## 📢 노트
- HTTP 메서드도 반영할 수 있도록 리펙토링 진행하겠습니다.
- 완료되기 전까지 SecurityPath 경로 설정 잠정 중단 부탁드립니다 ㅠㅠ