### PR TITLE
[FEAT] 지도 검색 API SortBy 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/map/dto/request/SearchMarkerRequest.java
+++ b/src/main/java/JJinBBang/app/domain/map/dto/request/SearchMarkerRequest.java
@@ -3,6 +3,7 @@ package JJinBBang.app.domain.map.dto.request;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import JJinBBang.app.domain.common.dto.item.Filters;
+import JJinBBang.app.domain.common.enums.SortType;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -20,6 +21,9 @@ public record SearchMarkerRequest(
 	@NotNull(message = "{pagination.page.notNull}")
 	@Min(value = 0, message = "{pagination.page.min}")
 	Integer page,
+
+	@NotNull(message = "{sortType.notNull}")
+	SortType sortBy,
 
 	@NotNull(message = "{filter.notNull}")
 	Filters filters

--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -190,6 +190,11 @@ public class MapServiceImpl implements MapService{
 			items.add(searchInfo.agencySearchWithBound(agency.getAgencyId(), liked, filters.viewType()));
 		}
 
+		Comparator<SearchInfoDto> comparator = getSearchComparator(request.sortBy(), filters.viewType());
+		if (comparator != null) {
+			items.sort(comparator);
+		}
+
 		int from = Math.max(0, (request.page() - 1) * request.num());
 		int to = Math.min(items.size(), from + request.num());
 		if (from > to) {
@@ -302,19 +307,47 @@ public class MapServiceImpl implements MapService{
 			.build();
 	}
 
-	private Comparator<InfoDto> getComparator(SortType sort, ViewType type) {
+	private Comparator<SearchInfoDto> getSearchComparator(SortType sort, ViewType type) {
 		return switch (sort) {
-			case LIKES -> Comparator.comparing(this::extractLikeCount).reversed();
-			case STARS -> Comparator.comparing(this::extractRating, Comparator.nullsLast(BigDecimal::compareTo)).reversed();
-			case LATEST -> Comparator.comparing(this::extractUpdatedAt, Comparator.nullsLast(LocalDateTime::compareTo)).reversed();
+			case LIKES -> Comparator.<SearchInfoDto, Integer>comparing(dto -> extractLikeCount(dto)).reversed();
+			case STARS -> Comparator.comparing((SearchInfoDto dto) -> extractRating(dto), Comparator.nullsLast(BigDecimal::compareTo)).reversed();
+			case LATEST -> Comparator.comparing((SearchInfoDto dto) -> extractUpdatedAt(dto), Comparator.nullsLast(LocalDateTime::compareTo)).reversed();
 			case RCMND -> {
 				if (type == ViewType.BUILDING) {
-					yield Comparator.comparing(this::extractReviewCount).reversed();
+					yield Comparator.<SearchInfoDto, Integer>comparing(dto -> extractReviewCount(dto)).reversed();
 				} else {
 					yield null; // 리뷰 추천순은 요청 순서 유지
 				}
 			}
 		};
+	}
+
+	private Comparator<InfoDto> getComparator(SortType sort, ViewType type) {
+		return switch (sort) {
+			case LIKES -> Comparator.<InfoDto, Integer>comparing(dto -> extractLikeCount(dto)).reversed();
+			case STARS -> Comparator.comparing((InfoDto dto) -> extractRating(dto), Comparator.nullsLast(BigDecimal::compareTo)).reversed();
+			case LATEST -> Comparator.comparing((InfoDto dto) -> extractUpdatedAt(dto), Comparator.nullsLast(LocalDateTime::compareTo)).reversed();
+			case RCMND -> {
+				if (type == ViewType.BUILDING) {
+					yield Comparator.<InfoDto, Integer>comparing(dto -> extractReviewCount(dto)).reversed();
+				} else {
+					yield null; // 리뷰 추천순은 요청 순서 유지
+				}
+			}
+		};
+	}
+
+	private Integer extractReviewCount(SearchInfoDto dto) {
+		if (dto.generalBuildingInfo() != null) {
+			return dto.generalBuildingInfo().reviewCount();
+		}
+		if (dto.agencyBuildingInfo() != null) {
+			return dto.agencyBuildingInfo().reviewCount();
+		}
+		if (dto.dormitoryBuildingInfo() != null) {
+			return dto.dormitoryBuildingInfo().reviewCount();
+		}
+		return 0;
 	}
 
 	private Integer extractReviewCount(InfoDto dto) {
@@ -327,8 +360,34 @@ public class MapServiceImpl implements MapService{
 		return 0;
 	}
 
+	private Integer extractLikeCount(SearchInfoDto dto) {
+		return dto.reviewInfo() != null ? dto.reviewInfo().likeCount() : 0;
+	}
+
 	private Integer extractLikeCount(InfoDto dto) {
 		return dto.reviewInfo() != null ? dto.reviewInfo().likeCount() : 0;
+	}
+
+	private BigDecimal extractRating(SearchInfoDto dto) {
+		if (dto.generalReviewInfo() != null) {
+			return dto.generalReviewInfo().rating();
+		}
+		if (dto.dormitoryReviewInfo() != null) {
+			return dto.dormitoryReviewInfo().rating();
+		}
+		if (dto.agencyReviewInfo() != null) {
+			return dto.agencyReviewInfo().rating();
+		}
+		if (dto.generalBuildingInfo() != null) {
+			return dto.generalBuildingInfo().rating();
+		}
+		if (dto.dormitoryBuildingInfo() != null) {
+			return dto.dormitoryBuildingInfo().rating();
+		}
+		if (dto.agencyBuildingInfo() != null) {
+			return dto.agencyBuildingInfo().rating();
+		}
+		return BigDecimal.ZERO;
 	}
 
 	private BigDecimal extractRating(InfoDto dto) {
@@ -351,6 +410,10 @@ public class MapServiceImpl implements MapService{
 			return dto.agencyBuildingInfo().rating();
 		}
 		return BigDecimal.ZERO;
+	}
+
+	private LocalDateTime extractUpdatedAt(SearchInfoDto dto) {
+		return dto.reviewInfo() != null ? dto.reviewInfo().updateAt() : null;
 	}
 
 	private LocalDateTime extractUpdatedAt(InfoDto dto) {


### PR DESCRIPTION
## 📌 이슈 번호
> #159 

## 💬 리뷰 포인트
> 지도 검색 API SortBy 추가

## 🚀 상세 설명
- SearchMarkerRequest에 `sortBy`항목 추가
- `getSearchComparator`를 통한 sortBy 적용
- `extractReviewCount`, `extractRating`, `extractLikeCount` 등 추가 

## 📸 스크린샷
<img width="520" height="772" alt="image" src="https://github.com/user-attachments/assets/6166118a-3875-4c6f-8a79-af1142b8eda1" />


## 📢 노트
현재 코드가 기존 주변 찐빵 조회하기의 SortBy와 중복됨이 있는데 차후 타 API들과 해당 두 API도 함께 
코드 통합을 진행하면서 리팩토링하도록 하겠습니당