### PR TITLE
✨ Feat[#156]: 캠퍼스 식별 방법 변경에 따른 API 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryCustom.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryCustom.java
@@ -17,7 +17,7 @@ public interface BuildingsRepositoryCustom {
 		Integer monthlyRentMin, Integer monthlyRentMax,
 		Boolean inMaintenanceCost,
 		List<KeywordType> reviewKeywords,
-		List<String> campusNames
+		List<Long> campusIds
 	);
 
 	List<Buildings> searchBuildings(
@@ -28,6 +28,6 @@ public interface BuildingsRepositoryCustom {
 		Integer monthlyRentMin, Integer monthlyRentMax,
 		Boolean inMaintenanceCost,
 		List<KeywordType> reviewKeywords,
-		List<String> campusNames
+		List<Long> campusIds
 	);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
@@ -36,7 +36,7 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		Integer monthlyRentMin, Integer monthlyRentMax,
 		Boolean inMaintenanceCost,
 		List<KeywordType> reviewKeywords,
-		List<String> campusNames
+		List<Long> campusIds
 	) {
 		QBuildings b = QBuildings.buildings;
 		QCampuses c = QCampuses.campuses;
@@ -60,8 +60,9 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		}
 
 		// 3. 캠퍼스 필터
-		if (campusNames != null && !campusNames.isEmpty()) {
-			builder.and(b.campus.campusName.in(campusNames));
+		// 3. 캠퍼스 필터
+		if (campusIds != null && !campusIds.isEmpty()) {
+			builder.and(b.campus.id.in(campusIds));
 		}
 
 		// 4. Treat()를 이용한 GeneralReviews 전용 조인
@@ -107,7 +108,7 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		Integer monthlyRentMin, Integer monthlyRentMax,
 		Boolean inMaintenanceCost,
 		List<KeywordType> reviewKeywords,
-		List<String> campusNames
+		List<Long> campusIds
 	) {
 		QBuildings b = QBuildings.buildings;
 		QCampuses c = QCampuses.campuses;
@@ -132,8 +133,8 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 			builder.and(typeBuilder);
 		}
 
-		if (campusNames != null && !campusNames.isEmpty()) {
-			builder.and(b.campus.campusName.in(campusNames));
+		if (campusIds != null && !campusIds.isEmpty()) {
+			builder.and(b.campus.id.in(campusIds));
 		}
 
 		PathBuilder<GeneralReviews> grPath = new PathBuilder<>(GeneralReviews.class, "generalReview");

--- a/src/main/java/JJinBBang/app/domain/common/dto/item/Filters.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/item/Filters.java
@@ -25,7 +25,7 @@ public record Filters(
 	@NotNull(message = "{filter.contractType.notNull}")
 	String contractType, // 계약 유형 (ALL, MONTHLY_RENT, DEPOSIT_RENT)
 
-	List<String> campus, // 캠퍼스
+	List<Long> campus, // 캠퍼스 ID 목록
 
 	@Min(value = 0, message = "{filter.depositMin.min}")
 	Integer depositMin, // 보증금 최소


### PR DESCRIPTION
## 📌 이슈 번호
> #156

## 💬 리뷰 포인트
> 캠퍼스 식별 방법 변경에 따라 Dto 및 repository 수정

## 🚀 상세 설명
- 지도 마커 불러오기 및 지도 검색 API에서 필터의 campus 필드를 Long ID 배열로 변경.
- Filters DTO에 campus IDs를 반영하고, ID 리스트의 비어 있음을 허용하여 기본(전체) 검색을 유지.
- Building, review 마커 검색 로직에서 b.campus.id.in(campusIds) 조건을 적용하고, campus 이름 기반 메서드 호출을 제거.
- 관련 repository 인터페이스와 구현체에서 캠퍼스 이름을 사용하는 메서드를 삭제하거나 ID 기반 조건으로 대체.

## 📸 스크린샷
<img width="682" height="829" alt="image" src="https://github.com/user-attachments/assets/fc586a77-3b35-4eb5-a665-2d8bf97fe774" />
<img width="814" height="818" alt="image" src="https://github.com/user-attachments/assets/60f5c3d9-22f5-4720-9efa-5db4cda9c955" />

## 📢 노트