### PR TITLE
[Feat #207] S3 Presigned 업로드 API 추가 및 리뷰 삭제 시 이미지 정리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 	implementation 'com.google.apis:google-api-services-drive:v3-rev20250511-2.0.0' // Google Drive
 	implementation 'com.google.apis:google-api-services-sheets:v4-rev20250509-2.0.0' // Google Sheets
 	implementation 'com.google.auth:google-auth-library-oauth2-http:1.20.0' // Google Auth
+
+	// AWS S3
+	implementation 'software.amazon.awssdk:s3:2.32.31'
 }
 
 // Q 클래스 경로 지정

--- a/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Buildings.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -223,10 +224,13 @@ public class Buildings extends BaseEntity {
 		}
 	}
 
-	public void updateBuildingType(Set<BuildingType> newBuildingTypes) {
-		this.buildingType = newBuildingTypes.stream()
-				.map(BuildingType::toString)
-				.collect(Collectors.joining(","));
+	public void addBuildingType(BuildingType type) {
+		Set<BuildingType> set = new HashSet<>(this.getBuildingType());
+		set.add(type);
+
+		this.buildingType = set.stream()
+			.map(BuildingType::toString)
+			.collect(Collectors.joining(","));
 	}
 
     public void decrementLikeCount() {

--- a/src/main/java/JJinBBang/app/domain/building/exception/ReviewNotFoundException.java
+++ b/src/main/java/JJinBBang/app/domain/building/exception/ReviewNotFoundException.java
@@ -10,4 +10,8 @@ public class ReviewNotFoundException extends NotFoundGroupException {
 	public static ReviewNotFoundException missingReview() {
 		return new ReviewNotFoundException("해당 리뷰 정보가 존재하지 않습니다.");
 	}
+
+	public static ReviewNotFoundException missingReviewType() {
+		return new ReviewNotFoundException("해당 리뷰 유형이 존재하지 않습니다.");
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -3,7 +3,6 @@ package JJinBBang.app.domain.building.service;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -17,6 +16,7 @@ import JJinBBang.app.domain.building.exception.*;
 import JJinBBang.app.domain.building.repository.*;
 import JJinBBang.app.domain.common.dto.PaginatedResponse;
 import JJinBBang.app.domain.common.entity.Campuses;
+import JJinBBang.app.domain.common.service.S3Service;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.common.enums.KeywordType;
 import lombok.RequiredArgsConstructor;
@@ -39,8 +39,9 @@ public class ReviewServiceImpl implements ReviewService {
 	private final DormitoryFacilitiesRepository dormitoryFacilitiesRepository;
 	private final BuildingKeywordCountsRepository buildingKeywordCountsRepository;
 	private final CampusesRepository campusesRepository;
+	private final S3Service s3Service;
 
-    /**
+	/**
      * 특정 건물 또는 공인중개사에 대한 리뷰 목록을 페이징 조회
      *
      * @param buildingId  건물 또는 공인중개사 ID
@@ -78,8 +79,10 @@ public class ReviewServiceImpl implements ReviewService {
                 reviewPage,
                 review -> {
                     // 3.1) 좋아요 여부 확인
-                    boolean liked = review.getReviewLikes().stream()
-                            .anyMatch(like -> like.getUser().equals(user));
+					boolean liked = review.getReviewLikes().stream()
+						.anyMatch(like -> like.getUser() != null
+							&& user != null
+							&& like.getUser().getUserId().equals(user.getUserId()));
 
                     // 3.3) 요약 응답 생성
                     return ReviewSummaryResponse.of(review, liked);
@@ -102,8 +105,10 @@ public class ReviewServiceImpl implements ReviewService {
                 .orElseThrow(ReviewNotFoundException::missingReview);
 
         // 2) 좋아요 여부 확인
-        boolean liked = review.getReviewLikes().stream()
-			.anyMatch(like -> like.getUser().getUserId().equals(user.getUserId()));
+		boolean liked = review.getReviewLikes().stream()
+			.anyMatch(like -> like.getUser() != null
+				&& user != null
+				&& like.getUser().getUserId().equals(user.getUserId()));
 
         // 3) 상세 정보 로드
         ReviewDetails detail = reviewDetailsRepository.findByReviewId(reviewId)
@@ -179,13 +184,10 @@ public class ReviewServiceImpl implements ReviewService {
         building.addRating(saved.getRating());
 
         // 4.3) 이미지 카운트 반영
-        if (!dto.imageUrls().isEmpty()) {
-            building.incrementImagesCount();
-        }
+		building.incrementImagesCount();
 
         // 4.4) 건물 유형 업데이트
-		Set<BuildingType> newBuildingType = getBuildingTypesFromBuilding(building);
-		building.updateBuildingType(newBuildingType);
+		building.addBuildingType(dto.buildingRequest().type());
 
 		// 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 추가
 		recalculateAndApplyBuildingAverages(building);
@@ -235,9 +237,7 @@ public class ReviewServiceImpl implements ReviewService {
         building.addRating(saved.getRating());
 
         // 6.3) 이미지 카운트 반영
-        if (!dto.imageUrls().isEmpty()) {
-            building.incrementImagesCount();
-        }
+		building.incrementImagesCount();
 
         // 6.4) 건물 엔티티 저장
         buildingsRepository.save(building);
@@ -271,7 +271,7 @@ public class ReviewServiceImpl implements ReviewService {
 		agency.addRating(saved.getRating());
 
 		// 4.3) 이미지 카운트 반영
-		if (!dto.imageUrls().isEmpty()) {
+		if (details.getImages() != null && !details.getImages().isEmpty()) {
 			agency.incrementImagesCount();
 		}
 
@@ -292,15 +292,8 @@ public class ReviewServiceImpl implements ReviewService {
 		return buildingsRepository.findByBuildingCode(dto.buildingCode())
 			// 기존에 있는 건물인 경우,
 			.map(existing -> {
-				// 1) 건물의 건물 유형 가져와서
-				List<BuildingType> buildingtypeList = new ArrayList<>(existing.getBuildingType());
-
-				// 2) 기존에 없는 건물 타입이면 추가
-				if (!buildingtypeList.contains(dto.type())) {
-					buildingtypeList.add(dto.type());
-					existing.setBuildingType(buildingtypeList);
-					buildingsRepository.save(existing);
-				}
+				existing.addBuildingType(dto.type());
+				buildingsRepository.save(existing);
 				return existing;
 			})
 
@@ -415,7 +408,7 @@ public class ReviewServiceImpl implements ReviewService {
 		} else if (review instanceof AgencyReviews agency) {
 			updateAgencyReview(agency, dto);
 		} else {
-			throw new UnsupportedOperationException("지원하지 않는 리뷰 타입입니다.");
+			throw ReviewNotFoundException.missingReviewType();
 		}
 	}
 
@@ -452,11 +445,11 @@ public class ReviewServiceImpl implements ReviewService {
 			ReviewDetails updatedDetails = dto.toUpdatedReviewDetails(oldDetails, newBuilding.getId());
 			reviewDetailsRepository.save(updatedDetails);
 
+			// 삭제할 이미지 삭제
+			deleteRemovedImages(oldDetails.getImages(), updatedDetails.getImages());
+
 			// d) 건물 유형 업데이트
-			Set<BuildingType> newOldBuildingType = getBuildingTypesFromBuilding(oldBuilding);
-			oldBuilding.updateBuildingType(newOldBuildingType);
-			Set<BuildingType> newNewBuildingType = getBuildingTypesFromBuilding(oldBuilding);
-			oldBuilding.updateBuildingType(newNewBuildingType);
+			newBuilding.addBuildingType(dto.buildingRequest().type());
 
 			// 이전 건물 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 삭제
 			recalculateAndApplyBuildingAverages(oldBuilding);
@@ -477,10 +470,11 @@ public class ReviewServiceImpl implements ReviewService {
 			reviewsRepository.save(updatedReview);
 			ReviewDetails updatedDetails = dto.toUpdatedReviewDetails(oldDetails, newBuilding.getId());
 			reviewDetailsRepository.save(updatedDetails);
+			// 삭제할 이미지 삭제
+			deleteRemovedImages(oldDetails.getImages(), updatedDetails.getImages());
 
 			// c) 건물 유형 업데이트
-			Set<BuildingType> newBuildingType = getBuildingTypesFromBuilding(oldBuilding);
-			oldBuilding.updateBuildingType(newBuildingType);
+			oldBuilding.addBuildingType(dto.buildingRequest().type());
 
 			// 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 추가
 			recalculateAndApplyBuildingAverages(oldBuilding);
@@ -546,6 +540,9 @@ public class ReviewServiceImpl implements ReviewService {
 		// 7) 상세 정보 갱신 저장
 		ReviewDetails updatedDetails = dto.toUpdatedReviewDetails(oldDetails, newBuilding.getId());
 		reviewDetailsRepository.save(updatedDetails);
+
+		// 삭제할 이미지 삭제
+		deleteRemovedImages(oldDetails.getImages(), updatedDetails.getImages());
 	}
 
 	/**
@@ -563,20 +560,26 @@ public class ReviewServiceImpl implements ReviewService {
 		// 2) 기존 상세 정보 로드
 		ReviewDetails oldDetails = reviewDetailsRepository.findByReviewId(oldReview.getId())
 			.orElseThrow(ReviewInternalServerErrorException::missingReviewDetailException);
+
+		// 리뷰/상세 저장
+		AgencyReviews updatedReview = dto.toUpdatedAgencyReviews(oldReview, newAgency);
+		reviewsRepository.save(updatedReview);
+		ReviewDetails updatedDetails = dto.toUpdatedReviewDetails(oldDetails, newAgency.getAgencyId());
+		reviewDetailsRepository.save(updatedDetails);
+
+		deleteRemovedImages(oldDetails.getImages(), updatedDetails.getImages());
+
 		// 3) 이미지 유무 확인
-		boolean oldHasImage = oldReview.getThumbnailImage() != null;
-		boolean newHasImage = dto.imageUrls() != null && !dto.imageUrls().isEmpty();
+		boolean oldHas = oldDetails.getImages() != null && !oldDetails.getImages().isEmpty();
+		boolean nowHas = updatedDetails.getImages() != null && !updatedDetails.getImages().isEmpty();
 
 		// 4) 이미지 변경 및 공인중개사 변경 처리
 		if (!oldAgency.getAgencySerial().equals(newAgency.getAgencySerial())) {
-			if (!oldHasImage && newHasImage)
-				newAgency.incrementImagesCount();
-			else if (oldHasImage && !newHasImage)
+			if (oldHas)
 				oldAgency.decrementImagesCount();
-			else if (oldHasImage && newHasImage) {
-				oldAgency.decrementImagesCount();
+			if (nowHas)
 				newAgency.incrementImagesCount();
-			}
+
 			updateKeywordCounts(oldAgency.getAgencyId(), true, oldDetails.getKeywords().positive(),
 				Collections.emptyList());
 			updateKeywordCounts(newAgency.getAgencyId(), true, Collections.emptyList(), dto.keywords().positive());
@@ -584,21 +587,18 @@ public class ReviewServiceImpl implements ReviewService {
 			newAgency.addRating(dto.agencyReview().getRating());
 			agenciesRepository.saveAll(List.of(oldAgency, newAgency));
 		} else {
-			if (!oldHasImage && newHasImage)
+			if (!oldHas && nowHas) {
 				oldAgency.incrementImagesCount();
-			else if (oldHasImage && !newHasImage)
+			} else if (oldHas && !nowHas) {
 				oldAgency.decrementImagesCount();
+			}
+
 			updateKeywordCounts(oldAgency.getAgencyId(), true, oldDetails.getKeywords().positive(),
 				dto.keywords().positive());
 			oldAgency.updateRating(oldReview.getRating(), dto.agencyReview().getRating());
 			agenciesRepository.save(oldAgency);
 		}
 
-		// 5) 리뷰 및 상세 정보 저장
-		AgencyReviews updatedReview = dto.toUpdatedAgencyReviews(oldReview, newAgency);
-		reviewsRepository.save(updatedReview);
-		ReviewDetails updatedDetails = dto.toUpdatedReviewDetails(oldDetails, newAgency.getAgencyId());
-		reviewDetailsRepository.save(updatedDetails);
 	}
 
     /**
@@ -646,21 +646,20 @@ public class ReviewServiceImpl implements ReviewService {
 
         // b)평점 제거
         building.removeRating(review.getRating());
+
         // c)이미지 카운트 감소
-        if (review.getThumbnailImage() != null) {
-            building.decrementImagesCount();
-        }
+		building.decrementImagesCount();
+
         // d)키워드 통계 감소
         updateKeywordCounts(building.getId(), false,
                 detail.getKeywords().positive(), Collections.emptyList());
 
-        // e)연관 데이터 삭제
-        reviewDetailsRepository.deleteByReviewId(review.getId());
-        reviewsRepository.delete(review);
+		// 리뷰 데이터 삭제
+		detail.getImages().forEach(s3Service::deleteFile);
 
-		// f)건물 유형 업데이트
-		Set<BuildingType> newBuildingType = getBuildingTypesFromBuilding(building);
-		building.updateBuildingType(newBuildingType);
+		// e)연관 데이터 삭제
+		reviewDetailsRepository.delete(detail);
+        reviewsRepository.delete(review);
 
 		// 평균 보증금, 평균 관리비, 평균 월세, 평균 전세 정보 추가
 		recalculateAndApplyBuildingAverages(building);
@@ -684,9 +683,8 @@ public class ReviewServiceImpl implements ReviewService {
         // 평점 제거
         building.removeRating(review.getRating());
         // 이미지 카운트 감소
-        if (review.getThumbnailImage() != null) {
-            building.decrementImagesCount();
-        }
+		building.decrementImagesCount();
+
         // 키워드 통계 감소
         updateKeywordCounts(building.getId(), false,
                 detail.getKeywords().positive(), Collections.emptyList());
@@ -694,7 +692,13 @@ public class ReviewServiceImpl implements ReviewService {
 
         // b) 연관된 시설, 상세정보, 리뷰 삭제
         dormitoryFacilitiesRepository.deleteAllByDormitoryReview(review);
-        reviewDetailsRepository.deleteByReviewId(review.getId());
+
+		// 리뷰 데이터 삭제
+		detail.getImages().forEach(s3Service::deleteFile);
+
+		// e)연관 데이터 삭제
+		reviewDetailsRepository.delete(detail);
+
         reviewsRepository.delete(review);
     }
 
@@ -714,28 +718,29 @@ public class ReviewServiceImpl implements ReviewService {
         // b) 평점 제거
         agency.removeRating(review.getRating());
         // 이미지 카운트 감소
-        if (review.getThumbnailImage() != null) {
-            agency.decrementImagesCount();
-        }
+		if (detail.getImages() != null && !detail.getImages().isEmpty()) {
+			agency.decrementImagesCount();
+		}
+
         // c) 키워드 통계 감소
         updateKeywordCounts(agency.getAgencyId(), true,
                 detail.getKeywords().positive(), Collections.emptyList());
         agenciesRepository.save(agency);
 
-        // d) 상세정보 및 리뷰 삭제
-        reviewDetailsRepository.deleteByReviewId(review.getId());
+		// 리뷰 데이터 삭제
+		if (detail.getImages() != null) {
+			detail.getImages().forEach(s3Service::deleteFile);
+		}
+
+		// e)연관 데이터 삭제
+		reviewDetailsRepository.delete(detail);
         reviewsRepository.delete(review);
     }
 
-	// 건물과 관련된 리뷰들의 건물 유형 집합 조회하는 메서드
-	private Set<BuildingType> getBuildingTypesFromBuilding(Buildings building) {
-		return reviewsRepository.findDistinctBuildingTypesByBuilding(building);
-	}
-
 	// 건물의 평균 금액(월세/전세/관리비)을 재계산하여 적용
 	private void recalculateAndApplyBuildingAverages(Buildings building) {
-		List<GeneralReviews> list = reviewsRepository.findAllByBuilding(building)
-			.stream()
+		List<GeneralReviews> list = reviewsRepository.findAllByBuilding(building).stream()
+			.filter(r -> r instanceof GeneralReviews)
 			.map(r -> (GeneralReviews)r)
 			.toList();
 
@@ -777,5 +782,15 @@ public class ReviewServiceImpl implements ReviewService {
 		Long avgRentDeposit = (cntJeonse > 0) ? Math.round((double)sumJeonse / cntJeonse) : null;
 
 		building.applyAverages(avgDeposit, avgMaintenance, avgMonthlyRent, avgRentDeposit);
+	}
+
+	// null-safe로 상세 이미지 삭제 (old - new 차집합)
+	private void deleteRemovedImages(List<String> oldImages, List<String> newImages) {
+		List<String> safeOld = (oldImages == null) ? Collections.emptyList() : oldImages;
+		List<String> safeNew = (newImages == null) ? Collections.emptyList() : newImages;
+
+		List<String> imagesToDelete = new ArrayList<>(safeOld);
+		imagesToDelete.removeAll(safeNew);
+		imagesToDelete.forEach(s3Service::deleteFile);
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/common/config/S3Config.java
+++ b/src/main/java/JJinBBang/app/domain/common/config/S3Config.java
@@ -1,0 +1,56 @@
+package JJinBBang.app.domain.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Value("${cloud.aws.credentials.access-key:}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key:}")
+	private String secretKey;
+
+	@Bean
+	public S3Presigner s3Presigner() {
+		S3Presigner.Builder builder = S3Presigner.builder()
+			.region(Region.of(region));
+
+		if (!accessKey.isBlank() && !secretKey.isBlank()) {
+			builder.credentialsProvider(StaticCredentialsProvider.create(
+				AwsBasicCredentials.create(accessKey, secretKey)));
+		} else {
+			builder.credentialsProvider(DefaultCredentialsProvider.builder().build());
+		}
+
+		return builder.build();
+	}
+
+	@Bean
+	public S3Client s3() {
+		S3ClientBuilder builder = S3Client.builder()
+			.region(Region.of(region));
+
+		if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
+			builder.credentialsProvider(StaticCredentialsProvider.create(
+				AwsBasicCredentials.create(accessKey, secretKey)));
+		} else {
+			builder.credentialsProvider(DefaultCredentialsProvider.builder().build());
+		}
+
+		return builder.build();
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/common/controller/S3Controller.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/S3Controller.java
@@ -1,0 +1,34 @@
+package JJinBBang.app.domain.common.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import JJinBBang.app.domain.common.dto.PresignedUrlResponse;
+import JJinBBang.app.domain.common.service.S3Service;
+import JJinBBang.app.global.template.ResTemplate;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/s3")
+public class S3Controller {
+
+	private final S3Service s3Service;
+
+	/**
+	 *  업로드용 Presigned URL 발급
+	 * 프론트에서 파일 업로드 전에 요청
+	 */
+	@GetMapping("/presigned-upload")
+	public ResTemplate<PresignedUrlResponse> getPresignedUploadUrl(
+		@RequestParam String folder,
+		@RequestParam String fileName
+	) {
+		return new ResTemplate<>(
+			HttpStatus.OK, "처리 완료", s3Service.generateUploadPresignedUrl(folder, fileName)
+		);
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/common/dto/PresignedUrlResponse.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/PresignedUrlResponse.java
@@ -1,0 +1,12 @@
+package JJinBBang.app.domain.common.dto;
+
+public record PresignedUrlResponse(
+	String presignedUrl,
+	String expiresAt,
+	String cdnUrl
+) {
+
+	public static PresignedUrlResponse of (String presignedUrl, String expiresAt, String cdnUrl) {
+		return new PresignedUrlResponse(presignedUrl, expiresAt, cdnUrl);
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/common/service/S3Service.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/S3Service.java
@@ -1,0 +1,134 @@
+package JJinBBang.app.domain.common.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import JJinBBang.app.domain.common.dto.PresignedUrlResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+	private final S3Presigner s3Presigner;
+
+	@Value("${cloud.aws.cdn.domain}")
+	private String cdnDomain;
+
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	@Value("${cloud.aws.s3.presign.ttl-minutes:5}")
+	private long presignTtlMinutes;
+
+	private static final Set<String> ALLOWED_FOLDERS = Set.of(
+		"review", "profile"
+	);
+
+	private static final Map<String, String> EXT_TO_MIME = Map.ofEntries(
+		Map.entry("jpg", "image/jpeg"),
+		Map.entry("jpeg", "image/jpeg"),
+		Map.entry("png", "image/png"),
+		Map.entry("webp", "image/webp"),
+		Map.entry("gif", "image/gif"),
+		Map.entry("avif", "image/avif"),
+		Map.entry("heic", "image/heic"),
+		Map.entry("heif", "image/heif")
+	);
+
+	private static String extOf(String name) {
+		if (name == null)
+			return null;
+		int dot = name.lastIndexOf('.');
+		if (dot < 0 || dot == name.length() - 1)
+			return null;
+		return name.substring(dot + 1).toLowerCase();
+	}
+
+	//  S3에 이미지 업로드용 Presigned URL 발급 (PUT 방식)
+	public PresignedUrlResponse generateUploadPresignedUrl(String folder, String originalFileName) {
+		// 폴더명 체크
+		String safeFolder = validateFolder(folder);     // 화이트리스트 체크
+		// 파일명 정제: 특수문자를 언더스코어(_)로 변경, 긴 이름 자르기
+		String safeName = sanitizeFileName(originalFileName); // 파일명 정리
+		// 고유 키 생성: {폴더명}/{UUID}-{파일명}
+		String key = joinKey(safeFolder, UUID.randomUUID() + "-" + safeName);
+		// 파일 확장자 → MIME 타입
+		String mime = fileNameToMime(safeName);
+
+		// S3에 업로드할 파일 요청 정보
+		PutObjectRequest objectRequest = PutObjectRequest.builder()
+			.bucket(bucket)
+			.key(key)
+			.contentType(mime)
+			.build();
+
+		Duration ttl = Duration.ofMinutes(presignTtlMinutes);
+		PresignedPutObjectRequest presigned = s3Presigner.presignPutObject(b -> b
+			.signatureDuration(ttl)
+			.putObjectRequest(objectRequest));
+
+		Instant expiresAt = Instant.now().plus(ttl);
+		String cdnUrl = buildCdnUrl(key);
+
+		return PresignedUrlResponse.of(
+			presigned.url().toString(),
+			expiresAt.toString(),
+			cdnUrl);
+	}
+
+	private static String sanitizeFileName(String original) {
+		if (original == null || original.isBlank())
+			throw new IllegalArgumentException("파일명이 비었습니다.");
+		// 경로 분리자/제어문자 제거
+		String cleaned = original.replaceAll("[\\\\/\\p{Cntrl}]", "_");
+		// 허용 문자만
+		cleaned = cleaned.replaceAll("[^A-Za-z0-9._-]", "_");
+		// 너무 긴 이름 컷 (S3 키 전체 1024byte 제한 고려)
+		return cleaned.length() > 200 ? cleaned.substring(0, 200) : cleaned;
+	}
+
+	private String fileNameToMime(String safeName) {
+		String ext = extOf(safeName);
+		String mime = ext != null ? EXT_TO_MIME.get(ext) : null;
+		if (mime == null) {
+			throw new IllegalArgumentException("허용되지 않은 파일 형식: " + safeName);
+		}
+		return mime;
+	}
+
+	private String validateFolder(String folder) {
+		if (!ALLOWED_FOLDERS.contains(folder)) {
+			throw new IllegalArgumentException("허용되지 않은 업로드 경로: " + folder);
+		}
+		return folder;
+	}
+
+	// 키 조합
+	private String joinKey(String... parts) {
+		return String.join("/", Arrays.stream(parts)
+			.filter(Objects::nonNull)
+			.map(p -> p.replaceAll("^/+", "").replaceAll("/+$", ""))
+			.toList());
+	}
+
+	// CdnUrl에서 "폴더명/파일명" 추출
+	private String buildCdnUrl(String key) {
+		String host = cdnDomain.replaceAll("^https?://", "").replaceAll("/+$", "");
+		String path = key.startsWith("/") ? key : "/" + key;
+		return "https://" + host + path;
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/common/service/S3Service.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/S3Service.java
@@ -1,5 +1,7 @@
 package JJinBBang.app.domain.common.service;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
@@ -14,7 +16,11 @@ import org.springframework.stereotype.Service;
 import JJinBBang.app.domain.common.dto.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 
@@ -24,6 +30,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequ
 public class S3Service {
 
 	private final S3Presigner s3Presigner;
+	private final S3Client s3;
 
 	@Value("${cloud.aws.cdn.domain}")
 	private String cdnDomain;
@@ -130,5 +137,38 @@ public class S3Service {
 		String host = cdnDomain.replaceAll("^https?://", "").replaceAll("/+$", "");
 		String path = key.startsWith("/") ? key : "/" + key;
 		return "https://" + host + path;
+	}
+
+	// S3에서 이미지 삭제
+	public void deleteFile(String imageUrl) {
+		String key = toKey(imageUrl);
+		if (key == null || key.isBlank()) return;
+
+		try {
+			s3.deleteObject(DeleteObjectRequest.builder()
+				.bucket(bucket)
+				.key(key)
+				.build());
+		} catch (NoSuchKeyException e) {
+			// 이미 없는 키면 무시
+		} catch (S3Exception e) {
+			log.warn("S3 delete failed. key={}, code={}", key, e.awsErrorDetails().errorCode(), e);
+		}
+
+	}
+
+	// S3 URL에서 Key 추출
+	private String toKey(String url) {
+		if (url == null || url.isBlank()) {
+			throw new IllegalArgumentException("빈 URL입니다.");
+		}
+		int schemeEnd = url.indexOf("://");
+		int pathStart = url.indexOf('/', (schemeEnd >= 0 ? schemeEnd + 3 : 0));
+		if (pathStart < 0 || pathStart == url.length() - 1) {
+			throw new IllegalArgumentException("경로가 없는 URL입니다: " + url);
+		}
+		int q = url.indexOf('?', pathStart);
+		String path = (q >= 0) ? url.substring(pathStart + 1, q) : url.substring(pathStart + 1);
+		return URLDecoder.decode(path, StandardCharsets.UTF_8);
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,15 @@ spring:
     encoding: UTF-8
     basename: ValidationMessages
 
+cloud:
+  aws:
+    region:
+      static: ${cloud.aws.region.static}
+    s3:
+      bucket: ${cloud.aws.s3.bucket}
+    cdn:
+      domain: ${cloud.aws.cdn.domain}
+
 jwt:
   secret: ${jwt.secret}
   expiration-time:
@@ -143,6 +152,7 @@ security:
       - "/api/v1/building/**"
       - "/api/v1/review/**"
 #      - "/api/v1/notification/**"
+      - "/api/v1/s3/**"
     anonymous:
       - "/api/v1/auth"
     verification-status-based:


### PR DESCRIPTION
## 📌 이슈 번호

* #207

## 💬 리뷰 포인트

* **Presigned 업로드 API**: 클라이언트가 S3에 직접 PUT 업로드할 수 있도록 **단기 유효 Presigned URL** 발급 (`presignedUrl / expiresAt / cdnUrl`)
* **이미지 실삭제 연동**: 리뷰 **수정/삭제 시** 제거된 이미지들을 **S3에서 원본 삭제**

## 🚀 상세 설명

### 1) Presigned 업로드 API

1. **요청 수신**: `GET /api/v1/s3/presigned-upload?folder={review|profile}&fileName={원본명}`
2. **입력 검증**
   * `folder`는 `review`, `profile`만 허용
   * `fileName`은 경로/제어문자 제거, 허용문자만 유지, 길이 제한(최대 200)
   * 확장자 기반 **MIME 매핑**(jpg/jpeg/png/webp/gif/avif/heic/heif), 미지원시 예외
3. **URL 서명**
   * `UUID-정제파일명`으로 S3 Object Key 생성
   * `Content-Type`을 고정하여 **PUT Presigned URL** 발급(기본 TTL 5분)
4. **응답 반환**
   * `presignedUrl`(PUT용), `expiresAt`(만료 시각), `cdnUrl`(CloudFront 경유 접근 URL) 제공
   * 클라이언트는 **presignedUrl**로 S3에 이미지 직접 업로드
   * **주의**: 클라이언트 **PUT 요청의 `Content-Type`**은 발급 시 서명에 사용된 값과 **동일**해야 함

### 2) 리뷰 수정/삭제 시 이미지 원본 삭제

* **수정(Update)**
  1. 기존 이미지 목록(저장된 URL)과 신규 목록을 비교
  2. **(기존 − 신규)** 차집합만 추출하여 해당 이미지를 S3에서 **삭제**
* **삭제(Delete)**
  1. 리뷰에 연결된 **모든 이미지 URL**을 순회
  2. 각각 S3에서 **삭제** 처리
* **삭제 구현 공통**
  * CDN/S3 URL에서 **S3 Object Key**(`{folderName}/{fileName}`)를 안전하게 추출(쿼리스트링 제거 및 URL decode) 후 `DeleteObject` 호출

## 📸 스크린샷
![Presigned URL 요청](https://github.com/user-attachments/assets/5e25b399-a47f-4798-9a78-73a1a92fed00)
> **Presigned URL 발급** — 업로드 키 생성 후 5분 유효한 PUT URL과 CDN 경로 반환

![이미지 업로드](https://github.com/user-attachments/assets/2856cd0a-1de6-48ca-bfe9-d6141976b60d)
> **이미지 업로드** — 발급된 Presigned URL로 파일 PUT(200 OK / ETag 확인)

![이미지 조회](https://github.com/user-attachments/assets/cfb0d8c3-b231-4dd6-861d-6fc74906500f)
> **이미지 조회** — CloudFront URL로 업로드 이미지 표시

## 📢 노트

### 이미지 업로드 흐름

1. 클라이언트 → 백엔드 : `folder`, `fileName`으로 **Presigned 업로드 API** 요청
2. 백엔드 → 클라이언트: `presignedUrl / expiresAt / cdnUrl` 응답
3. 클라이언트 → AWS S3: **S3로 직접 PUT 업로드**
4. AWS S3 → 클라이언트: 200 ok 응답
5. 업로드 완료 후  `cdnUrl`을 이미지 url로 사용

### B. 로컬/배포 환경 설정

* **로컬 테스트(실 S3 연동 필요 시)**
  * `application-prod.yml`에 **`cloud.aws.credentials.access-key` / `secret-key`** 설정
* **배포(EC2 기준)**
  * EC2 인스턴스에 **IAM Role** 부여(필요 S3 권한 포함) → 애플리케이션은 **DefaultCredentialsProvider**를 통해 자동 사용
  * 애플리케이션 설정에 **액세스 키를 두지 않음**
