### PR TITLE
[Feat#169]: DormitoryReviewInfo에 캠퍼스 ID를 추가

### DIFF
--- a/src/main/java/JJinBBang/app/global/common/dto/DormitoryReviewInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/DormitoryReviewInfo.java
@@ -8,14 +8,12 @@ import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.domain.building.enums.Floor;
 import lombok.Builder;
 
-import java.math.BigDecimal;
-import java.util.List;
-
 @Builder
 public record DormitoryReviewInfo(
         Long id,
         String name,
         BuildingType type,
+        Long campusId,
         String universityName,
         Floor floor,
         Integer capacity,
@@ -38,11 +36,17 @@ public record DormitoryReviewInfo(
     }
 
     public static DormitoryReviewInfo of(DormReviews dormReviews, Boolean liked) {
+
+        String universityName = dormReviews.getBuilding().getCampus().getUniversity().getUniversityName();
+        String campusName =  dormReviews.getBuilding().getCampus().getCampusName();
+        Long campusId = dormReviews.getBuilding().getCampus().getId();
+
         return DormitoryReviewInfo.builder()
             .id(dormReviews.getId())
             .name(dormReviews.getBuilding().getBuildingName())
             .type(BuildingType.DORMITORY)
-            .universityName(dormReviews.getBuilding().getCampus().getCampusName())
+            .universityName(universityName + " " + campusName)
+            .campusId(campusId)
             .floor(dormReviews.getFloor())
             .capacity(dormReviews.getCapacity())
             .dormFee(dormReviews.getDormFee())


### PR DESCRIPTION
## 📌 이슈 번호
- #169

## 💬 리뷰 포인트
- DormitoryReviewInfo에 `campusId`를 추가했습니다.

## 🚀 상세 설명
- 기숙사 유형 리뷰를 수정할 때 필요한 `campusId`를 제공하기 위해 리뷰 상세 조회에서 `campusId`를 포함하도록 했습니다.
- `DormitoryReviewInfo` 레코드에 `campusId` 필드를 추가했습니다.
- 팩터리 메서드(of)에 `campusId` 설정 로직을 추가했습니다.

## 📸 스크린샷
<img width="591" height="491" alt="image" src="https://github.com/user-attachments/assets/8c8791a3-fb9f-4167-82c4-c8a676065d52" />

## 📢 노트