### PR TITLE
[Fix #188]: 리뷰 요청의 크기 검증 로직에서 최소 크기를 1로 변경

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/ReviewRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/ReviewRequest.java
@@ -72,7 +72,7 @@ public record ReviewRequest (
 			return size <= 20;
 		}
 
-		return size >= 2 && size <= 20;
+		return size >= 1 && size <= 20;
 	}
 
 


### PR DESCRIPTION
## 📌 이슈 번호
- #188 

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요
- 임시로 리뷰 수정 요청의 이미지 개수 최소 크기를 1로 수정했습니다.

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요
- 임시로 리뷰 수정 요청의 이미지 개수 검증 로직에서 최소 크기를 1로 변경했습니다.
## 📸 스크린샷

## 📢 노트