### PR TITLE
[Fix #202]: 리뷰상세조회 시 좋아요 확인 로직을 사용자 ID 비교하는 방식으로 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -103,7 +103,7 @@ public class ReviewServiceImpl implements ReviewService {
 
         // 2) 좋아요 여부 확인
         boolean liked = review.getReviewLikes().stream()
-                .anyMatch(like -> like.getUser().equals(user));
+			.anyMatch(like -> like.getUser().getUserId().equals(user.getUserId()));
 
         // 3) 상세 정보 로드
         ReviewDetails detail = reviewDetailsRepository.findByReviewId(reviewId)


### PR DESCRIPTION
## 📌 이슈 번호
- #202

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요
- 리뷰상세조회 시 좋아요 호가인 로직을 사용자 ID를 비교하는 방식으로 수정했습니다.

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요
- 기존에는 좋아요 확인 로직을 유저 객체를 비교하면서 제대로 동작하지 않았습니다.
- 유저의 id 값을 비교하면서 좋아요 확인 로직이 동작하도록 수정했습니다.
## 📸 스크린샷
<img width="844" height="588" alt="image" src="https://github.com/user-attachments/assets/574985f4-c6bd-4d7f-86b0-97ddb4b8d4aa" />

## 📢 노트