### PR TITLE
[Feat #199] 건물에 관한 평균 비용 계산 로직 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/BuildingRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/BuildingRequest.java
@@ -11,46 +11,51 @@ import lombok.Builder;
 
 @Builder
 public record BuildingRequest (
-        @NotBlank
-        String buildingCode,
-        @NotBlank
-        String name,
-        @NotNull
-        BuildingType type,
-        @NotBlank
-        String address,
-        @NotNull
-        Double latitude,
-        @NotNull
-        Double longitude
+    @NotBlank
+    String buildingCode,
+    @NotBlank
+    String name,
+    @NotNull
+    BuildingType type,
+    @NotBlank
+    String address,
+    @NotNull
+    Double latitude,
+    @NotNull
+    Double longitude
 ){
     public Buildings toBuildingEntity(Campuses campus) {
         return Buildings.builder()
-                .buildingCode(buildingCode)
-                .buildingName(name)
-                .buildingType(type.toString())
-                .buildingAddress(address)
-                .buildingLat(latitude)
-                .buildingLot(longitude)
-                .buildingRating(null)
-                .reviewCount(0)
-                .likeCount(0)
-                .imagesCount(0)
-                .campus(campus)
-                .build();
+            .buildingCode(buildingCode)
+            .buildingName(name)
+            .buildingType(type.toString())
+            .buildingAddress(address)
+            .buildingLat(latitude)
+            .buildingLot(longitude)
+            .buildingRating(null)
+            .avgRentDeposit(null)
+            .avgMonthlyRent(null)
+            .avgMaintenanceCost(null)
+            .avgDeposit(null)
+            .reviewCount(0)
+            .likeCount(0)
+            .imagesCount(0)
+            .campus(campus)
+            .build();
     }
+
     public Agencies toAgencyEntity() {
         return Agencies.builder()
-                .agencySerial(buildingCode)
-                .name(name)
-                .address(address)
-                .agencyLat(latitude)
-                .agencyLot(longitude)
-                .rating(null)
-                .reviewCount(0)
-                .likeCount(0)
-                .imagesCount(0)
-                .build();
+            .agencySerial(buildingCode)
+            .name(name)
+            .address(address)
+            .agencyLat(latitude)
+            .agencyLot(longitude)
+            .rating(null)
+            .reviewCount(0)
+            .likeCount(0)
+            .imagesCount(0)
+            .build();
     }
 }
 

--- a/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
@@ -241,4 +241,11 @@ public class Buildings extends BaseEntity {
 		}
 		this.likeCount++;
 	}
+
+	public void applyAverages(Long avgDeposit, Long avgMaintenance, Long avgMonthlyRent, Long avgRentDeposit) {
+		this.avgDeposit         = avgDeposit;
+		this.avgMaintenanceCost = avgMaintenance;
+		this.avgMonthlyRent     = avgMonthlyRent;
+		this.avgRentDeposit     = avgRentDeposit;
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/ReviewsRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/ReviewsRepository.java
@@ -5,6 +5,8 @@ import JJinBBang.app.domain.building.entity.Buildings;
 import JJinBBang.app.domain.building.entity.Reviews;
 import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.domain.building.enums.ReviewType;
+
+import java.util.List;
 import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +17,7 @@ public interface ReviewsRepository extends CrudRepository<Reviews,Long> {
     Reviews findFirstByBuildingOrderByCreatedAtDesc(Buildings building);
     Reviews findFirstByAgencyAndDtypeOrderByCreatedAtDesc(Agencies agency, ReviewType dtype);
     Page<Reviews> findAllByBuilding(Buildings building, Pageable pageable);
+    List<Reviews> findAllByBuilding(Buildings building);
     Page<Reviews> findAllByAgency(Agencies agency, Pageable pageable);
 
     @Query("SELECT DISTINCT r.buildingType FROM Reviews r WHERE r.building = :building")

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -3,8 +3,8 @@ package JJinBBang.app.domain.building.service;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import java.util.Set;
+
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -184,8 +184,11 @@ public class ReviewServiceImpl implements ReviewService {
         }
 
         // 4.4) 건물 유형 업데이트
-				Set<BuildingType> newBuildingType = getBuildingTypesFromBuilding(building);
-				building.updateBuildingType(newBuildingType);
+		Set<BuildingType> newBuildingType = getBuildingTypesFromBuilding(building);
+		building.updateBuildingType(newBuildingType);
+
+		// 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 추가
+		recalculateAndApplyBuildingAverages(building);
 
         // 4.5) 건물 엔티티 저장
         buildingsRepository.save(building);
@@ -455,6 +458,11 @@ public class ReviewServiceImpl implements ReviewService {
 			Set<BuildingType> newNewBuildingType = getBuildingTypesFromBuilding(oldBuilding);
 			oldBuilding.updateBuildingType(newNewBuildingType);
 
+			// 이전 건물 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 삭제
+			recalculateAndApplyBuildingAverages(oldBuilding);
+			// 신규 건물 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 추가
+			recalculateAndApplyBuildingAverages(newBuilding);			// 이전 건물 월세인 경우 평균 보증금, 평균 관리비, 평균 월세 정보 삭제
+
 			// c) 두 건물 저장
 			buildingsRepository.saveAll(List.of(oldBuilding, newBuilding));
 		} else {
@@ -473,6 +481,9 @@ public class ReviewServiceImpl implements ReviewService {
 			// c) 건물 유형 업데이트
 			Set<BuildingType> newBuildingType = getBuildingTypesFromBuilding(oldBuilding);
 			oldBuilding.updateBuildingType(newBuildingType);
+
+			// 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 추가
+			recalculateAndApplyBuildingAverages(oldBuilding);
 
 			// d) 건물 저장
 			buildingsRepository.save(oldBuilding);
@@ -651,6 +662,9 @@ public class ReviewServiceImpl implements ReviewService {
 		Set<BuildingType> newBuildingType = getBuildingTypesFromBuilding(building);
 		building.updateBuildingType(newBuildingType);
 
+		// 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 추가
+		recalculateAndApplyBuildingAverages(building);
+
         buildingsRepository.save(building);
     }
 
@@ -717,5 +731,51 @@ public class ReviewServiceImpl implements ReviewService {
 	private Set<BuildingType> getBuildingTypesFromBuilding(Buildings building) {
 		return reviewsRepository.findDistinctBuildingTypesByBuilding(building);
 	}
-}
 
+	// 건물의 평균 금액(월세/전세/관리비)을 재계산하여 적용
+	private void recalculateAndApplyBuildingAverages(Buildings building) {
+		List<GeneralReviews> list = reviewsRepository.findAllByBuilding(building)
+			.stream()
+			.map(r -> (GeneralReviews)r)
+			.toList();
+
+		long sumDeposit = 0L, sumMonthly = 0L, sumMaint = 0L, sumJeonse = 0L;
+		int cntDeposit = 0, cntMonthly = 0, cntMaint = 0, cntJeonse = 0;
+
+		for (GeneralReviews r : list) {
+			// 관리비: 월세/전세 공통
+			Integer maintenanceCost = r.getMaintenanceCost();
+			if (maintenanceCost != null) {
+				sumMaint += maintenanceCost;
+				cntMaint++;
+			}
+
+			ContractType type = r.getContractType();
+			if (type == ContractType.MONTHLY_RENT) {
+				Integer monthly = r.getPrice();    // 월세
+				if (monthly != null) {
+					sumMonthly += monthly;
+					cntMonthly++;
+				}
+				Integer deposit = r.getDeposit();  // 보증금
+				if (deposit != null) {
+					sumDeposit += deposit;
+					cntDeposit++;
+				}
+			} else {
+				Integer jeonse = r.getDeposit();     // 전세 보증금
+				if (jeonse != null) {
+					sumJeonse += jeonse;
+					cntJeonse++;
+				}
+			}
+		}
+
+		Long avgDeposit = (cntDeposit > 0) ? Math.round((double)sumDeposit / cntDeposit) : null;
+		Long avgMonthlyRent = (cntMonthly > 0) ? Math.round((double)sumMonthly / cntMonthly) : null;
+		Long avgMaintenance = (cntMaint > 0) ? Math.round((double)sumMaint / cntMaint) : null;
+		Long avgRentDeposit = (cntJeonse > 0) ? Math.round((double)sumJeonse / cntJeonse) : null;
+
+		building.applyAverages(avgDeposit, avgMaintenance, avgMonthlyRent, avgRentDeposit);
+	}
+}


### PR DESCRIPTION
## 📌 이슈 번호

* \#199

## 💬 리뷰 포인트

* 일반 리뷰 생성/수정/삭제 시 **건물 평균 금액(보증금/월세/관리비/전세보증금)** 자동 갱신

## 🚀 상세 설명

* `ReviewServiceImpl`에 `recalculateAndApplyBuildingAverages(Buildings building)` 추가

  * `ReviewsRepository.findAllByBuilding(building)` 결과 중 **GeneralReviews** 기준으로 합산/평균
  * `ContractType.MONTHLY_RENT`: 보증금/월세/관리비 집계
  * `ContractType.DEPOSIT_RENT(전세)`: 전세보증금/관리비 집계
  * 관리비는 월세/전세 **공통** 집계, 값 없으면 카운트 제외
  * 결과는 `building.applyAverages(...)`로 반영
## 📸 스크린샷

## 📢 노트
