### PR TITLE
[FIX #165] 리뷰상세조회 API 오류 해결

### DIFF
--- a/src/main/java/JJinBBang/app/global/common/dto/AgencyReviewInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/AgencyReviewInfo.java
@@ -21,7 +21,7 @@ public record AgencyReviewInfo(
                 .id(reviews.getId())
                 .name(agencies.getName())
                 .type(BuildingType.AGENCY)
-                .rating(agencies.getRating())
+                .rating(reviews.getRating())
                 .liked(liked)
                 .build();
 
@@ -32,7 +32,7 @@ public record AgencyReviewInfo(
             .id(agencyReview.getId())
             .name(agencyReview.getAgency().getName())
             .type(BuildingType.AGENCY)
-            .rating(agencyReview.getAgency().getRating())
+            .rating(agencyReview.getRating())
             .liked(liked)
             .build();
 

--- a/src/main/java/JJinBBang/app/global/common/dto/DormitoryReviewInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/DormitoryReviewInfo.java
@@ -8,9 +8,6 @@ import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.domain.building.enums.Floor;
 import lombok.Builder;
 
-import java.math.BigDecimal;
-import java.util.List;
-
 @Builder
 public record DormitoryReviewInfo(
         Long id,
@@ -38,11 +35,15 @@ public record DormitoryReviewInfo(
     }
 
     public static DormitoryReviewInfo of(DormReviews dormReviews, Boolean liked) {
+
+        String university = dormReviews.getBuilding().getCampus().getUniversity().getUniversityName();
+        String campus =  dormReviews.getBuilding().getCampus().getCampusName();
+
         return DormitoryReviewInfo.builder()
             .id(dormReviews.getId())
             .name(dormReviews.getBuilding().getBuildingName())
             .type(BuildingType.DORMITORY)
-            .universityName(dormReviews.getBuilding().getCampus().getCampusName())
+            .universityName(university + " " + campus)
             .floor(dormReviews.getFloor())
             .capacity(dormReviews.getCapacity())
             .dormFee(dormReviews.getDormFee())


### PR DESCRIPTION
## 📌 이슈 번호

* #165

## 💬 리뷰 포인트

* 상세 조회 API 필드 `rating`이 **건물 전체 리뷰 평균**이 아닌 **개별 리뷰 평점**을 반환하도록 수정
* **기숙사 리뷰** 응답에 **대학 명 + 캠퍼스 명** 모두 포함

## 🚀 상세 설명

* `AgencyReviewInfo`: `rating`을 `reviews/agencyReview.getRating()`으로 매핑
* `DormitoryReviewInfo`: `universityName`을  **대학 명 + 캠퍼스 명**으로 세팅

## 📸 스크린샷
리뷰 상세 조회 API - 기숙사 유형 
<img width="858" height="792" alt="image" src="https://github.com/user-attachments/assets/22550607-5b5c-4cae-93e7-f59f0bc1ffd8" />

## 📢 노트
AgencyReviewInfo.of(Reviews reviews, Agencies agencies, Boolean liked) 메서드도 rating에 건물 전체 리뷰 평균이 매핑되어 있어서 개별 리뷰 평점으로 변경했습니다. 이 메서드를 사용하시는 분은 확인 부탁드립니다.
- @seoiiwon `UserReviewResponse.fromAgency(...)`: 68줄에 사용됩니다.
- @dlfnrud0605 `InfoDto.ofAgencyReviewInfo(...)`: 64줄에 사용됩니다.
- @ryuwon2407 `SearchInfoDto.ofSearchAgencyReviewInfo(...)`: 74줄에 사용됩니다.