### PR TITLE
Fix[#214]: 스케쥴러 미실행 문제, 인메모리 인증코드 저장로직(덮어쓰기로 변경) 수정

### DIFF
--- a/src/main/java/JJinBBang/app/AppApplication.java
+++ b/src/main/java/JJinBBang/app/AppApplication.java
@@ -3,9 +3,11 @@ package JJinBBang.app;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing // 엔티티 객체가 생성이 되거나 변경이 되었을 때 자동으로 날짜를 매핑
+@EnableScheduling
 public class AppApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AuthController.java
@@ -102,6 +102,7 @@ public class AuthController {
         boolean verifyResult = mailAuthService.verifyAuthCode(user.getUserId(), email, code);
         if(verifyResult) {
             usersService.verifyUniversityEmail(user, email);
+            mailAuthService.deleteAuthCode(user.getUserId());
             return new ResTemplate<>(HttpStatus.OK, "인증이 완료되었습니다.", null);
         } else {
             return new ResTemplate<>(HttpStatus.I_AM_A_TEAPOT, "인증코드 검증에 실패하였습니다.", null);

--- a/src/main/java/JJinBBang/app/global/mail/repository/InMemoryEmailAuthCodeRepository.java
+++ b/src/main/java/JJinBBang/app/global/mail/repository/InMemoryEmailAuthCodeRepository.java
@@ -30,11 +30,11 @@ public class InMemoryEmailAuthCodeRepository implements EmailAuthCodeRepository 
 
     @Override
     public void save(Long userId, String email, String authCode) {
-        EmailAuthInfo info = new EmailAuthInfo(email, authCode, System.currentTimeMillis());
-        EmailAuthInfo prev = emailAuthCodeMap.putIfAbsent(userId, info);
-        if (prev != null) {
-            throw new DuplicateKeyException("Duplicate key: " + userId);
-        }
+        long now = System.currentTimeMillis();
+        emailAuthCodeMap.compute(userId, (k, prev) -> {
+            // prev가 없거나, 만료됐거나, 혹은 정책상 재발급은 항상 갱신
+            return new EmailAuthInfo(email, authCode, now);
+        });
     }
 
     @Override

--- a/src/main/java/JJinBBang/app/global/mail/service/MailAuthService.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/MailAuthService.java
@@ -30,4 +30,10 @@ public interface MailAuthService {
      * @throws MailInvalidException  코드 미발급·만료
      */
     boolean verifyAuthCode(Long userId, String email, String authCode);
+
+    /**
+     * 주어진 userId에 대한 인증코드를 삭제합니다.
+     * @param userId 인증코드를 발급받은 유저의 아이디
+     */
+    void deleteAuthCode(Long userId);
 }

--- a/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
@@ -41,6 +41,10 @@ public class MailAuthServiceImpl implements MailAuthService {
         return savedAuthCode.email().equals(email) && savedAuthCode.code().equals(authCode);
     }
 
+    @Override
+    public void deleteAuthCode(Long userId) {
+        emailAuthCodeRepository.deleteByUserId(userId);
+    }
 
     // utility --------------------------------------------------------------------------------------------------------
     private String generateAuthCode() {
@@ -54,11 +58,6 @@ public class MailAuthServiceImpl implements MailAuthService {
     }
 
     private void saveAuthCode(Long userId, String email, String authCode) {
-        if(emailAuthCodeRepository.isExistByUserId(userId)) {
-            // 이미 인증 코드가 발급된 이메일인 경우
-            log.info("이미 인증 코드가 발급된 이메일입니다. [userId: {}]. 기존 인증 코드를 삭제합니다.", userId);
-            emailAuthCodeRepository.deleteByUserId(userId);
-        }
         emailAuthCodeRepository.save(userId, email, authCode);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -126,8 +126,8 @@ logging:
 app:
   repository:
     mode:
-      inmemory
-#      redis
+#      inmemory
+      redis
 
 user:
   deletion:


### PR DESCRIPTION
# Fix\[#214]: 인증 코드 저장 로직 및 스케줄러 활성화

## 📌 이슈 번호

* \#214

## 💬 리뷰 포인트

* `InMemoryEmailAuthCodeRepository`에서 `putIfAbsent` → `compute`로 변경하여 만료 코드 중복 예외 방지
* 인증 완료 시 사용된 코드 즉시 삭제 로직 추가
* `@EnableScheduling` 활성화 여부 확인 및 적용

## 🚀 상세 설명

* 기존 로직에서는 만료된 코드가 청소되기 전 재발급하면 `DuplicateKeyException`이 발생하는 문제가 있었음
* 저장 시 항상 갱신(`compute`)하도록 수정해 중복 예외를 제거
* 인증 성공 시 `deleteAuthCode`를 호출해 불필요한 엔트리 남지 않도록 처리
* 스케줄러 실행을 위해 `@EnableScheduling` 어노테이션 추가

## 📸 스크린샷


## 📢 노트

* Redis 저장소(`RedisEmailAuthCodeRepository`)는 TTL 기반이라 동일 문제 없음
* 인메모리 저장소만 영향