### PR TITLE
♻️ Refactor[#212]: 건물 보기일때 hasReview 추가 - 지도 마커 불러오기

### DIFF
--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -102,7 +102,7 @@ public class MapServiceImpl implements MapService{
 			// 건물에 딸린 리뷰 ID별로 마커 생성
 			buildings.forEach(b ->
 				b.getReviews().forEach(r ->
-					markers.add(new MarkerInfo(
+					markers.add(MarkerInfo.fromReview(
 						r.getId(),
 						b.getBuildingType().get(0),
 						b.getBuildingLat(),
@@ -110,25 +110,28 @@ public class MapServiceImpl implements MapService{
 
 			agencies.forEach(a ->
 				a.getReviews().forEach(r ->
-					markers.add(new MarkerInfo(
+					markers.add(MarkerInfo.fromReview(
 						r.getId(),
 						BuildingType.AGENCY,
 						a.getAgencyLat(),
 						a.getAgencyLot()))));
 		} else {
 			buildings.forEach(b ->
-				markers.add(new MarkerInfo(
-					b.getId(),
-					b.getBuildingType().get(0),
-					b.getBuildingLat(),
-					b.getBuildingLot())));
+				markers.add(MarkerInfo.fromBuidling(
+                        b.getId(),
+                        b.getBuildingType().get(0),
+                        b.getBuildingLat(),
+                        b.getBuildingLot(),
+                        b.getReviewCount() > 0
+                )));
 
 			agencies.forEach(a ->
-				markers.add(new MarkerInfo(
+				markers.add(MarkerInfo.fromBuidling(
 					a.getAgencyId(),
 					BuildingType.AGENCY,
 					a.getAgencyLat(),
-					a.getAgencyLot())));
+					a.getAgencyLot(),
+           a.getReviewCount() > 0)));
 		}
 
 		return markers;

--- a/src/main/java/JJinBBang/app/global/common/dto/MarkerInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/MarkerInfo.java
@@ -1,6 +1,7 @@
 package JJinBBang.app.global.common.dto;
 
 import JJinBBang.app.domain.building.enums.BuildingType;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 @Builder
@@ -8,9 +9,11 @@ public record MarkerInfo (
 	Long id,
 	BuildingType type,
 	Double latitude,
-	Double longitude
+	Double longitude,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Boolean hasReview
 ){
-	public static MarkerInfo from(Long id, BuildingType type, Double latitude, Double longitude) {
+	public static MarkerInfo fromReview(Long id, BuildingType type, Double latitude, Double longitude) {
 		return MarkerInfo.builder()
 			.id(id)
 			.type(type)
@@ -18,4 +21,14 @@ public record MarkerInfo (
 			.longitude(longitude)
 			.build();
 	}
+
+    public static MarkerInfo fromBuidling(Long id, BuildingType type, Double latitude, Double longitude, Boolean hasReview) {
+        return MarkerInfo.builder()
+            .id(id)
+            .type(type)
+            .latitude(latitude)
+            .longitude(longitude)
+            .hasReview(hasReview)
+            .build();
+    }
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #212 

## 💬 리뷰 포인트
> `hasReview`를 통해 리뷰 작성 여부 파악가능 (프론트 요청)

## 🚀 상세 설명
지도에서 찐빵(리뷰)이 있을 경우 색깔있는 마커로, 없는 경우 회색 마커로 표시하길 원함. (프론트)
그래서 마커 조회 API에서 보기 유형이 건물일 때 Dto에 `hasReview`를 추가해줌으로써 리뷰 존재 여부를 표시 (해당 존재 여부는 `reviewCount`를 확인)

## 📸 스크린샷
> 보기 타입이 REVIEW일때
<img width="617" height="388" alt="image" src="https://github.com/user-attachments/assets/687fd01f-e938-4a40-b877-497db97cbb81" />

> 보기 타입이 BUILDING일때
<img width="556" height="399" alt="image" src="https://github.com/user-attachments/assets/6e0a5220-78c5-46c6-b31c-c9c19d37360a" />


## 📢 노트