### PR TITLE
Feat[#118]: 지도 검색 API BoundInfo 추가 및 공인중개사 조회 에러 해결

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/repository/AgenciesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/AgenciesRepository.java
@@ -1,10 +1,12 @@
 package JJinBBang.app.domain.building.repository;
 
 import JJinBBang.app.domain.building.entity.Agencies;
+import JJinBBang.app.domain.building.repository.custom.AgenciesRepositoryCustom;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface AgenciesRepository extends JpaRepository<Agencies, Long> {
+public interface AgenciesRepository extends JpaRepository<Agencies, Long>, AgenciesRepositoryCustom {
     Optional<Agencies> findByBuildingCode(String buildingCode);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/BuildingsRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/BuildingsRepository.java
@@ -1,6 +1,8 @@
 package JJinBBang.app.domain.building.repository;
 
 import JJinBBang.app.domain.building.entity.Buildings;
+import JJinBBang.app.domain.building.repository.custom.BuildingsRepositoryCustom;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/AgenciesRepositoryCustom.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/AgenciesRepositoryCustom.java
@@ -1,0 +1,8 @@
+package JJinBBang.app.domain.building.repository.custom;
+
+import java.util.List;
+import JJinBBang.app.domain.building.entity.Agencies;
+
+public interface AgenciesRepositoryCustom {
+	List<Agencies> searchAgencies(String keyword);
+}

--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/AgenciesRepositoryImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/AgenciesRepositoryImpl.java
@@ -1,0 +1,29 @@
+package JJinBBang.app.domain.building.repository.custom;
+
+import JJinBBang.app.domain.building.entity.Agencies;
+import JJinBBang.app.domain.building.entity.QAgencies;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+@RequiredArgsConstructor
+public class AgenciesRepositoryImpl implements AgenciesRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Agencies> searchAgencies(String keyword) {
+		QAgencies a = QAgencies.agencies;
+
+		BooleanBuilder builder = new BooleanBuilder();
+		if (keyword != null && !keyword.isEmpty()) {
+			builder.and(a.name.containsIgnoreCase(keyword)
+				.or(a.address.containsIgnoreCase(keyword)));
+		}
+
+		return queryFactory.selectFrom(a)
+			.where(builder)
+			.fetch();
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryCustom.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryCustom.java
@@ -1,4 +1,4 @@
-package JJinBBang.app.domain.building.repository;
+package JJinBBang.app.domain.building.repository.custom;
 
 import java.util.List;
 

--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import JJinBBang.app.domain.building.entity.Buildings;
 import JJinBBang.app.domain.building.entity.GeneralReviews;
+import JJinBBang.app.domain.building.entity.QAgencies;
 import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.domain.building.enums.ContractType;
 import JJinBBang.app.domain.building.repository.custom.BuildingsRepositoryCustom;
@@ -41,6 +42,7 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		QCampuses c = QCampuses.campuses;
 		QReviews r = QReviews.reviews;
 		QGeneralReviews gr = QGeneralReviews.generalReviews;
+		QAgencies a = QAgencies.agencies;
 
 		BooleanBuilder builder = new BooleanBuilder();
 
@@ -111,12 +113,15 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		QCampuses c = QCampuses.campuses;
 		QReviews r = QReviews.reviews;
 		QGeneralReviews gr = QGeneralReviews.generalReviews;
+		QAgencies a = QAgencies.agencies;
 
 		BooleanBuilder builder = new BooleanBuilder();
 
 		if (keyword != null && !keyword.isEmpty()) {
 			builder.and(b.buildingName.containsIgnoreCase(keyword)
-				.or(b.buildingAddress.containsIgnoreCase(keyword)));
+				.or(b.buildingAddress.containsIgnoreCase(keyword))
+				.or(a.name.containsIgnoreCase(keyword))
+				.or(a.address.containsIgnoreCase(keyword)));
 		}
 
 		if (buildTypes != null && !buildTypes.contains(BuildingType.ALL)) {
@@ -139,6 +144,7 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 			.leftJoin(b.reviews, r).fetchJoin()
 			.leftJoin(treated).on(r.id.eq(treated.id))
 			.leftJoin(b.campus, c).fetchJoin()
+			.leftJoin(a).on(b.buildingCode.eq(a.buildingCode))
 			.where(builder);
 
 		if (contractType != null) {

--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
@@ -1,4 +1,4 @@
-package JJinBBang.app.domain.building.repository;
+package JJinBBang.app.domain.building.repository.custom;
 
 import java.util.List;
 
@@ -11,6 +11,7 @@ import JJinBBang.app.domain.building.entity.Buildings;
 import JJinBBang.app.domain.building.entity.GeneralReviews;
 import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.domain.building.enums.ContractType;
+import JJinBBang.app.domain.building.repository.custom.BuildingsRepositoryCustom;
 import JJinBBang.app.global.common.enums.KeywordType;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
@@ -9,6 +9,7 @@ import JJinBBang.app.domain.building.repository.*;
 import JJinBBang.app.domain.common.entity.Campuses;
 import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.global.common.dto.SearchInfoDto;
+import JJinBBang.app.global.common.enums.ViewType;
 import JJinBBang.app.global.error.exception.UnprocessableGroupException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -132,9 +133,13 @@ public class SearchInfo {
         }
     }
 
-    public SearchInfoDto agencySearchWithBound(Long itemId, Boolean liked){
-        Agencies agencies = agenciesRepository.findById(itemId).orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
-        Reviews reviews = reviewsRepository.findFirstByAgencyAndDtypeOrderByCreatedAtDesc(agencies,ReviewType.AGENCY);
-        return SearchInfoDto.ofSearchAgencyBuildingInfo(reviews,agencies,liked);
+    public SearchInfoDto agencySearchWithBound(Long itemId, Boolean liked, ViewType viewType){
+        Agencies agencies = agenciesRepository.findById(itemId)
+            .orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
+        Reviews reviews = reviewsRepository.findFirstByAgencyAndDtypeOrderByCreatedAtDesc(agencies, ReviewType.AGENCY);
+        if (viewType == ViewType.REVIEW) {
+            return SearchInfoDto.ofSearchAgencyReviewInfo(reviews, agencies, liked);
+        }
+        return SearchInfoDto.ofSearchAgencyBuildingInfo(reviews, agencies, liked);
     }
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
@@ -8,6 +8,7 @@ import JJinBBang.app.domain.building.exception.BookmarkNotFoundException;
 import JJinBBang.app.domain.building.repository.*;
 import JJinBBang.app.domain.common.entity.Campuses;
 import JJinBBang.app.domain.common.entity.Universities;
+import JJinBBang.app.global.common.dto.SearchInfoDto;
 import JJinBBang.app.global.error.exception.UnprocessableGroupException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -72,5 +73,68 @@ public class SearchInfo {
         Agencies agencies = agenciesRepository.findById(itemId).orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
         Reviews reviews = reviewsRepository.findFirstByAgencyAndDtypeOrderByCreatedAtDesc(agencies,ReviewType.AGENCY);
         return InfoDto.ofAgencyBuildingInfo(reviews,agencies,liked);
+    }
+
+    public SearchInfoDto reviewSearchWithBound(Long reviewId, Boolean liked){
+        Reviews item = reviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("Review"));
+        switch (item.getDtype()){
+            case ReviewType.GENERAL:
+                GeneralReviews generalReviews = generalReviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("GeneralReview"));
+                if(generalReviews.getContractType()==null || generalReviews.getFloor()==null||generalReviews.getArea()==null){
+                    throw new BookmarkNotFoundException("GeneralReview");
+                }
+                return SearchInfoDto.ofSearchGeneralReviewInfo(generalReviews,liked);
+            case ReviewType.DORM:
+                DormReviews dormReviews = dormReviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("DormReview"));
+                if(dormReviews.getDormFee()==null||dormReviews.getDormFee()==null||dormReviews.getCapacity()==null){
+                    throw new BookmarkNotFoundException("DormReview");
+                }
+                Buildings building = item.getBuilding();
+                Campuses campuses = building.getCampus();
+                Universities universities = campuses.getUniversity();
+                String universityName = universities.getUniversityName();
+                return SearchInfoDto.ofSearchDormitoryReviewInfo(dormReviews, building, universityName, liked);
+            case ReviewType.AGENCY:
+                Agencies agencies = item.getAgency();
+                return SearchInfoDto.ofSearchAgencyReviewInfo(item,agencies,liked);
+            default:
+                throw new UnprocessableGroupException("후기 유형 dtype에 이상있습니다.");
+        }
+    }
+
+    public SearchInfoDto buildingSearchWithBound(Long itemId, Boolean liked){
+        Buildings building = buildingsRepository.findById(itemId)
+            .orElseThrow(() -> new BookmarkNotFoundException("Building"));
+
+        Reviews reviews = reviewsRepository.findFirstByBuildingOrderByCreatedAtDesc(building);
+
+        BuildingType mainType = BuildingType.ALL;
+        if (building.getBuildingType().contains(BuildingType.DORMITORY)) {
+            mainType = BuildingType.DORMITORY;
+        } else if (building.getBuildingType().contains(BuildingType.AGENCY)) {
+            mainType = BuildingType.AGENCY;
+        }
+
+        switch (mainType) {
+            case DORMITORY:
+                Campuses campuses = building.getCampus();
+                Universities universities = campuses.getUniversity();
+                String universityName = universities.getUniversityName();
+                return SearchInfoDto.ofSearchDormitoryBuildingInfo(reviews, building, universityName, liked);
+            case AGENCY:
+                Agencies agency = agenciesRepository.findByBuildingCode(building.getBuildingCode())
+                    .orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
+                Reviews agencyReview = reviewsRepository.findFirstByAgencyAndDtypeOrderByCreatedAtDesc(
+                    agency, ReviewType.AGENCY);
+                return SearchInfoDto.ofSearchAgencyBuildingInfo(agencyReview, agency, liked);
+            default:
+                return SearchInfoDto.ofSearchGeneralBuildingInfo(reviews, building, liked);
+        }
+    }
+
+    public SearchInfoDto agencySearchWithBound(Long itemId, Boolean liked){
+        Agencies agencies = agenciesRepository.findById(itemId).orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
+        Reviews reviews = reviewsRepository.findFirstByAgencyAndDtypeOrderByCreatedAtDesc(agencies,ReviewType.AGENCY);
+        return SearchInfoDto.ofSearchAgencyBuildingInfo(reviews,agencies,liked);
     }
 }

--- a/src/main/java/JJinBBang/app/domain/map/controller/MapController.java
+++ b/src/main/java/JJinBBang/app/domain/map/controller/MapController.java
@@ -7,6 +7,7 @@ import JJinBBang.app.domain.map.dto.request.NearByMapItemRequest;
 import JJinBBang.app.domain.map.dto.request.SearchMarkerRequest;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.common.dto.InfoDto;
+import JJinBBang.app.global.common.dto.SearchInfoDto;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,11 +38,11 @@ public class MapController {
 	}
 
 	@PostMapping("/search")
-	public ResTemplate<PaginatedResponse<InfoDto>> searchMarkers(
+	public ResTemplate<PaginatedResponse<SearchInfoDto>> searchMarkers(
 		@AuthenticationPrincipal Users user,
 		@Valid @RequestBody SearchMarkerRequest request
 	) {
-		PaginatedResponse<InfoDto> response = mapService.searchMarker(request, user);
+		PaginatedResponse<SearchInfoDto> response = mapService.searchMarker(request, user);
 		return new ResTemplate<>(HttpStatus.OK, "지도 검색 성공", response);
 	}
 

--- a/src/main/java/JJinBBang/app/domain/map/service/MapService.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapService.java
@@ -9,6 +9,7 @@ import JJinBBang.app.domain.map.dto.request.NearByMapItemRequest;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.common.dto.InfoDto;
 import JJinBBang.app.global.common.dto.MarkerInfo;
+import JJinBBang.app.global.common.dto.SearchInfoDto;
 
 public interface MapService {
 	/**
@@ -25,7 +26,7 @@ public interface MapService {
 	 * @param request keyword, 페이지네이션, 필터
 	 * @return 마커 상세 정보
 	 */
-	PaginatedResponse<InfoDto> searchMarker(SearchMarkerRequest request, Users user);
+	PaginatedResponse<SearchInfoDto> searchMarker(SearchMarkerRequest request, Users user);
 
 	/**
 	 * 주변 건물, 리뷰들을 상세 조회하는 서비스

--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -6,7 +6,10 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+import JJinBBang.app.domain.building.entity.Agencies;
 import JJinBBang.app.domain.building.enums.ContractType;
+import JJinBBang.app.domain.building.repository.AgenciesRepository;
+import JJinBBang.app.domain.building.repository.AgencyLikesRepository;
 import JJinBBang.app.domain.building.repository.BuildingLikesRepository;
 import JJinBBang.app.domain.building.repository.BuildingsRepository;
 import JJinBBang.app.domain.building.repository.ReviewLikesRepository;
@@ -29,6 +32,7 @@ import JJinBBang.app.domain.map.exception.MapInvalidException;
 import JJinBBang.app.domain.map.exception.MapNoContentException;
 import JJinBBang.app.domain.map.exception.MapUnprocessableException;
 import JJinBBang.app.global.common.dto.MarkerInfo;
+import JJinBBang.app.global.common.dto.SearchInfoDto;
 import JJinBBang.app.global.common.enums.KeywordType;
 import JJinBBang.app.global.common.enums.ViewType;
 import lombok.RequiredArgsConstructor;
@@ -43,6 +47,8 @@ public class MapServiceImpl implements MapService{
 	private final ReviewsRepository reviewsRepository;
 	private final BuildingLikesRepository buildingLikesRepository;
 	private final ReviewLikesRepository reviewLikesRepository;
+	private final AgenciesRepository agenciesRepository;
+	private final AgencyLikesRepository agencyLikesRepository;
 	private final SearchInfo searchInfo;
 
 	@Override
@@ -94,7 +100,7 @@ public class MapServiceImpl implements MapService{
 
 	@Override
 	@Transactional(readOnly = true)
-	public PaginatedResponse<InfoDto> searchMarker(SearchMarkerRequest request, Users user) {
+	public PaginatedResponse<SearchInfoDto> searchMarker(SearchMarkerRequest request, Users user) {
 		Filters filters = request.filters();
 
 		// 기본 유효성 검사
@@ -116,11 +122,13 @@ public class MapServiceImpl implements MapService{
 			filters.campus()
 		);
 
-		if (buildings.isEmpty()) {
+		List<Agencies> agencies = agenciesRepository.searchAgencies(request.keyword());
+
+		if (buildings.isEmpty() && agencies.isEmpty()) {
 			throw MapNoContentException.searchFailed();
 		}
 
-		List<InfoDto> items = new ArrayList<>();
+		List<SearchInfoDto> items = new ArrayList<>();
 		for (Buildings b : buildings) {
 			if (filters.viewType() == ViewType.REVIEW) {
 				b.getReviews().forEach(r -> {
@@ -128,7 +136,7 @@ public class MapServiceImpl implements MapService{
 						.findByReviewIdAndUserUserId(r.getId(), user.getUserId())
 						.isPresent();
 					try {
-						items.add(searchInfo.reviewSearch(r.getId(), liked));
+						items.add(searchInfo.reviewSearchWithBound(r.getId(), liked));
 					} catch (Exception e) {
 						throw MapNotFoundException.notFoundReview();
 					}
@@ -137,8 +145,13 @@ public class MapServiceImpl implements MapService{
 				boolean liked = user != null && buildingLikesRepository
 					.findByBuildingAndUser(b, user)
 					.isPresent();
-				items.add(searchInfo.buildingSearch(b.getId(), liked));
+				items.add(searchInfo.buildingSearchWithBound(b.getId(), liked));
 			}
+		}
+
+		for (Agencies agency : agencies) {
+			boolean liked = user != null && agencyLikesRepository.existsByAgencyAndUser(agency, user);
+			items.add(searchInfo.agencySearchWithBound(agency.getAgencyId(), liked));
 		}
 
 		int from = Math.max(0, (request.page() - 1) * request.num());
@@ -147,9 +160,9 @@ public class MapServiceImpl implements MapService{
 			from = to;
 		}
 
-		List<InfoDto> paged = items.subList(from, to);
+		List<SearchInfoDto> paged = items.subList(from, to);
 
-		return PaginatedResponse.<InfoDto>builder()
+		return PaginatedResponse.<SearchInfoDto>builder()
 			.num(paged.size())
 			.page(request.page())
 			.itemNum((long) items.size())

--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -151,7 +151,7 @@ public class MapServiceImpl implements MapService{
 
 		for (Agencies agency : agencies) {
 			boolean liked = user != null && agencyLikesRepository.existsByAgencyAndUser(agency, user);
-			items.add(searchInfo.agencySearchWithBound(agency.getAgencyId(), liked));
+			items.add(searchInfo.agencySearchWithBound(agency.getAgencyId(), liked, filters.viewType()));
 		}
 
 		int from = Math.max(0, (request.page() - 1) * request.num());

--- a/src/main/java/JJinBBang/app/global/common/dto/BoundInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/BoundInfo.java
@@ -1,0 +1,16 @@
+package JJinBBang.app.global.common.dto;
+
+import lombok.Builder;
+
+@Builder
+public record BoundInfo(
+	Double latitude,
+	Double longitude
+) {
+	public static BoundInfo of(Double latitude, Double longitude) {
+		return BoundInfo.builder()
+			.latitude(latitude)
+			.longitude(longitude)
+			.build();
+	}
+}

--- a/src/main/java/JJinBBang/app/global/common/dto/SearchInfoDto.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/SearchInfoDto.java
@@ -1,0 +1,89 @@
+package JJinBBang.app.global.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import JJinBBang.app.domain.building.entity.Agencies;
+import JJinBBang.app.domain.building.entity.Buildings;
+import JJinBBang.app.domain.building.entity.DormReviews;
+import JJinBBang.app.domain.building.entity.GeneralReviews;
+import JJinBBang.app.domain.building.entity.Reviews;
+import lombok.Builder;
+
+@Builder
+public record SearchInfoDto(
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	GeneralReviewInfo generalReviewInfo,
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	GeneralBuildingInfo generalBuildingInfo,
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	DormitoryReviewInfo dormitoryReviewInfo,
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	DormitoryBuildingInfo dormitoryBuildingInfo,
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	AgencyReviewInfo agencyReviewInfo,
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	AgencyBuildingInfo agencyBuildingInfo,
+
+	ReviewInfo reviewInfo,
+	BoundInfo boundInfo,
+	String image
+) {
+	public static SearchInfoDto ofSearchGeneralReviewInfo(GeneralReviews generalReview, Boolean liked) {
+		return SearchInfoDto.builder()
+			.generalReviewInfo(GeneralReviewInfo.of(generalReview, liked))
+			.reviewInfo(ReviewInfo.of(generalReview))
+			.boundInfo(BoundInfo.of(generalReview.getBuilding().getBuildingLat(), generalReview.getBuilding().getBuildingLot()))
+			.image(generalReview.getThumbnailImage())
+			.build();
+	}
+
+	public static SearchInfoDto ofSearchGeneralBuildingInfo(Reviews review, Buildings building, Boolean liked) {
+		return SearchInfoDto.builder()
+			.generalBuildingInfo(GeneralBuildingInfo.of(building, liked))
+			.reviewInfo(ReviewInfo.ofBuilding(review, building))
+			.boundInfo(BoundInfo.of(building.getBuildingLat(), building.getBuildingLot()))
+			.image(review.getThumbnailImage())
+			.build();
+	}
+
+	public static SearchInfoDto ofSearchDormitoryReviewInfo(DormReviews dormReview, Buildings building, String universityName, Boolean liked) {
+		return SearchInfoDto.builder()
+			.dormitoryReviewInfo(DormitoryReviewInfo.of(dormReview, building, universityName, liked))
+			.reviewInfo(ReviewInfo.of(dormReview))
+			.boundInfo(BoundInfo.of(building.getBuildingLat(), building.getBuildingLot()))
+			.image(dormReview.getThumbnailImage())
+			.build();
+	}
+
+	public static SearchInfoDto ofSearchDormitoryBuildingInfo(Reviews review, Buildings building, String universityName, Boolean liked) {
+		return SearchInfoDto.builder()
+			.dormitoryBuildingInfo(DormitoryBuildingInfo.of(building, universityName, liked))
+			.reviewInfo(ReviewInfo.ofBuilding(review, building))
+			.boundInfo(BoundInfo.of(building.getBuildingLat(), building.getBuildingLot()))
+			.image(review.getThumbnailImage())
+			.build();
+	}
+
+	public static SearchInfoDto ofSearchAgencyReviewInfo(Reviews review, Agencies agency, Boolean liked) {
+		return SearchInfoDto.builder()
+			.agencyReviewInfo(AgencyReviewInfo.of(review, agency, liked))
+			.reviewInfo(ReviewInfo.of(review))
+			.boundInfo(BoundInfo.of(agency.getAgencyLat(), agency.getAgencyLot()))
+			.image(review.getThumbnailImage())
+			.build();
+	}
+
+	public static SearchInfoDto ofSearchAgencyBuildingInfo(Reviews review, Agencies agency, Boolean liked) {
+		return SearchInfoDto.builder()
+			.agencyBuildingInfo(AgencyBuildingInfo.of(agency, liked))
+			.reviewInfo(ReviewInfo.ofAgency(review, agency))
+			.boundInfo(BoundInfo.of(agency.getAgencyLat(), agency.getAgencyLot()))
+			.image("http://localhost:8080/image/1.jpg")
+			.build();
+	}
+}


### PR DESCRIPTION
## 📌 이슈 번호
> #118, #119

## 💬 리뷰 포인트
> 지도 검색 API BoundInfo 추가 및 공인중개사 조회 에러 해결

## 🚀 상세 설명
- domain/building/repository 안 custom 디렉토리를 통해 customRepository 및 repositoryImpl 정리
- 공인중개사 검색을 위한 AgenciesRepositoryCustom, AgenciesRepositoryImpl 추가
- BuildingsRepositoryImpl에서 공인중개사의 building ID와 빌딩 ID 간 leftjoin으로 검색 로직 추가
- 좌표도 응답 주기 위해 BoundInfo 및 SearchInfoDto 추가
- SearchInfo에 bound 추가된 응답들 추가

## 📸 스크린샷
> 검색 API 리뷰 조회 성공
<img width="1303" height="609" alt="image" src="https://github.com/user-attachments/assets/a33ee67b-d5c5-4b29-97b2-f580eb764d45" />

> 찐빵 - 공인중개사 
<img width="711" height="806" alt="image" src="https://github.com/user-attachments/assets/4e9bec8d-9fae-49bd-8974-2fc4f9bd319a" />

> 검색 API 빌딩 조회 성공
<img width="1220" height="676" alt="image" src="https://github.com/user-attachments/assets/87dc1526-e52f-4f87-84ee-bec845cd4e0a" />

> 빌딩 - 공인중개사
<img width="468" height="527" alt="image" src="https://github.com/user-attachments/assets/e7fdf85b-ddf8-4068-98d3-b7f738be1505" />

## 📢 노트
기존 InfoDto를 두고 SearchInfoDto를 만든건 Bound 추가때문에 그렇습니당
InfoDto 밑에 적어둘까 하다가 검색 API에서만 쓰일 것 같아 따로 빼뒀어요