### PR TITLE
[Fix #196]: 기숙사 유형 리뷰 작성 시 기숙사 합격 조건 관련 유효성 검사 삭제

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/Conditions.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/Conditions.java
@@ -1,14 +1,11 @@
 package JJinBBang.app.domain.building.dto;
 
 import JJinBBang.app.domain.building.entity.DormReviews;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record Conditions(
-	@NotNull
 	String currentRegion,
-	@NotNull
 	Double currentGrade
 ) {
 	public static Conditions of(DormReviews dormReviews) {

--- a/src/main/java/JJinBBang/app/domain/building/dto/ReviewRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/ReviewRequest.java
@@ -37,16 +37,14 @@ public record ReviewRequest (
 	Keywords keywords,
 
 	// 기숙사 전용
-	@Valid
 	Conditions condition,
 	@Valid
 	FacilitiesDto facilities
 ){
-	@AssertTrue(message = "기숙사 리뷰인 경우 condition 및 facilities 필드는 필수입니다.")
+	@AssertTrue(message = "기숙사 리뷰인 경우 facilities 필드는 필수입니다.")
 	private boolean isDormitoryDetailsProvided() {
 		if (dormitoryReview != null) {
-			return condition   != null
-				&& facilities  != null;
+			return facilities  != null;
 		}
 		return true;
 	}


### PR DESCRIPTION
## 📌 이슈 번호
- #196

## 💬 리뷰 포인트
- 기숙사 리뷰에서 성적/거리 조건 null 허용 및 검증 로직 완화가 의도대로 동작하는지 확인

## 🚀 상세 설명
- Conditions의 @NotNull 제거로 currentRegion/currentGrade nullable 처리, ReviewRequest에서 condition 필수 검증 제거(시설만 필수 유지)

## 📸 스크린샷
- 해당 없음

## 📢 노트
