### PR TITLE
:sparkles: Feat[#167]: 유저 회원탈퇴 시스템 구현

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/repository/AgencyLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/AgencyLikesRepository.java
@@ -3,12 +3,18 @@ package JJinBBang.app.domain.building.repository;
 import JJinBBang.app.domain.building.entity.Agencies;
 import JJinBBang.app.domain.building.entity.AgencyLikes;
 import JJinBBang.app.domain.user.entity.Users;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AgencyLikesRepository extends CrudRepository<AgencyLikes, Long> {
     Optional<AgencyLikes> findByAgencyAndUser(Agencies agency, Users user);
 
     Boolean existsByAgencyAndUser(Agencies agencies, Users users);
+
+	@EntityGraph(attributePaths = {"agency"})
+	List<AgencyLikes> findAllByUser_UserId(Long targetUserId);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/BuildingLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/BuildingLikesRepository.java
@@ -4,12 +4,18 @@ import JJinBBang.app.domain.building.entity.BuildingLikeId;
 import JJinBBang.app.domain.building.entity.BuildingLikes;
 import JJinBBang.app.domain.building.entity.Buildings;
 import JJinBBang.app.domain.user.entity.Users;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BuildingLikesRepository extends CrudRepository<BuildingLikes, BuildingLikeId> {
     Optional<BuildingLikes> findByBuildingAndUser(Buildings building, Users user);
 
     Boolean existsByBuildingAndUser(Buildings buildings, Users users);
+
+    @EntityGraph(attributePaths = {"building"})
+    List<BuildingLikes> findAllByUser_UserId(Long userId);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/GeneralReviewsRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/GeneralReviewsRepository.java
@@ -1,13 +1,22 @@
 package JJinBBang.app.domain.building.repository;
 
 import JJinBBang.app.domain.building.entity.GeneralReviews;
+import JJinBBang.app.domain.user.entity.Users;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GeneralReviewsRepository extends JpaRepository<GeneralReviews, Long> {
 
     @EntityGraph(attributePaths = "building")
     Page<GeneralReviews> findByUser_UserId(Long userId, Pageable pageable);
+
+    // 작성자 일괄 재매핑
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Reviews r SET r.user = :systemUser WHERE r.user.userId = :userId")
+    int updateUserToSystemUser(Long userId, Users systemUser);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/ReviewLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/ReviewLikesRepository.java
@@ -3,12 +3,19 @@ package JJinBBang.app.domain.building.repository;
 import JJinBBang.app.domain.building.entity.ReviewLikes;
 import JJinBBang.app.domain.building.entity.Reviews;
 import JJinBBang.app.domain.user.entity.Users;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ReviewLikesRepository extends CrudRepository<ReviewLikes, Long> {
     Optional<ReviewLikes> findByReviewAndUser(Reviews reviews, Users user);
     Optional<ReviewLikes> findByReviewIdAndUserUserId(Long reviewId, Long userId);
     Boolean existsByReviewAndUser(Reviews reviews, Users user);
+
+
+	@EntityGraph(attributePaths = {"review"})
+	List<ReviewLikes> findAllByUser_UserId(Long targetUserId);
 }

--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -1,11 +1,14 @@
 package JJinBBang.app.domain.user.controller;
 
+import java.time.LocalDateTime;
+
 import JJinBBang.app.domain.user.dto.request.IssueEmailCodeRequest;
 import JJinBBang.app.domain.user.dto.request.LoginRequest;
 import JJinBBang.app.domain.user.dto.request.VerifyEmailCodeRequest;
 import JJinBBang.app.domain.user.dto.response.TokenResponse;
 import JJinBBang.app.domain.user.dto.response.SignupRequiredResponse;
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.exception.UserAuthException;
 import JJinBBang.app.domain.user.service.OAuthService;
 import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.jwt.JwtUtils;
@@ -45,6 +48,11 @@ public class AuthController {
             SignupRequiredResponse signupRequiredResponse = SignupRequiredResponse.of(signupToken);
             return new ResTemplate<>(HttpStatus.PRECONDITION_REQUIRED, "약관동의가 필요합니다.", signupRequiredResponse);
         } else {
+            if(user.getDisabledAt() != null && user.getDisabledAt().isBefore(LocalDateTime.now())) {
+                // 탈퇴한 유저인 경우
+                throw UserAuthException.deletedUser();
+            }
+
             // 약관 동의가 완료된 유저의 경우
             // user 객체는 DB에 저장된 상태 -> 엑세스 토큰, 리프레시 토큰 발급
             String accessToken = jwtUtils.generateAccessToken(user);
@@ -119,5 +127,13 @@ public class AuthController {
     ){
         jwtUtils.deleteRefreshToken(user.getUserId());
         return new ResTemplate<>(HttpStatus.OK, "로그아웃 성공", null);
+    }
+
+    @DeleteMapping("/user")
+    public ResTemplate<?> deleteUser(
+            @AuthenticationPrincipal Users user
+    ) {
+        usersService.deleteUser(user);
+        return new ResTemplate<>(HttpStatus.OK, "회원 탈퇴 성공", null);
     }
 }

--- a/src/main/java/JJinBBang/app/domain/user/entity/Users.java
+++ b/src/main/java/JJinBBang/app/domain/user/entity/Users.java
@@ -1,5 +1,7 @@
 package JJinBBang.app.domain.user.entity;
 
+import static JJinBBang.app.domain.user.service.UsersServiceImpl.*;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -105,5 +107,28 @@ public class Users extends BaseEntity {
 
 	public void updateUniversity(Universities university) {
 		this.university = university;
+	}
+
+	public Users createDeletedSystemUser() {
+		Users user = new Users();
+		user.provider = Provider.google;
+		user.providerId = SYSTEM_DELETE_ID;
+		user.studentNumber = null; // 시스템 유저는 학번이 없음
+		user.universityEmail = null; // 시스템 유저는 대학 이메일이 없음
+		user.admissionCertificate = null; // 시스템 유저는 입학 증명서가
+		user.admissionCertificateUploadDate = null; // 시스템 유저는 입학 증명서 업로드 날짜가 없음
+		user.verificationStatus = VerificationStatus.VERIFIED; // 시스템 유저는 검증
+		user.disabledAt = null; // 시스템 유저는 비활성화되지 않음
+		return user;
+	}
+
+	public void delete() {
+		this.disabledAt = LocalDateTime.now();
+		this.studentNumber = null;
+		this.universityEmail = null;
+		this.admissionCertificate = null;
+		this.admissionCertificateUploadDate = null;
+		this.verificationStatus = VerificationStatus.UNVERIFIED;
+		this.university = null; // 대학교 정보 초기화
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/user/exception/UserAuthException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/UserAuthException.java
@@ -12,4 +12,8 @@ public class UserAuthException extends AuthGroupException {
     }
 
     public static UserAuthException InvalidToken(){ return new UserAuthException("유효하지 않은 토콘입니다."); }
+
+    public static UserAuthException deletedUser() {
+        return new UserAuthException("탈퇴한 유저입니다.");
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/UserNotFoundException.java
@@ -14,4 +14,8 @@ public class UserNotFoundException extends NotFoundGroupException {
 	public static UserNotFoundException searchFailed(){
 		return new UserNotFoundException("유저 조회에 실패하였습니다.");
 	}
+
+	public static UserNotFoundException systemError() {
+		return new UserNotFoundException("시스템 에러입니다.");
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/user/repository/UsersRepository.java
+++ b/src/main/java/JJinBBang/app/domain/user/repository/UsersRepository.java
@@ -8,9 +8,9 @@ import org.springframework.data.domain.Example;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import JJinBBang.app.domain.user.entity.Users;
-import io.lettuce.core.dynamic.annotation.Param;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
 

--- a/src/main/java/JJinBBang/app/domain/user/repository/UsersRepository.java
+++ b/src/main/java/JJinBBang/app/domain/user/repository/UsersRepository.java
@@ -1,11 +1,16 @@
 package JJinBBang.app.domain.user.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Example;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import JJinBBang.app.domain.user.entity.Users;
+import io.lettuce.core.dynamic.annotation.Param;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
 
@@ -15,4 +20,9 @@ public interface UsersRepository extends JpaRepository<Users, Long> {
     Optional<Users> findWithUniversityByProviderId(String providerId);
 
     Optional<Users> findByUserId(Long userId);
+
+    @Query("SELECT u FROM Users u WHERE u.disabledAt IS NOT NULL AND u.disabledAt <= :deadline")
+    List<Users> findAllDeletionDue(@Param("deadline") LocalDateTime deadline);
+
+    boolean existsByProviderId(@Param("providerId") String providerId);
 }

--- a/src/main/java/JJinBBang/app/domain/user/scheduler/UserScheduler.java
+++ b/src/main/java/JJinBBang/app/domain/user/scheduler/UserScheduler.java
@@ -1,0 +1,47 @@
+package JJinBBang.app.domain.user.scheduler;
+
+import static JJinBBang.app.domain.user.service.UsersServiceImpl.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.repository.UsersRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserScheduler {
+
+	private final UsersRepository usersRepository;
+
+
+	@Value("${user.deletion.grace-days:30}") // 기본값 30일
+	private int graceDays;
+
+
+	/**
+	 * [2단계] 스케줄러: disabledAt로부터 N일 지난 계정 영구 삭제.
+	 * 매일 새벽 3시 실행 예시(CRON은 환경에 맞게 조정)
+	 */
+	@Scheduled(cron = "0 0 3 * * *")
+	@Transactional
+	public void finalizeDeletionBatch() {
+		LocalDateTime deadline = LocalDateTime.now().minusDays(graceDays);
+		List<Users> due = usersRepository.findAllDeletionDue(deadline);
+
+		// 작성 데이터는 1단계에서 이미 재매핑되어 있으므로 여기선 유저만 삭제
+		for (Users u : due) {
+			if (!u.getProviderId().equals(SYSTEM_DELETE_ID)) {
+				usersRepository.delete(u);
+			}
+		}
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersService.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersService.java
@@ -29,4 +29,6 @@ public interface UsersService {
 	Users verifyUniversityEmail(Users user, String universityEmail);
 
 	Users findByUserId(Long userId);
+
+	void deleteUser(Users user);
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -3,6 +3,9 @@ package JJinBBang.app.domain.user.service;
 import JJinBBang.app.domain.building.dto.PageRequest;
 import JJinBBang.app.domain.building.dto.UserReviewListResponse;
 import JJinBBang.app.domain.building.dto.UserReviewResponse;
+import JJinBBang.app.domain.building.entity.AgencyLikes;
+import JJinBBang.app.domain.building.entity.BuildingLikes;
+import JJinBBang.app.domain.building.entity.ReviewLikes;
 import JJinBBang.app.domain.building.repository.*;
 import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.domain.user.dto.UserInfoResponseDto;
@@ -15,6 +18,7 @@ import org.springframework.stereotype.Service;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.domain.user.exception.UserNotFoundException;
 import JJinBBang.app.domain.user.repository.UsersRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,6 +31,8 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class UsersServiceImpl implements UsersService {
 
+	public static final String SYSTEM_DELETE_ID = "___system_delete_user___";
+
 	private final UsersRepository usersRepository;
 	private final GeneralReviewsRepository generalReviewsRepository;
 	private final DormReviewsRepository dormReviewsRepository;
@@ -34,6 +40,9 @@ public class UsersServiceImpl implements UsersService {
 	private final ReviewLikesRepository reviewLikesRepository;
 	private final ReviewDetailsRepository reviewDetailsRepository;
 	private final UniversityRepository universityRepository;
+	private final BuildingLikesRepository buildingLikesRepository;
+	private final AgencyLikesRepository agencyLikesRepository;
+
 
 	@Override
 	public boolean existsByProviderId(String providerId) {
@@ -152,11 +161,58 @@ public class UsersServiceImpl implements UsersService {
 		return usersRepository.findByUserId(userId).orElseThrow(UserNotFoundException::notFound);
 	}
 
+	@Override
+	@Transactional
+	public void deleteUser(Users user) {
+		if (user.getUserId() == 0L) {
+			throw UserNotFoundException.systemError();
+		}
+
+		// 1) 시스템 유저 보장
+		ensureSystemUserExists(user);
+
+		Users systemUser = usersRepository.findByProviderId(SYSTEM_DELETE_ID)
+			.orElseThrow(UserNotFoundException::systemError);
+
+		Long targetUserId = user.getUserId();
+
+		// 2) 작성 데이터(리뷰) → 시스템 유저로 재매핑 (벌크 업데이트)
+		//  - 벌크 연산 후 1차 캐시와의 불일치 줄이려면 flush/clear 고려
+		generalReviewsRepository.updateUserToSystemUser(targetUserId, systemUser);
+
+		// 3) 행동 데이터(좋아요) → 삭제 + 카운터 보정
+		// 3-1) 건물 좋아요
+		List<BuildingLikes> buildingLikes = buildingLikesRepository.findAllByUser_UserId(targetUserId);
+		buildingLikes.forEach(bl -> bl.getBuilding().decrementLikeCount());
+		buildingLikesRepository.deleteAll(buildingLikes);
+
+		// 3-2) 리뷰 좋아요
+		List<ReviewLikes> reviewLikes = reviewLikesRepository.findAllByUser_UserId(targetUserId);
+		reviewLikes.forEach(rl -> rl.getReview().decrementLikeCount());
+		reviewLikesRepository.deleteAll(reviewLikes);
+
+		// 3-3) 공인중개사 좋아요
+		List<AgencyLikes> agencyLikes = agencyLikesRepository.findAllByUser_UserId(targetUserId);
+		agencyLikes.forEach(al -> al.getAgency().decrementLikeCount());
+		agencyLikesRepository.deleteAll(agencyLikes);
+
+		// 4) 유저 탈퇴일 기록 (스케줄러가 N일 뒤 영구 삭제)
+		user.delete(); // 내부에서 disabledAt = now 등
+		usersRepository.save(user);
+	}
 
 	private String extractDomain(String email) {
 		int atIdx = email.lastIndexOf("@");
 		return (atIdx != -1 && atIdx < email.length() - 1)
 				? email.substring(atIdx + 1)
 				: "";
+	}
+
+	private void ensureSystemUserExists(Users anyUserForFactory) {
+		boolean exists = usersRepository.existsByProviderId(SYSTEM_DELETE_ID);
+		if (!exists) {
+			Users sys = anyUserForFactory.createDeletedSystemUser();
+			usersRepository.saveAndFlush(sys); // 즉시 반영
+		}
 	}
 }

--- a/src/main/java/JJinBBang/app/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/JJinBBang/app/global/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package JJinBBang.app.global.jwt;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -96,6 +97,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				}
 				else {
 					throw new InvalidTokenException("유효하지 않은 토큰 타입입니다.");
+				}
+
+				// 탈퇴한 유저 확인
+				if (user.getDisabledAt() != null && user.getDisabledAt().isBefore(LocalDateTime.now())) {
+					throw InvalidTokenException.deletedUser();
 				}
 
 				// 5. SecurityContextHolder에 인증 정보 저장

--- a/src/main/java/JJinBBang/app/global/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/JJinBBang/app/global/jwt/exception/InvalidTokenException.java
@@ -29,4 +29,8 @@ public class InvalidTokenException extends AuthGroupException {
 	public static InvalidTokenException refreshTokenNotAllowed(){
 		return new InvalidTokenException("리프레시 토큰을 사용할 수 없는 요청입니다.");
 	}
+
+	public static InvalidTokenException deletedUser() {
+		return new InvalidTokenException("탈퇴한 유저입니다.");
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -117,9 +117,12 @@ logging:
 app:
   repository:
     mode:
-#      inmemory
-      redis
+      inmemory
+#      redis
 
+user:
+  deletion:
+    grace-days: 30 # 사용자가 탈퇴한 후, 해당 사용자의 데이터가 삭제되기까지의 기간 (일 단위)
 
 security:
   path:


### PR DESCRIPTION
## 📌 이슈 번호

Closes #167

## 💬 리뷰 포인트
* 회원탈퇴 API 구현 : [DELETE] /api/v1/auth/user
* “**작성 데이터는 유지(시스템 유저로 재매핑), 행동 데이터는 삭제**” 플로우
* `SYSTEM_DELETE_ID`(자연키) 기반 **시스템 유저 보장 로직**
* **스케줄러**로 `disabledAt + N일` 경과 계정만 **영구 삭제**하는 정책/코드 타이밍
* **보안 경로**: 로그인/토큰 발급 시 **탈퇴 유저 차단** 처리 (AuthController / JWT Filter)

## 🚀 상세 설명

### 1) 사용자 탈퇴 2단계 플로우 도입

* **1단계(즉시 처리)**: `UsersServiceImpl#deleteUser`

  * 시스템 유저 (`SYSTEM_DELETE_ID="___system_delete_user___"`)
  * **리뷰(작성 데이터)**: 시스템 유저로 재매핑

    * `GeneralReviewsRepository.updateUserToSystemUser(userId, systemUser)`
  * **좋아요(행동 데이터)**: 조회 → **카운트 감소** → `deleteAll(...)`

    * `BuildingLikes`, `ReviewLikes`, `AgencyLikes` 각각 처리
  * `user.delete()`로 `disabledAt` 기록 및 일부 개인정보 삭제
* **2단계(영구 삭제)**: `UserScheduler#finalizeDeletionBatch`

  * 매일 03:00, `disabledAt <= now - graceDays` 대상 **DB 하드 딜리트**
  * `user.deletion.grace-days`(기본 30일)로 기간 설정 가능

### 2) 시스템 유저 정책(고정 PK 제거, 자연키로 조회)
* **자연키**(`providerId = SYSTEM_DELETE_ID`)로 조회/생성

  * 존재하지 않으면 생성(`saveAndFlush`)
  * 존재하면 그대로 사용

### 3) 인증/접근 제어

* **로그인 시**(AuthController): `disabledAt != null && disabledAt < now` 이면 **로그인 차단**
* **JWT 필터**에서도 동일 검증 추가 → 토큰 사용 단계에서도 **탈퇴 유저 차단**

### 4) N+1 제거(좋아요 조회)

* `@EntityGraph(attributePaths = {"building" | "review" | "agency"})` 추가

### 5) 설정값

* `application.yml`

  * `user.deletion.grace-days: 30` 기본값 추가

### 6) 예외 타입 추가

* `UserAuthException#deletedUser`, `InvalidTokenException#deletedUser`

### 7) 기타

* `Users#delete()` 메서드: 탈퇴 처리 시점에 `disabledAt` 세팅 및 일부 사용자 필드 정리

---

## 📸 스크린샷

---

## 📢 노트

시스템유저는 UsersServiceImpl의  `SYSTEM_DELETE_ID="___system_delete_user___"을 providerId로 가지고, 대학 정보나 학번, 인증상태 등의 정보가 없습니다.

유저 탈퇴 시, 기존에 유저가 작성했던 게시글들을 하나의 시스템 유저로 전부 매핑을 하는데, 이러한 구조가 문제가 없는지 확인해주시면 감사하겠습니다.

또한 이러한 작업으로 인해 다른 로직에 문제가 생기면 문의해주시면 감사하겠습니다!
