### PR TITLE
[Fix #152] 리뷰 작성 API 500 에러 해결

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/ReviewRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/ReviewRequest.java
@@ -158,6 +158,7 @@ public record ReviewRequest (
 			.content(dormitoryReview.getContent())
 			.tags(keywords.positive().stream().limit(5).toList())
 			.rating(dormitoryReview.getRating())
+			.buildingType(BuildingType.DORMITORY)
 			.user(user)
 			.building(building)
 			.floor(dormitoryReview.getFloor())
@@ -177,6 +178,7 @@ public record ReviewRequest (
 				.content(dormitoryReview.getContent())
 				.tags(keywords.positive().stream().limit(5).toList())
 				.rating(dormitoryReview.getRating())
+				.buildingType(BuildingType.DORMITORY)
 				.user(oldReview.getUser())
 				.building(building)
 				.floor(dormitoryReview.getFloor())
@@ -195,6 +197,7 @@ public record ReviewRequest (
 			.content(agencyReview.getContent())
 			.tags(keywords.positive().stream().limit(5).toList())
 			.rating(agencyReview.getRating())
+			.buildingType(BuildingType.AGENCY)
 			.user(user)
 			.agency(agency)
 			.build();
@@ -209,6 +212,7 @@ public record ReviewRequest (
 				.content(agencyReview.getContent())
 				.tags(keywords.positive().stream().limit(5).toList())
 				.rating(agencyReview.getRating())
+				.buildingType(BuildingType.AGENCY)
 				.user(oldReview.getUser())
 				.agency(agency)
 				.build();


### PR DESCRIPTION
## 📌 이슈 번호

* \#152

## 💬 리뷰 포인트

- 생성/업데이트 시 Dto를 리뷰 엔티티로 변환하는 메서드에 `buildingType` 필드가 누락되어 있어서 추가했습니다.

## 🚀 상세 설명

* `ReviewRequest`의 메서드 4곳 (`toDormReviews`, `toUpdatedDormitoryReviews`, `toAgencyReviews`, `toUpdatedAgencyReviews`) 에 `buildingType(...)` 을 추가했습니다.

  * 기숙사 유형 리뷰로 변환 시 `BuildingType.DORMITORY` 지정
  * 공인중개사 리뷰로 변환 시 `BuildingType.AGENCY` 지정

## 📸 스크린샷

## 📢 노트
