### PR TITLE
[Feat #205]: 건물 유형 추가 및 업데이트 로직 변경

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -247,5 +248,11 @@ public class Buildings extends BaseEntity {
 		this.avgMaintenanceCost = avgMaintenance;
 		this.avgMonthlyRent     = avgMonthlyRent;
 		this.avgRentDeposit     = avgRentDeposit;
+	}
+
+	public void addBuildingType(BuildingType buildingType) {
+		Set<BuildingType> buildingTypes = new HashSet<>(this.getBuildingType());
+		buildingTypes.add(buildingType);
+		this.updateBuildingType(buildingTypes);
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -3,7 +3,6 @@ package JJinBBang.app.domain.building.service;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -184,8 +183,7 @@ public class ReviewServiceImpl implements ReviewService {
         }
 
         // 4.4) 건물 유형 업데이트
-		Set<BuildingType> newBuildingType = getBuildingTypesFromBuilding(building);
-		building.updateBuildingType(newBuildingType);
+		building.addBuildingType(dto.buildingRequest().type());
 
 		// 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 추가
 		recalculateAndApplyBuildingAverages(building);
@@ -453,10 +451,7 @@ public class ReviewServiceImpl implements ReviewService {
 			reviewDetailsRepository.save(updatedDetails);
 
 			// d) 건물 유형 업데이트
-			Set<BuildingType> newOldBuildingType = getBuildingTypesFromBuilding(oldBuilding);
-			oldBuilding.updateBuildingType(newOldBuildingType);
-			Set<BuildingType> newNewBuildingType = getBuildingTypesFromBuilding(oldBuilding);
-			oldBuilding.updateBuildingType(newNewBuildingType);
+			newBuilding.addBuildingType(dto.buildingRequest().type());
 
 			// 이전 건물 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 삭제
 			recalculateAndApplyBuildingAverages(oldBuilding);
@@ -479,8 +474,7 @@ public class ReviewServiceImpl implements ReviewService {
 			reviewDetailsRepository.save(updatedDetails);
 
 			// c) 건물 유형 업데이트
-			Set<BuildingType> newBuildingType = getBuildingTypesFromBuilding(oldBuilding);
-			oldBuilding.updateBuildingType(newBuildingType);
+			oldBuilding.addBuildingType(dto.buildingRequest().type());
 
 			// 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 추가
 			recalculateAndApplyBuildingAverages(oldBuilding);
@@ -658,10 +652,6 @@ public class ReviewServiceImpl implements ReviewService {
         reviewDetailsRepository.deleteByReviewId(review.getId());
         reviewsRepository.delete(review);
 
-		// f)건물 유형 업데이트
-		Set<BuildingType> newBuildingType = getBuildingTypesFromBuilding(building);
-		building.updateBuildingType(newBuildingType);
-
 		// 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 추가
 		recalculateAndApplyBuildingAverages(building);
 
@@ -726,11 +716,6 @@ public class ReviewServiceImpl implements ReviewService {
         reviewDetailsRepository.deleteByReviewId(review.getId());
         reviewsRepository.delete(review);
     }
-
-	// 건물과 관련된 리뷰들의 건물 유형 집합 조회하는 메서드
-	private Set<BuildingType> getBuildingTypesFromBuilding(Buildings building) {
-		return reviewsRepository.findDistinctBuildingTypesByBuilding(building);
-	}
 
 	// 건물의 평균 금액(월세/전세/관리비)을 재계산하여 적용
 	private void recalculateAndApplyBuildingAverages(Buildings building) {


### PR DESCRIPTION
## 📌 이슈 번호

> \#205

## 💬 리뷰 포인트

* `building_type`가 **append-only**로 일관 적용되었는지(생성/수정/삭제)
* 중복 추가 방지(`addBuildingType`, `findOrCreateBuilding`)와 트랜잭션 처리

## 🚀 상세 설명

* 건물 데이터 **유지**, 리뷰 변경 시 건물 `building_type`은 **추가만**(삭제/축소 없음)
  * 리뷰 생성 → `addBuildingType`로 신규 유형 추가
  * 리뷰 수정 → 동일 건물은 추가만, 건물 변경 시 **신규 건물만** 추가
  * 리뷰 삭제 → 건물 `building_type` 변경 없음

## 📸 스크린샷

## 📢 노트
