### PR TITLE
[Fix #224] reviews.content TEXT 변경, 길이(1-1000) 검증 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/GeneralReviewDto.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/GeneralReviewDto.java
@@ -2,6 +2,8 @@ package JJinBBang.app.domain.building.dto;
 
 import java.math.BigDecimal;
 
+import org.hibernate.validator.constraints.Length;
+
 import JJinBBang.app.domain.building.enums.ContractType;
 import JJinBBang.app.domain.building.enums.Floor;
 import jakarta.validation.constraints.*;
@@ -24,7 +26,7 @@ public class GeneralReviewDto {
 	private Double space;
 	@NotNull @Min(1) @Max(5)
 	private BigDecimal rating;
-	@NotBlank
+	@NotBlank @Length(min = 1, max = 1000)
 	private String content;
 
 	@AssertTrue(message = "계약 타입에 따라 deposit, monthlyRent, maintenanceCost 필드를 올바르게 설정해주세요.")

--- a/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/Reviews.java
@@ -37,8 +37,8 @@ public class Reviews extends BaseEntity {
     @Column(name = "thumbnail_image", nullable = true, length = 2083)
     private String thumbnailImage; // 썸네일 이미지
 
-    @Column(nullable = false)
-    private String content; // 후기 내용
+    @Column(nullable = false, columnDefinition = "TEXT")
+	private String content; // 후기 내용
 
     @Column(length = 70)
     private String tags; // 태그


### PR DESCRIPTION
## 📌 이슈 번호
- #224 

## 💬 리뷰 포인트
- `reviews.content` 타입 변경(VARCHAR→TEXT)
- GeneralReviewDto.content 길이 검증 추가

## 🚀 상세 설명
- `reviews.content`를 **TEXT**로 변경
- GeneralReviewDto의 `content` 필드에 길이(1~1000자) 검증 추가

## 📸 스크린샷
<img width="1141" height="646" alt="image" src="https://github.com/user-attachments/assets/51dca80a-9b28-4555-afd8-cc762fc4e992" />

## 📢 노트
로컬에서 테스트할 때 데이터타입을 수정해도 DB에 반영되지 않더라고요.
그래서 직접 데이터 타입을 수정해야 할것 같습니다.
release에 머지하실 때 알려주시면 수정하겠습니다.