### PR TITLE
[Feat #154] 캠퍼스 식별 방법 변경에 따른 리뷰 수정 및 작성 API 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/DormitoryReviewDto.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/DormitoryReviewDto.java
@@ -11,8 +11,8 @@ import lombok.Getter;
 
 @Getter
 public class DormitoryReviewDto {
-	@NotBlank
-	private String campus;
+	@NotNull
+	private Long campusId;
 	@NotNull
 	@Min(1)
 	private Integer capacity;

--- a/src/main/java/JJinBBang/app/domain/building/repository/CampusesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/CampusesRepository.java
@@ -4,9 +4,6 @@ import JJinBBang.app.domain.common.entity.Campuses;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-
 @Repository("BuildingCampusesRepository")
 public interface CampusesRepository extends JpaRepository<Campuses, Long> {
-    Optional<Campuses> findByCampusName(String campusName);
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -204,7 +204,7 @@ public class ReviewServiceImpl implements ReviewService {
      */
     private Long createDormitoryReview(ReviewRequest dto, Users user) {
         // 1) 캠퍼스 조회
-        Campuses campus = campusesRepository.findByCampusName(dto.dormitoryReview().getCampus())
+        Campuses campus = campusesRepository.findById(dto.dormitoryReview().getCampusId())
                 .orElseThrow(CampusNotFoundException::missingCampus);
 
         // 2) 건물 로드/생성
@@ -491,7 +491,7 @@ public class ReviewServiceImpl implements ReviewService {
 	 */
 	private void updateDormitoryReview(DormReviews oldReview, ReviewRequest dto) {
 		// 1) 캠퍼스 검증
-		Campuses campus = campusesRepository.findByCampusName(dto.dormitoryReview().getCampus())
+		Campuses campus = campusesRepository.findById(dto.dormitoryReview().getCampusId())
 			.orElseThrow(CampusNotFoundException::missingCampus);
 
 		// 2) 건물 엔티티 로드


### PR DESCRIPTION
## 📌 이슈 번호

- \#154

## 💬 리뷰 포인트

- 리뷰 작성 및 수정 API에서 기숙사 유형 리뷰인 경우 입력 파라미터를 변경했습니다
- 리뷰 작성 및 수정 API의 서비스 로직에서 캠퍼스 식별 방식을 변경했습니다.

## 🚀 상세 설명

- 리뷰 작성 및 수정 API에서 기숙사 유형 리뷰인 경우 입력 파라미터를 변경했습니다
  - `DormitoryReviewDto`의 캠퍼스 이름(`String campus`) 필드를  → 캠퍼스 ID (`Long campusId`)로 변경
  - `campusId` 필드의 유효성 검사 방식 `@NotBlank`를 → `@NotNull`로 변경
- 리뷰 작성 및 수정 API의 서비스 로직에서 캠퍼스 식별 방식을 변경했습니다.
  - `ReviewServiceImpl`의 기숙사 유형 리뷰 작성(createDormitoryReview) 및 수정(updateDormitoryReview) 메서드에서 캠퍼스 조회 방식이 `findByCampusName` → `findById`로 변경했습니다.
  - `CampusesRepository`에서 이제 사용하지 않는 `findByCampusName(String)` 메서드를 제거했습니다.

## 📸 스크린샷
*기숙사 유형 리뷰 작성*
![기숙사 유형 리뷰 작성](https://github.com/user-attachments/assets/60832939-664c-483b-929f-0d9f52020362)

*기숙사 유형 리뷰 수정*
![기숙사 유형 리뷰 수정](https://github.com/user-attachments/assets/c38718d0-a869-4008-903e-cb801f3ad8f7)


## 📢 노트
