### PR TITLE
[Feat #229] 탈퇴 사유, 문의 내용 시트 저장 API

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
@@ -4,7 +4,7 @@ import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.domain.user.service.CertificateService;
 import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.common.enums.VerificationStatus;
-import JJinBBang.app.global.config.GoogleProperties;
+import JJinBBang.app.global.sheets.properties.GoogleProperties;
 import JJinBBang.app.global.template.ResTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
@@ -93,11 +93,12 @@ public class UsersController {
 
 		UserOpinionDto data = new UserOpinionDto(
 				userId,
+				userOpinionRequest.targetId(),
 				userOpinionRequest.opinion(),
 				LocalDateTime.now()
 		);
 
-		googleSheetsService.appendUserOpinion(data);
+		googleSheetsService.appendUserOpinion(data, userOpinionRequest.opinionType());
 
 		return new ResTemplate<>(HttpStatus.OK, "문의 성공", null);
 	}

--- a/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
@@ -2,8 +2,14 @@ package JJinBBang.app.domain.user.controller;
 
 import JJinBBang.app.domain.building.dto.UserReviewListResponse;
 import JJinBBang.app.domain.user.dto.UserInfoResponseDto;
+import JJinBBang.app.domain.user.dto.request.UnregisterReasonRequest;
+import JJinBBang.app.domain.user.dto.request.UserOpinionRequest;
 import JJinBBang.app.domain.user.exception.InvalidTokenException;
+import JJinBBang.app.global.sheets.dto.UnregisterReasonDto;
+import JJinBBang.app.global.sheets.dto.UserOpinionDto;
+import JJinBBang.app.global.sheets.service.GoogleSheetsService;
 import JJinBBang.app.global.template.ResTemplate;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +19,9 @@ import JJinBBang.app.domain.user.service.UsersService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.IOException;
+import java.time.LocalDateTime;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/user")
@@ -20,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UsersController {
 
 	private final UsersService usersService;
+	private final GoogleSheetsService googleSheetsService;
 
 	@GetMapping
 	public ResTemplate<UserInfoResponseDto> getUserInfo(@AuthenticationPrincipal Users user) {
@@ -45,5 +55,50 @@ public class UsersController {
 		}
 		var reviews = usersService.getUserReviews(user, offset, limit, orderby);
 		return new ResTemplate<>(HttpStatus.OK, "리뷰 조회 성공", reviews);
+	}
+
+	@PostMapping("/unregisterReason")
+	public ResTemplate<?> addUnregisterReason(
+			@AuthenticationPrincipal Users user,
+			@Valid @RequestBody UnregisterReasonRequest unregisterReasonRequest
+	) throws IOException {
+
+		if (user == null) throw InvalidTokenException.unauthorized();
+
+		Long userId = user.getUserId();
+		String unregisterReason = usersService.optionToText(unregisterReasonRequest.option());
+
+		UnregisterReasonDto data = new UnregisterReasonDto(
+				userId,
+				unregisterReasonRequest.option(),
+				unregisterReason,
+				user.getCreatedAt(),
+				LocalDateTime.now()
+		);
+
+		googleSheetsService.appendUnregisterReason(data);
+
+		return new ResTemplate<>(HttpStatus.OK, "탈퇴사유 추가 성공", null);
+	}
+
+	@PostMapping("/getOpinion")
+	public ResTemplate<?> addUserOpinion(
+			@AuthenticationPrincipal Users user,
+			@Valid @RequestBody UserOpinionRequest userOpinionRequest
+	) throws IOException {
+
+		if (user == null) throw InvalidTokenException.unauthorized();
+
+		Long userId = user.getUserId();
+
+		UserOpinionDto data = new UserOpinionDto(
+				userId,
+				userOpinionRequest.opinion(),
+				LocalDateTime.now()
+		);
+
+		googleSheetsService.appendUserOpinion(data);
+
+		return new ResTemplate<>(HttpStatus.OK, "문의 성공", null);
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/user/dto/request/UnregisterReasonRequest.java
+++ b/src/main/java/JJinBBang/app/domain/user/dto/request/UnregisterReasonRequest.java
@@ -1,0 +1,11 @@
+package JJinBBang.app.domain.user.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+// 탈퇴 사유 옵션
+public record UnregisterReasonRequest(
+        @NotNull @Min(1) @Max(6) Integer option
+) {
+}

--- a/src/main/java/JJinBBang/app/domain/user/dto/request/UserOpinionRequest.java
+++ b/src/main/java/JJinBBang/app/domain/user/dto/request/UserOpinionRequest.java
@@ -1,7 +1,11 @@
 package JJinBBang.app.domain.user.dto.request;
 
+import JJinBBang.app.global.sheets.enums.OpinionType;
+
 // 문의하기(신고하기) - 신고내용
 public record UserOpinionRequest(
-        String opinion
+        String opinion,
+        OpinionType opinionType, // 문의 타입
+        Long targetId // 신고 대상 (리뷰, 빌딩)
 ) {
 }

--- a/src/main/java/JJinBBang/app/domain/user/dto/request/UserOpinionRequest.java
+++ b/src/main/java/JJinBBang/app/domain/user/dto/request/UserOpinionRequest.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.domain.user.dto.request;
+
+// 문의하기(신고하기) - 신고내용
+public record UserOpinionRequest(
+        String opinion
+) {
+}

--- a/src/main/java/JJinBBang/app/domain/user/exception/OpinionException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/OpinionException.java
@@ -1,0 +1,18 @@
+package JJinBBang.app.domain.user.exception;
+
+
+import JJinBBang.app.global.error.exception.InvalidGroupException;
+
+public class OpinionException extends InvalidGroupException {
+    public OpinionException(String message) {
+        super(message);
+    }
+
+    public static OpinionException NoOptionException() {
+        return new OpinionException("선택된 옵션이 없습니다.");
+    }
+
+    public static OpinionException OptionMappingException() {
+        return new OpinionException("해당하는 옵션의 문항이 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/JJinBBang/app/domain/user/service/CertificateServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/CertificateServiceImpl.java
@@ -4,7 +4,7 @@ import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.domain.user.exception.*;
 import JJinBBang.app.domain.user.repository.UsersRepository;
 import JJinBBang.app.global.common.enums.VerificationStatus;
-import JJinBBang.app.global.config.GoogleProperties;
+import JJinBBang.app.global.sheets.properties.GoogleProperties;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.InputStreamContent;
 import com.google.api.services.drive.Drive;
@@ -182,9 +182,9 @@ public class CertificateServiceImpl implements CertificateService {
             String fileName,
             String fileLink
     ) {
-        String spreadsheetId = googleProps.getSpreadsheet().getId(); // 스프레드시트
-        String sheetName = googleProps.getSpreadsheet().getSheets().get(type); // 스프레드시트의 탭
-        String range = String.format(googleProps.getSpreadsheet().getRangeTemplate(), sheetName); // 시트 범위 포맷팅
+        String spreadsheetId = googleProps.getSpreadsheetCertificate().getId(); // 스프레드시트
+        String sheetName = googleProps.getSpreadsheetCertificate().getSheets().get(type); // 스프레드시트의 탭
+        String range = String.format(googleProps.getSpreadsheetCertificate().getRangeTemplate(), sheetName); // 시트 범위 포맷팅
         String hyperlinkFormula = String.format("=HYPERLINK(\"%s\",\"%s\")", fileLink, fileName); // url 포뮬러
 
         List<Object> row = List.of(

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersService.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersService.java
@@ -33,4 +33,7 @@ public interface UsersService {
 	void deleteUser(Users user);
 
 	void forceDeleteExecute();
+
+	// 탈퇴 사유 문항 조회
+	String optionToText(Integer option);
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -12,6 +12,7 @@ import JJinBBang.app.domain.user.dto.UserInfoResponseDto;
 import JJinBBang.app.domain.user.exception.OpinionException;
 import JJinBBang.app.domain.user.exception.UniversityNotFoundException;
 import JJinBBang.app.domain.user.repository.UniversityRepository;
+import JJinBBang.app.global.common.enums.UnregisterReason;
 import org.springframework.data.domain.Pageable;
 import JJinBBang.app.global.common.enums.VerificationStatus;
 import org.springframework.stereotype.Service;
@@ -44,15 +45,6 @@ public class UsersServiceImpl implements UsersService {
 	private final UniversityRepository universityRepository;
 	private final BuildingLikesRepository buildingLikesRepository;
 	private final AgencyLikesRepository agencyLikesRepository;
-
-	private static final Map<Integer, String> UnregisterReasonMap = Map.of(
-			1, "대체 서비스로 이동",
-			2, "개인정보/보안 우려",
-			3, "알림/마케팅 메시지가 많음",
-			4, "일시 사용 중단을 위해",
-			5, "사용 빈도가 낮음",
-			6, "이용이 불편하고 장애가 많음"
-	);
 
 
 	@Override
@@ -245,11 +237,6 @@ public class UsersServiceImpl implements UsersService {
 	// 탈퇴 사유 문항 조회
 	@Override
 	public String optionToText(Integer option) {
-		if (option == null) throw OpinionException.NoOptionException();
-
-		String text = UnregisterReasonMap.get(option);
-		if (text == null) throw OpinionException.OptionMappingException();
-
-		return text;
+		return UnregisterReason.fromNumber(option).getDescription();
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -9,6 +9,7 @@ import JJinBBang.app.domain.building.entity.ReviewLikes;
 import JJinBBang.app.domain.building.repository.*;
 import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.domain.user.dto.UserInfoResponseDto;
+import JJinBBang.app.domain.user.exception.OpinionException;
 import JJinBBang.app.domain.user.exception.UniversityNotFoundException;
 import JJinBBang.app.domain.user.repository.UniversityRepository;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -42,6 +44,15 @@ public class UsersServiceImpl implements UsersService {
 	private final UniversityRepository universityRepository;
 	private final BuildingLikesRepository buildingLikesRepository;
 	private final AgencyLikesRepository agencyLikesRepository;
+
+	private static final Map<Integer, String> UnregisterReasonMap = Map.of(
+			1, "대체 서비스로 이동",
+			2, "개인정보/보안 우려",
+			3, "알림/마케팅 메시지가 많음",
+			4, "일시 사용 중단을 위해",
+			5, "사용 빈도가 낮음",
+			6, "이용이 불편하고 장애가 많음"
+	);
 
 
 	@Override
@@ -228,5 +239,17 @@ public class UsersServiceImpl implements UsersService {
 			Users sys = anyUserForFactory.createDeletedSystemUser();
 			usersRepository.saveAndFlush(sys); // 즉시 반영
 		}
+	}
+
+
+	// 탈퇴 사유 문항 조회
+	@Override
+	public String optionToText(Integer option) {
+		if (option == null) throw OpinionException.NoOptionException();
+
+		String text = UnregisterReasonMap.get(option);
+		if (text == null) throw OpinionException.OptionMappingException();
+
+		return text;
 	}
 }

--- a/src/main/java/JJinBBang/app/global/common/enums/UnregisterReason.java
+++ b/src/main/java/JJinBBang/app/global/common/enums/UnregisterReason.java
@@ -1,0 +1,31 @@
+package JJinBBang.app.global.common.enums;
+
+import JJinBBang.app.domain.user.exception.OpinionException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+@Getter
+@RequiredArgsConstructor
+public enum UnregisterReason {
+    REASON_1(1, "대체 서비스로 이동"),
+    REASON_2(2, "개인정보/보안 우려"),
+    REASON_3(3, "알림/마케팅 메시지가 많음"),
+    REASON_4(4, "일시 사용 중단을 위해"),
+    REASON_5(5, "사용 빈도가 낮음"),
+    REASON_6(6, "이용이 불편하고 장애가 많음");
+
+
+    private final int number;
+    private final String description;
+
+    public static UnregisterReason fromNumber(Integer number) {
+        if (number == null) throw OpinionException.NoOptionException();
+
+        return Arrays.stream(values())
+                .filter(unregisterReason -> unregisterReason.number == number)
+                .findFirst()
+                .orElseThrow(OpinionException::NoOptionException);
+    }
+}

--- a/src/main/java/JJinBBang/app/global/config/GoogleApiConfig.java
+++ b/src/main/java/JJinBBang/app/global/config/GoogleApiConfig.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.global.config;
 
+import JJinBBang.app.global.sheets.properties.GoogleProperties;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.gson.GsonFactory;

--- a/src/main/java/JJinBBang/app/global/sheets/dto/UnregisterReasonDto.java
+++ b/src/main/java/JJinBBang/app/global/sheets/dto/UnregisterReasonDto.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.global.sheets.dto;
+
+import java.time.LocalDateTime;
+
+// 탈퇴 사유 조회 sheets feature
+public record UnregisterReasonDto(
+        Long userId,
+        Integer option, // 선택 번호
+        String unregisterReason, // 탈퇴 사유
+        LocalDateTime registeredAt, // 가입일
+        LocalDateTime unregisteredAt // 탈퇴일
+) {
+}

--- a/src/main/java/JJinBBang/app/global/sheets/dto/UserOpinionDto.java
+++ b/src/main/java/JJinBBang/app/global/sheets/dto/UserOpinionDto.java
@@ -1,0 +1,11 @@
+package JJinBBang.app.global.sheets.dto;
+
+import java.time.LocalDateTime;
+
+// 문의하기 sheets feature
+public record UserOpinionDto(
+        Long userId,
+        String opinion, // 문의(신고) 내용
+        LocalDateTime timestamp // 작성 일시
+) {
+}

--- a/src/main/java/JJinBBang/app/global/sheets/dto/UserOpinionDto.java
+++ b/src/main/java/JJinBBang/app/global/sheets/dto/UserOpinionDto.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 // 문의하기 sheets feature
 public record UserOpinionDto(
         Long userId,
+        Long targetId, // 문의 대상 ID (리뷰 or 건물의 ID)
         String opinion, // 문의(신고) 내용
         LocalDateTime timestamp // 작성 일시
 ) {

--- a/src/main/java/JJinBBang/app/global/sheets/enums/OpinionType.java
+++ b/src/main/java/JJinBBang/app/global/sheets/enums/OpinionType.java
@@ -1,0 +1,6 @@
+package JJinBBang.app.global.sheets.enums;
+
+public enum OpinionType {
+    REVIEW_REPORT, // 리뷰 신고
+    BUILDING_REPORT // 건물 신고
+}

--- a/src/main/java/JJinBBang/app/global/sheets/properties/GoogleProperties.java
+++ b/src/main/java/JJinBBang/app/global/sheets/properties/GoogleProperties.java
@@ -1,4 +1,4 @@
-package JJinBBang.app.global.config;
+package JJinBBang.app.global.sheets.properties;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -12,7 +12,11 @@ import java.util.Map;
 @ConfigurationProperties(prefix = "google")
 public class GoogleProperties {
     private Drive drive = new Drive();
-    private Spreadsheet spreadsheet = new Spreadsheet();
+
+    private Spreadsheet spreadsheetCertificate = new Spreadsheet(); // 중명서 시트
+
+    private Spreadsheet spreadsheetUnregister = new Spreadsheet(); // 탈퇴 사유 시트
+    private Spreadsheet spreadsheetOpinion = new Spreadsheet(); // 문의(신고) 시트
 
     @Setter
     @Getter
@@ -27,6 +31,5 @@ public class GoogleProperties {
         private String id;
         private Map<String, String> sheets;
         private String rangeTemplate;
-
     }
 }

--- a/src/main/java/JJinBBang/app/global/sheets/service/GoogleSheetsService.java
+++ b/src/main/java/JJinBBang/app/global/sheets/service/GoogleSheetsService.java
@@ -2,6 +2,7 @@ package JJinBBang.app.global.sheets.service;
 
 import JJinBBang.app.global.sheets.dto.UnregisterReasonDto;
 import JJinBBang.app.global.sheets.dto.UserOpinionDto;
+import JJinBBang.app.global.sheets.enums.OpinionType;
 
 import java.io.IOException;
 
@@ -12,8 +13,10 @@ public interface GoogleSheetsService {
             UnregisterReasonDto unregisterReasonDto
     ) throws IOException;
 
+
     // 문의 내용
     void appendUserOpinion(
-            UserOpinionDto userOpinionDto
+            UserOpinionDto userOpinionDto,
+            OpinionType opinionType
     ) throws IOException;
 }

--- a/src/main/java/JJinBBang/app/global/sheets/service/GoogleSheetsService.java
+++ b/src/main/java/JJinBBang/app/global/sheets/service/GoogleSheetsService.java
@@ -1,0 +1,19 @@
+package JJinBBang.app.global.sheets.service;
+
+import JJinBBang.app.global.sheets.dto.UnregisterReasonDto;
+import JJinBBang.app.global.sheets.dto.UserOpinionDto;
+
+import java.io.IOException;
+
+public interface GoogleSheetsService {
+
+    // 탈퇴 사유
+    void appendUnregisterReason(
+            UnregisterReasonDto unregisterReasonDto
+    ) throws IOException;
+
+    // 문의 내용
+    void appendUserOpinion(
+            UserOpinionDto userOpinionDto
+    ) throws IOException;
+}

--- a/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
@@ -1,0 +1,81 @@
+package JJinBBang.app.global.sheets.service.impl;
+
+import JJinBBang.app.global.sheets.dto.UnregisterReasonDto;
+import JJinBBang.app.global.sheets.dto.UserOpinionDto;
+import JJinBBang.app.global.sheets.properties.GoogleProperties;
+import JJinBBang.app.global.sheets.service.GoogleSheetsService;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.AppendValuesResponse;
+import com.google.api.services.sheets.v4.model.ValueRange;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleSheetsServiceImpl implements GoogleSheetsService {
+
+    private final Sheets googleSheets;
+    private final GoogleProperties googleProperties;
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    // 시트 데이터 입력
+    private AppendValuesResponse appendRowToGoogleSheets(
+            GoogleProperties.Spreadsheet sheet,
+            String sheetName,
+            List<Object> data
+    ) throws IOException {
+        String sheetsId = sheet.getId();
+        String name = sheet.getSheets().get(sheetName);
+        String range = String.format(sheet.getRangeTemplate(), name);
+
+        ValueRange row = new ValueRange().setValues(List.of(data));
+
+        return googleSheets.spreadsheets().values()
+                .append(sheetsId, range, row)
+                .setValueInputOption("USER_ENTERED")
+                .execute();
+    }
+
+
+    // 탈퇴 사유
+    @Override
+    public void appendUnregisterReason(
+            UnregisterReasonDto unregisterReasonDto
+    ) throws IOException {
+        var sheet = googleProperties.getSpreadsheetUnregister();
+
+        List<Object> row = List.of(
+                unregisterReasonDto.userId(),
+                unregisterReasonDto.option(),
+                unregisterReasonDto.unregisterReason(),
+                unregisterReasonDto.registeredAt().format(DATE_TIME_FORMATTER),
+                unregisterReasonDto.unregisteredAt().format(DATE_TIME_FORMATTER)
+        );
+
+        appendRowToGoogleSheets(sheet, "unregister-reason", row);
+    }
+
+
+    // 문의 내용
+    @Override
+    public void appendUserOpinion(
+            UserOpinionDto userOpinionDto
+    ) throws IOException {
+        var sheet = googleProperties.getSpreadsheetOpinion();
+
+        List<Object> row = List.of(
+                userOpinionDto.userId(),
+                userOpinionDto.opinion(),
+                userOpinionDto.timestamp().format(DATE_TIME_FORMATTER)
+        );
+
+        appendRowToGoogleSheets(sheet, "user-opinion", row);
+    }
+}

--- a/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
@@ -2,6 +2,7 @@ package JJinBBang.app.global.sheets.service.impl;
 
 import JJinBBang.app.global.sheets.dto.UnregisterReasonDto;
 import JJinBBang.app.global.sheets.dto.UserOpinionDto;
+import JJinBBang.app.global.sheets.enums.OpinionType;
 import JJinBBang.app.global.sheets.properties.GoogleProperties;
 import JJinBBang.app.global.sheets.service.GoogleSheetsService;
 import com.google.api.services.sheets.v4.Sheets;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -28,11 +30,11 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
     // 시트 데이터 입력
     private AppendValuesResponse appendRowToGoogleSheets(
             GoogleProperties.Spreadsheet sheet,
-            String sheetName,
+            String sheetKey,
             List<Object> data
     ) throws IOException {
         String sheetsId = sheet.getId();
-        String name = sheet.getSheets().get(sheetName);
+        String name = sheet.getSheets().get(sheetKey);
         String range = String.format(sheet.getRangeTemplate(), name);
 
         ValueRange row = new ValueRange().setValues(List.of(data));
@@ -66,16 +68,31 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
     // 문의 내용
     @Override
     public void appendUserOpinion(
-            UserOpinionDto userOpinionDto
+            UserOpinionDto userOpinionDto,
+            OpinionType opinionType
     ) throws IOException {
+        Objects.requireNonNull(userOpinionDto, "userOpinionDto is null");
+
         var sheet = googleProperties.getSpreadsheetOpinion();
+        String sheetKey = resolveOpinionSheetKey(opinionType);
 
         List<Object> row = List.of(
                 userOpinionDto.userId(),
+                userOpinionDto.targetId(),
                 userOpinionDto.opinion(),
                 userOpinionDto.timestamp().format(DATE_TIME_FORMATTER)
         );
 
-        appendRowToGoogleSheets(sheet, "user-opinion", row);
+        appendRowToGoogleSheets(sheet, sheetKey, row);
+    }
+
+    // 문의 타입에 따라 시트 선택
+    private String resolveOpinionSheetKey(OpinionType opinionType) {
+        if (opinionType == null) throw new IllegalArgumentException("opinionType is null");
+
+        return switch (opinionType) {
+            case BUILDING_REPORT -> "user-building-opinion";
+            case REVIEW_REPORT ->  "user-review-opinion";
+        };
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
> ex) #1

#229 

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요

- 회원 탈퇴 사유 Google Sheets 저장 API
- 문의(신고)하기 Google Sheets 저장 API


## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

기존 Google Sheet 로직에도 변경이 있습니다.
- application-prod.yml에서 spreadsheet로 정의해놓은 시트 속성을 spreadsheet-certificate 형식으로 분기하였습니다.
- properties도 마찬가지로 변경되었고 파일 위치를 global.sheets 내부에서 관리할 수 있도록 이동하였습니다.

sheet 관련해서 추가 로직이 발생하였을 경우를 대비하여 업로드 로직을 따로 생성하였고 기존 로직은 drive 링크를 연결해야 하는 부분이 추가되며, 한 파일에서 2시트를 관리하기 때문에 그대로 유지합니다.

💥💥추가 수정사항💥💥
문의(신고)하기 API 요청 시 <문의 타입>과 <타겟(리뷰 or 빌딩) ID> 도 요청하도록 수정
타입에 따라 각자 다른 시트에 저장하도록 하며 타겟 ID도 추가하도록 변경

문의하기 APi 테스트 - 리뷰
<img width="1266" height="914" alt="image" src="https://github.com/user-attachments/assets/3b8b8f20-9b7a-44fa-9d0d-dd4cf375a07b" />
<img width="1270" height="566" alt="image" src="https://github.com/user-attachments/assets/c976c522-2f21-4167-802c-8cf6917977e7" />

문의하기 APi 테스트 - 빌딩
<img width="1266" height="910" alt="image" src="https://github.com/user-attachments/assets/03058ee7-6547-475d-b744-0b4c3e964490" />
<img width="1236" height="574" alt="image" src="https://github.com/user-attachments/assets/2d89ed83-361a-497e-9ea7-9a6392c72dd7" />



탈퇴 사유 API 테스트
<img width="1276" height="946" alt="image" src="https://github.com/user-attachments/assets/15e8a8dd-1437-431c-bb6f-e29b29b0ea11" />
<img width="722" height="219" alt="image" src="https://github.com/user-attachments/assets/87dcabde-8106-4ece-a386-5f76259e1eb4" />


## 📢 노트