### PR TITLE
[Feat #163]: 공인중개사 식별 방법 변경에 따른 API 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/Building.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/Building.java
@@ -30,7 +30,7 @@ public record Building (
 	public static Building of(Agencies agency, BuildingType buildingType) {
 		return Building.builder()
 			.buildingId(agency.getAgencyId())
-			.buildingCode(agency.getBuildingCode())
+			.buildingCode(agency.getAgencySerial())
 			.name(agency.getName())
 			.type(buildingType)
 			.address(agency.getAddress())

--- a/src/main/java/JJinBBang/app/domain/building/dto/BuildingRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/BuildingRequest.java
@@ -41,7 +41,7 @@ public record BuildingRequest (
     }
     public Agencies toAgencyEntity() {
         return Agencies.builder()
-                .buildingCode(buildingCode)
+                .agencySerial(buildingCode)
                 .name(name)
                 .address(address)
                 .agencyLat(latitude)

--- a/src/main/java/JJinBBang/app/domain/building/entity/Agencies.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Agencies.java
@@ -26,10 +26,7 @@ public class Agencies extends BaseEntity {
 	private Long agencyId;
 
 	@Column(name = "agency_serial")
-	private Long agencySerial;
-
-	@Column(name = "building_code", nullable = false, unique = true)
-	private String buildingCode; // 카카오 건물 관리 번호
+	private String agencySerial;
 
 	@Column(name = "name", length = 255, nullable = false)
 	private String name;

--- a/src/main/java/JJinBBang/app/domain/building/repository/AgenciesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/AgenciesRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AgenciesRepository extends JpaRepository<Agencies, Long>, AgenciesRepositoryCustom {
-    Optional<Agencies> findByAgencySerial(String buildingCode);
+    Optional<Agencies> findByAgencySerial(String agencySerial);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/AgenciesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/AgenciesRepository.java
@@ -8,5 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AgenciesRepository extends JpaRepository<Agencies, Long>, AgenciesRepositoryCustom {
-    Optional<Agencies> findByBuildingCode(String buildingCode);
+    Optional<Agencies> findByAgencySerial(String buildingCode);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
@@ -145,7 +145,7 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 			.leftJoin(b.reviews, r).fetchJoin()
 			.leftJoin(treated).on(r.id.eq(treated.id))
 			.leftJoin(b.campus, c).fetchJoin()
-			.leftJoin(a).on(b.buildingCode.eq(a.buildingCode))
+			.leftJoin(a).on(b.buildingCode.stringValue().eq(a.agencySerial))
 			.where(builder);
 
 		if (contractType != null) {

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -316,7 +316,7 @@ public class ReviewServiceImpl implements ReviewService {
 	 * @return Agencies 엔티티
 	 */
 	private Agencies findOrCreateAgency(BuildingRequest dto) {
-		return agenciesRepository.findByBuildingCode(dto.buildingCode())
+		return agenciesRepository.findByAgencySerial(dto.buildingCode())
 			.orElseGet(() -> {
 				// 신규 공인중개사 생성 및 초기 키워드 통계 생성
 				Agencies savedAgency = agenciesRepository.save(dto.toAgencyEntity());
@@ -557,7 +557,7 @@ public class ReviewServiceImpl implements ReviewService {
 		boolean newHasImage = dto.imageUrls() != null && !dto.imageUrls().isEmpty();
 
 		// 4) 이미지 변경 및 공인중개사 변경 처리
-		if (!oldAgency.getBuildingCode().equals(newAgency.getBuildingCode())) {
+		if (!oldAgency.getAgencySerial().equals(newAgency.getAgencySerial())) {
 			if (!oldHasImage && newHasImage)
 				newAgency.incrementImagesCount();
 			else if (oldHasImage && !newHasImage)

--- a/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
@@ -123,7 +123,7 @@ public class SearchInfo {
                 String universityName = universities.getUniversityName();
                 return SearchInfoDto.ofSearchDormitoryBuildingInfo(reviews, building, universityName, liked);
             case AGENCY:
-                Agencies agency = agenciesRepository.findByBuildingCode(building.getBuildingCode())
+                Agencies agency = agenciesRepository.findByAgencySerial(building.getBuildingCode())
                     .orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
                 Reviews agencyReview = reviewsRepository.findFirstByAgencyAndDtypeOrderByCreatedAtDesc(
                     agency, ReviewType.AGENCY);


### PR DESCRIPTION
## 📌 이슈 번호
- #163 

## 💬 리뷰 포인트
- 공인중개사 식별방법 변경 (`buidlingCode` → `agencySerial`)이 누락 없이 반영되었는지 확인부탁드립니다.
- 리뷰 작성 및 수정 API에서 공인중개사 식별 방법을 변경했습니다.
- 지도 검색 API에서 공인중개사 식별 방법을 변경했습니다.

## 🚀 상세 설명
- `Agencies` 엔티티의 `buildingCode` 필드 제거, `agencySerial` 데이터 타입 `Long` → `String` 변경
- `AgenciesRepository`의 메서드 `findByBuildingCode(...)` → `findByAgencySerial(...)`로 변경
- 리뷰 작성 및 수정 API에서 공인중개사 식별 방법 변경
  - `findOrCreateAgency(...)` 메서드에서 `AgenciesRepository.findByAgencySerial(...)` 사용
- 지도 검색 API에서 공인중개사 식별 방법 변경
  -  `SearchInfo.buildingSearchWithBound(...)`에서 조회한 건물이 공인중개사인 경우, `AgenciesRepository.findByAgencySerial(...)` 사용
  -  `BuildingRepositoryImpl.searchBuildings(...)`에서 공인중개사 테이블 조인을 `agencySerial` 기준으로 변경
 
## 📸 스크린샷


## 📢 노트
- @ryuwon2407 
`SearchInfo.buildingSearchWithBound(...)` 와 `AgenciesRepository.findByAgencySerial(...)`를 수정했습니다. 확인부탁드립니다.
