### PR TITLE
Feat[#189] OAuth 로그인에 redirectUri 파라미터 도입

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController {
         // 소셜 로그인 API
 
         // 전달받은 provider에 따라 매칭되는 LoginService 인터페이스 구현체를 실행하여 소셜 로그인 진행
-        Users user = oAuthService.login(loginRequest.oauthProvider(), loginRequest.oauthCode());
+        Users user = oAuthService.login(loginRequest.oauthProvider(), loginRequest.oauthCode(), loginRequest.redirectUri());
 
         if (user.getUserId() == null) {
             // 약관 동의가 필요한 경우

--- a/src/main/java/JJinBBang/app/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/JJinBBang/app/domain/user/dto/request/LoginRequest.java
@@ -2,6 +2,7 @@ package JJinBBang.app.domain.user.dto.request;
 
 public record LoginRequest(
         String oauthProvider,
-        String oauthCode
+        String oauthCode,
+		String redirectUri
 ) {
 }

--- a/src/main/java/JJinBBang/app/domain/user/exception/GoogleAuthException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/GoogleAuthException.java
@@ -18,4 +18,8 @@ public class GoogleAuthException extends AuthGroupException {
     public static GoogleAuthException userInfoFetchFailed(){
         return new GoogleAuthException("구글 API 엑세스 토큰으로 유저 정보 조회에 실패하였습니다.");
     }
+
+    public static GoogleAuthException notAllowedRedirectUri() {
+        return new GoogleAuthException("허용되지 않은 리다이렉트 URI 입니다.");
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/user/exception/KakaoAuthException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/KakaoAuthException.java
@@ -18,4 +18,8 @@ public class KakaoAuthException extends AuthGroupException {
     public static KakaoAuthException userInfoFetchFailed(){
         return new KakaoAuthException("카카오 API 엑세스 토큰으로 유저 정보 조회에 실패하였습니다.");
     }
+
+    public static KakaoAuthException notAllowedRedirectUri(){
+        return new KakaoAuthException("허용되지 않은 리다이렉트 URI 입니다.");
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/user/exception/NaverAuthException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/NaverAuthException.java
@@ -18,4 +18,7 @@ public class NaverAuthException extends RuntimeException {
         return new NaverAuthException("네이버 API 엑세스 토큰으로 유저 정보 조회에 실패하였습니다.");
     }
 
+    public static NaverAuthException notAllowedRedirectUri() {
+        return new NaverAuthException("허용되지 않은 리다이렉트 URI 입니다.");
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/OAuthService.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/OAuthService.java
@@ -4,7 +4,7 @@ import JJinBBang.app.domain.user.entity.Users;
 
 public interface OAuthService {
 
-    Users login(String oauthProvider, String oauthCode);
+    Users login(String oauthProvider, String oauthCode, String redirectUri);
 
     Users signup(Users user);
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/OAuthServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/OAuthServiceImpl.java
@@ -34,7 +34,7 @@ public class OAuthServiceImpl implements OAuthService {
 
 
     @Override
-    public Users login(String oauthProvider, String oauthCode) {
+    public Users login(String oauthProvider, String oauthCode, String redirectUri) {
         LoginService loginService = loginServiceMap.get(oauthProvider);
 
         if (loginService == null) {
@@ -42,7 +42,7 @@ public class OAuthServiceImpl implements OAuthService {
             throw AuthNotFoundException.socialProviderNotFound();
         }
 
-        return loginService.login(oauthCode);
+        return loginService.login(oauthCode, redirectUri);
     }
 
     @Override

--- a/src/main/java/JJinBBang/app/domain/user/service/login/GoogleLoginServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/login/GoogleLoginServiceImpl.java
@@ -2,6 +2,7 @@ package JJinBBang.app.domain.user.service.login;
 
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.domain.user.exception.GoogleAuthException;
+import JJinBBang.app.domain.user.exception.KakaoAuthException;
 import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.common.enums.Provider;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -32,8 +34,11 @@ public class GoogleLoginServiceImpl implements LoginService {
     @Value("${spring.security.oauth2.client.registration.google.client-secret}")
     private String clientSecret;
 
-    @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
-    private String redirectUri;
+    @Value("${security.oauth.allowed-redirect-uri.local.google}")
+    private String localRedirectUri;
+
+    @Value("${security.oauth.allowed-redirect-uri.prod.google}")
+    private String prodRedirectUri;
 
     private final UsersService usersService;
 
@@ -48,8 +53,14 @@ public class GoogleLoginServiceImpl implements LoginService {
     }
 
     @Override
-    public Users login(String oauthCode) {
-        String accessToken = requestAccessToken(oauthCode);
+    public Users login(String oauthCode, String redirectUri) {
+        // redirectUri 검증
+        List<String> allowedRedirectUris = List.of(localRedirectUri, prodRedirectUri);
+        if(!allowedRedirectUris.contains(redirectUri)){
+            throw KakaoAuthException.notAllowedRedirectUri();
+        }
+
+        String accessToken = requestAccessToken(oauthCode, redirectUri);
         Map<String, Object> profile = requestUserInfo(accessToken);
 
         String googleId = (String) profile.get("sub");
@@ -66,7 +77,7 @@ public class GoogleLoginServiceImpl implements LoginService {
                 .build();
     }
 
-    private String requestAccessToken(String code) {
+    private String requestAccessToken(String code, String redirectUri) {
         RestTemplate rt = new RestTemplate();
         MultiValueMap<String,String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");

--- a/src/main/java/JJinBBang/app/domain/user/service/login/GoogleLoginServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/login/GoogleLoginServiceImpl.java
@@ -57,7 +57,7 @@ public class GoogleLoginServiceImpl implements LoginService {
         // redirectUri 검증
         List<String> allowedRedirectUris = List.of(localRedirectUri, prodRedirectUri);
         if(!allowedRedirectUris.contains(redirectUri)){
-            throw KakaoAuthException.notAllowedRedirectUri();
+            throw GoogleAuthException.notAllowedRedirectUri();
         }
 
         String accessToken = requestAccessToken(oauthCode, redirectUri);

--- a/src/main/java/JJinBBang/app/domain/user/service/login/KakaoLoginServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/login/KakaoLoginServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -33,8 +34,12 @@ public class KakaoLoginServiceImpl implements LoginService{
     @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
     private String clientSecret;
 
-    @Value("${spring.security.oauth2.client.registration.kakao.redirect-uri}")
-    private String redirectUri;
+    @Value("${security.oauth.allowed-redirect-uri.local.kakao}")
+    private String localRedirectUri;
+
+    @Value("${security.oauth.allowed-redirect-uri.prod.kakao}")
+    private String prodRedirectUri;
+
 
     private final UsersService usersService;
 
@@ -50,9 +55,14 @@ public class KakaoLoginServiceImpl implements LoginService{
     }
 
     @Override
-    public Users login(String oauthCode) {
+    public Users login(String oauthCode, String redirectUri) {
+        // redirectUri 검증
+        List<String> allowedRedirectUris = List.of(localRedirectUri, prodRedirectUri);
+        if(!allowedRedirectUris.contains(redirectUri)){
+            throw KakaoAuthException.notAllowedRedirectUri();
+        }
 
-        String oauthAccessToken = getAccessToken(oauthCode);
+        String oauthAccessToken = getAccessToken(oauthCode, redirectUri);
 
         Map<String, Object> kakaoUserInfo = getKakaoUserInfo(oauthAccessToken);
 
@@ -74,7 +84,7 @@ public class KakaoLoginServiceImpl implements LoginService{
     }
 
 
-    private String getAccessToken(String code) {
+    private String getAccessToken(String code, String redirectUri) {
         try {
             // 요청 파라미터
             MultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/src/main/java/JJinBBang/app/domain/user/service/login/LoginService.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/login/LoginService.java
@@ -9,5 +9,5 @@ public interface LoginService {
 
     String makeProviderId(String id);
 
-    Users login(String oauthCode);
+    Users login(String oauthCode, String redirectUri);
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/login/NaverLoginServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/login/NaverLoginServiceImpl.java
@@ -57,7 +57,7 @@ public class NaverLoginServiceImpl implements LoginService {
         // redirectUri 검증
         List<String> allowedRedirectUris = List.of(localRedirectUri, prodRedirectUri);
         if(!allowedRedirectUris.contains(redirectUri)){
-            throw KakaoAuthException.notAllowedRedirectUri();
+            throw NaverAuthException.notAllowedRedirectUri();
         }
 
         // 1) 액세스 토큰 발급

--- a/src/main/java/JJinBBang/app/domain/user/service/login/NaverLoginServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/login/NaverLoginServiceImpl.java
@@ -34,10 +34,10 @@ public class NaverLoginServiceImpl implements LoginService {
     @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
     private String clientSecret;
 
-    @Value("${security.oauth.allowed-redirect-uri.local.kakao}")
+    @Value("${security.oauth.allowed-redirect-uri.local.naver}")
     private String localRedirectUri;
 
-    @Value("${security.oauth.allowed-redirect-uri.prod.kakao}")
+    @Value("${security.oauth.allowed-redirect-uri.prod.naver}")
     private String prodRedirectUri;
 
     private final UsersService usersService;

--- a/src/main/java/JJinBBang/app/domain/user/service/login/NaverLoginServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/login/NaverLoginServiceImpl.java
@@ -1,6 +1,7 @@
 package JJinBBang.app.domain.user.service.login;
 
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.exception.KakaoAuthException;
 import JJinBBang.app.domain.user.exception.NaverAuthException;
 import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.common.enums.Provider;
@@ -13,6 +14,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.Map;
 
 @Slf4j
@@ -32,8 +34,11 @@ public class NaverLoginServiceImpl implements LoginService {
     @Value("${spring.security.oauth2.client.registration.naver.client-secret}")
     private String clientSecret;
 
-    @Value("${spring.security.oauth2.client.registration.naver.redirect-uri}")
-    private String redirectUri;
+    @Value("${security.oauth.allowed-redirect-uri.local.kakao}")
+    private String localRedirectUri;
+
+    @Value("${security.oauth.allowed-redirect-uri.prod.kakao}")
+    private String prodRedirectUri;
 
     private final UsersService usersService;
 
@@ -48,9 +53,15 @@ public class NaverLoginServiceImpl implements LoginService {
     }
 
     @Override
-    public Users login(String oauthCode) {
+    public Users login(String oauthCode, String redirectUri) {
+        // redirectUri 검증
+        List<String> allowedRedirectUris = List.of(localRedirectUri, prodRedirectUri);
+        if(!allowedRedirectUris.contains(redirectUri)){
+            throw KakaoAuthException.notAllowedRedirectUri();
+        }
+
         // 1) 액세스 토큰 발급
-        String accessToken = getAccessToken(oauthCode);
+        String accessToken = getAccessToken(oauthCode, redirectUri);
 
         // 2) 유저 정보 조회
         Map<String, Object> naverUserInfo = getUserInfo(accessToken);
@@ -72,7 +83,7 @@ public class NaverLoginServiceImpl implements LoginService {
                 .build();
     }
 
-    private String getAccessToken(String code) {
+    private String getAccessToken(String code, String redirectUri) {
         try {
             MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
             params.add("grant_type", "authorization_code");


### PR DESCRIPTION
## 📌 이슈 번호

> \#189

## 💬 리뷰 포인트

* 로그인 API 요청 바디에 redirectUri 필드 추가
* Kakao/Google/Naver 로그인에서 허용 목록 검증 후 토큰 교환
* 토큰 교환 요청에 전달된 redirectUri를 그대로 사용
* Provider별 notAllowedRedirectUri 예외 추가

---

## 🚀 상세 설명

* DTO

  * LoginRequest: redirectUri 필드 추가
* Controller/Service

  * OAuthService#login → login(oauthProvider, oauthCode, redirectUri)로 시그니처 변경
  * LoginService#login → login(oauthCode, redirectUri)로 시그니처 변경
* Provider 구현

  * Kakao/Google/Naver

    * 설정에 등록된 허용 redirectUri 목록과 일치하는지 검증
    * 토큰 교환 파라미터에 redirect uri를 전달된 값으로 포함
* 예외

  * KakaoAuthException/GoogleAuthException/NaverAuthException.notAllowedRedirectUri 추가

```yaml
security:
  oauth:
    allowed-redirect-uri:
      local:
        kakao: 
        naver: 
        google: 
      prod:
        kakao: 
        naver: 
        google: 
```

## 📸 스크린샷

## 📢 노트
