### PR TITLE
🔨 Fix[#193]: 올바른 경도값으로 설정하도록 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/Building.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/Building.java
@@ -23,7 +23,7 @@ public record Building (
 			.type(buildingType)
 			.address(building.getBuildingAddress())
 			.latitude(building.getBuildingLat())
-			.longitude(building.getBuildingLat())
+			.longitude(building.getBuildingLot())
 			.build();
 	}
 
@@ -35,7 +35,7 @@ public record Building (
 			.type(buildingType)
 			.address(agency.getAddress())
 			.latitude(agency.getAgencyLat())
-			.longitude(agency.getAgencyLat())
+			.longitude(agency.getAgencyLot())
 			.build();
 	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #193

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요
- 올바른 경도값으로 설정하도록 수정했습니다

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요
- 리뷰 상세 조회 중 컴포넌트 building을 생성할 때 longitude 필드에 위도 값을 넣어서 발생한 문제 였습니다.
- 이 문제를 해결하기 위해 경도 값으로 바꿨습니다.
## 📸 스크린샷

## 📢 노트