### PR TITLE
[Feat #231] VWorld API 연동 및 건물관리번호 갱신 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,10 @@ dependencies {
 
 	// AWS S3
 	implementation 'software.amazon.awssdk:s3:2.32.31'
+
+    // JTS Topology Suite
+    implementation 'org.locationtech.jts:jts-core:1.19.0'
+    implementation 'org.locationtech.jts.io:jts-io-common:1.19.0'
 }
 
 // Q 클래스 경로 지정

--- a/src/main/java/JJinBBang/app/domain/building/dto/BuildingRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/BuildingRequest.java
@@ -24,6 +24,17 @@ public record BuildingRequest (
     @NotNull
     Double longitude
 ){
+	public BuildingRequest updateBuildingCode(String buildingCode) {
+		return new BuildingRequest(
+			buildingCode,
+			this.name,
+			this.type,
+			this.address,
+			this.latitude,
+			this.longitude
+		);
+	}
+
     public Buildings toBuildingEntity(Campuses campus) {
         return Buildings.builder()
             .buildingCode(buildingCode)

--- a/src/main/java/JJinBBang/app/domain/building/dto/VWorldRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/VWorldRequest.java
@@ -1,0 +1,56 @@
+package JJinBBang.app.domain.building.dto;
+
+import java.util.Objects;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import lombok.Builder;
+
+@Builder
+public record VWorldRequest(
+	String request,     // 요청 서비스 오퍼레이션 (GetFeature, GetFeatureType)
+	String key,			// 발급받은 api key
+	Integer size,      	// 한 페이지에 출력될 응답결과 건수	(숫자, default(10), min(1), max(1000))
+	Integer page,		// 응답결과 페이지 번호 (숫자, 1(기본값))
+	String data,		// 조회할 데이터 (LT_C_SPBD)
+	String geomFilter,  // 지오메트리 필터
+	Integer buffer		// geomFilter파라미터에 입력한 feature를 buffer(거리, 단위:m)만큼 확장 (숫자, 기본값:0)
+) {
+
+	/** 기본값을 채운 빌더성 팩토리 */
+	public static VWorldRequest of(
+		String apiKey,
+		String geomFilter,
+		Integer buffer
+	) {
+		return new VWorldRequest(
+			"GetFeature",
+			Objects.requireNonNull(apiKey),
+			1000,
+			1,
+			"LT_C_SPBD",
+			Objects.requireNonNull(geomFilter),
+			buffer != null ? buffer : 0
+		);
+	}
+
+	/** 포인트 + 버퍼(m)로 조회 (경위도 순서: lon, lat) */
+	public static VWorldRequest byPoint(String apiKey, double lon, double lat, int bufferMeters) {
+		String gf = "POINT(" + lon + " " + lat + ")";
+		return of(apiKey, gf, bufferMeters);
+	}
+
+	public MultiValueMap<String, String> toQueryParams() {
+		MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+		map.add("request", request);
+		map.add("key", key);
+		map.add("size", size.toString());
+		map.add("page", page.toString());
+		map.add("format", "json");
+		map.add("data", data);
+		map.add("geomFilter", geomFilter);
+		map.add("buffer", buffer.toString());
+		return map;
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/VWorldResponse.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/VWorldResponse.java
@@ -1,0 +1,110 @@
+package JJinBBang.app.domain.building.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** vworld 2D Data API - 도로명주소 건물(spbd) 응답 DTO */
+public record VWorldResponse(
+	@JsonProperty("response") Response response
+) {
+
+	public record Response(
+		Service service,
+		String status,
+		Error error,
+		@JsonProperty("record") RecordInfo record,
+		Page page,
+		Result result
+	) {
+	}
+	public record Error(
+		Integer level,
+		String code,
+		String text
+	) {
+	}
+	public record Service(
+		String name,
+		String version,
+		String operation,
+		String time // 예: "25(ms)"
+	) {
+	}
+
+	public record RecordInfo(
+		String total,
+		String current
+	) {
+	}
+
+	public record Page(
+		String total,
+		String current,
+		String size
+	) {
+	}
+
+	public record Result(
+		@JsonProperty("featureCollection") FeatureCollection featureCollection
+	) {
+	}
+
+	public record FeatureCollection(
+		String type,                       // "FeatureCollection"
+		List<Double> bbox,                 // [minX, minY, maxX, maxY] (없을 수도 있음)
+		List<Feature> features
+	) {
+	}
+
+	public record Feature(
+		String type,                       // "Feature"
+		GeoJsonGeometry geometry,
+		Properties properties,
+		String id                          // 예: "LT_C_SPBD.5100132890"
+	) {
+	}
+
+	public record GeoJsonGeometry(
+		String type,
+		Object coordinates
+	) {
+	}
+
+	/** 문서 기준 핵심 속성 + 현장 응답에서 자주 보이는 필드 포함 */
+	public record Properties(
+		// 공식 식별자
+		@JsonProperty("bd_mgt_sn") String bd_mgt_sn,   // 건물관리번호(25자리)
+
+		// 행정구역/도로명
+		String sido,
+		String sigungu,
+		String gu,                     // 읍/면/동 명칭(문서/데이터에 따라 emd_nm 등으로도 표기되는 경우 존재)
+		@JsonProperty("rd_nm") String rd_nm,           // 도로명
+
+		// 건물명
+		@JsonProperty("buld_nm") String buld_nm,       // 건물명
+		@JsonProperty("buld_nm_dc") String buld_nm_dc, // 동/부속명
+		@JsonProperty("bul_eng_nm") String bul_eng_nm, // 영문명(있을 때)
+
+		// 건물번호(문서: 본번/부번이 일반적)
+		@JsonProperty("bld_s") String bld_s,           // 건물본번
+		@JsonProperty("bld_e") String bld_e,           // 건물부번
+		@JsonProperty("buld_no") String buld_no,       // 일부 응답에 존재(본번/부번 합성)
+
+		// 층수 등 부가정보
+		@JsonProperty("gro_flo_co") String gro_flo_co, // 지상층수
+		@JsonProperty("und_flo_co") String und_flo_co, // 지하층수(있을 때)
+
+		// 코드류(있을 때)
+		@JsonProperty("sig_cd") String sig_cd,
+		@JsonProperty("rn_cd") String rn_cd,
+		@JsonProperty("emd_cd") String emd_cd,
+
+		// 참조 키(있을 때)
+		String pnu,            // 토지 PNU
+		String xpos, String ypos, // 경위도 문자열일 때가 있어 String 권장
+		@JsonProperty("poi_chk") String poi_chk
+	) {
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/entity/PlaceBuildingMap.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/PlaceBuildingMap.java
@@ -1,0 +1,80 @@
+package JJinBBang.app.domain.building.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceBuildingMap {
+
+	@Id
+	@Column(name = "kakao_place_id", length = 64, nullable = false)
+	private String kakaoPlaceId;
+
+	@Column(name = "kakao_lat", nullable = false, precision = 20, scale = 15)
+	private BigDecimal kakaoLat;
+
+	@Column(name = "kakao_lng", nullable = false, precision = 20, scale = 15)
+	private BigDecimal kakaoLng;
+
+	@Column(name = "building_mgmt_no")
+	private String buildingMgmtNo; // 발견 시 채움, 미발견이면 NULL
+
+	@Column(name = "manual_override", nullable = false)
+	private boolean manualOverride; // 수동 수정 여부 (TINYINT(1) ↔ boolean)
+
+	// DB의 DEFAULT CURRENT_TIMESTAMP를 쓰면서도, 엔티티에선 값 자동 세팅
+	@CreationTimestamp
+	@Column(
+		name = "created_at",
+		nullable = false,
+		updatable = false
+	)
+	private LocalDateTime createdAt;
+
+	@UpdateTimestamp
+	@Column(
+		name = "updated_at",
+		nullable = false
+	)
+	private LocalDateTime updatedAt;
+
+	/** 편의 메서드: 한 달 경과 여부 체크 (lazy/배치 재검증에 활용 가능) */
+	public boolean needsMonthlyRecheck() {
+		return updatedAt == null || updatedAt.isBefore(LocalDateTime.now().minusMonths(1));
+	}
+
+	public void updateBuildingMgmtNo(String buildingMgmtNo) {
+		this.buildingMgmtNo = buildingMgmtNo;
+	}
+
+	public static PlaceBuildingMap of (
+		String kakaoPlaceId,
+		Double latitude,
+		Double longitude,
+		String buildingMgmtNo,
+		boolean manualOverride
+	) {
+		return PlaceBuildingMap.builder()
+			.kakaoPlaceId(kakaoPlaceId)
+			.kakaoLat(BigDecimal.valueOf(latitude))
+			.kakaoLng(BigDecimal.valueOf(longitude))
+			.buildingMgmtNo(buildingMgmtNo)
+			.manualOverride(manualOverride)
+			.build();
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/infra/VWorldApiClient.java
+++ b/src/main/java/JJinBBang/app/domain/building/infra/VWorldApiClient.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.domain.building.infra;
+
+import JJinBBang.app.domain.building.dto.VWorldResponse;
+
+public interface VWorldApiClient {
+	VWorldResponse searchByPoint(Double longitude, Double latitude);
+}

--- a/src/main/java/JJinBBang/app/domain/building/infra/VWorldApiClientImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/infra/VWorldApiClientImpl.java
@@ -1,0 +1,45 @@
+package JJinBBang.app.domain.building.infra;
+
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import JJinBBang.app.domain.building.dto.VWorldRequest;
+import JJinBBang.app.domain.building.dto.VWorldResponse;
+
+@Component
+public class VWorldApiClientImpl implements VWorldApiClient {
+
+	@Value("${vworld.base-url}")
+	private String baseUrl;
+	@Value("${vworld.api-key}")
+	private String apiKey;
+	@Value("${vworld.buffer-meter:5}")
+	private Integer bufferMeter;
+
+	@Override
+	public VWorldResponse searchByPoint(Double longitude, Double latitude) {
+		VWorldRequest request = VWorldRequest.byPoint(
+			apiKey,
+			longitude,
+			latitude,
+			bufferMeter
+		);
+
+		return search(request);
+	}
+
+	private VWorldResponse search(VWorldRequest request) {
+		RestTemplate restTemplate = new RestTemplate();
+
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUrl)
+			.queryParams(request.toQueryParams())
+			.build()
+			.toUri();
+
+		return restTemplate.getForObject(uri, VWorldResponse.class);
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/repository/PlaceBuildingMapRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/PlaceBuildingMapRepository.java
@@ -1,0 +1,8 @@
+package JJinBBang.app.domain.building.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import JJinBBang.app.domain.building.entity.PlaceBuildingMap;
+
+public interface PlaceBuildingMapRepository extends JpaRepository<PlaceBuildingMap, String> {
+}

--- a/src/main/java/JJinBBang/app/domain/building/service/BuildingCodeResolver.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BuildingCodeResolver.java
@@ -2,6 +2,7 @@ package JJinBBang.app.domain.building.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -16,7 +17,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import JJinBBang.app.domain.building.dto.VWorldResponse;
+import JJinBBang.app.domain.building.entity.PlaceBuildingMap;
 import JJinBBang.app.domain.building.infra.VWorldApiClient;
+import JJinBBang.app.domain.building.repository.PlaceBuildingMapRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,49 +30,116 @@ import lombok.extern.slf4j.Slf4j;
 public class BuildingCodeResolver {
 	private static final GeometryFactory GF = new GeometryFactory(new PrecisionModel(), 4326);
 	private final VWorldApiClient vWorldApiClient;
-	private static final ObjectMapper mapper = new ObjectMapper(); // 추가
+	private static final ObjectMapper mapper = new ObjectMapper();
+	private final PlaceBuildingMapRepository placeBuildingMapRepository;
 
-	public String resolve(Double longitude, Double latitude, String buildingCode) {
+	/**
+	 * 카카오 장소 ID와 좌표(경도, 위도)를 받아서 건물 관리 번호를 반환합니다.
+	 * 기존 매핑 정보가 있으면 그 정보를 우선 사용하고, 없으면 VWorld API를 호출하여 조회합니다.
+	 * 수동 수정된 매핑 정보는 우선 사용하며, 수동 수정되지 않은 매핑 정보는 한달마다 재검증합니다.
+	 * */
+	@Transactional
+	public String resolve(Double longitude, Double latitude, String kakaoPlaceId) {
 
-		// VWorld API를 사용하여 좌표 주위 5m 건물 목록 조회
-		VWorldResponse.Response res = vWorldApiClient.searchByPoint(longitude, latitude).response();
+		// 기존 매핑 정보 확인
+		Optional<PlaceBuildingMap> opt = placeBuildingMapRepository.findById(kakaoPlaceId);
 
-		// 건물이 없으면 임시로 buildingCode(카카오 장소 ID) 반환
-		if (res.status().equals("NOT_FOUND")) {
-			log.warn(
-				"VWorld API: 해당 좌표에 건물이 없습니다. longitude={}, latitude={}, 임시 건물 번호({})를 저장합니다.",
-				longitude, latitude, "KAKAO_PLACE_ID_"+buildingCode
-			);
-			return "KAKAO_PLACE_ID_"+buildingCode;
+		// 기존 매핑 정보가 있다면, 수동 수정 여부 및 한달 경과 여부 확인
+		if (opt.isPresent()) {
+			PlaceBuildingMap map = opt.get();
+
+			// 수동 수정했으면 기존 매핑 정보 사용
+			if (map.isManualOverride()) {
+				return map.getBuildingMgmtNo();
+			}
+
+			// 수동 수정 안 했으면 한달 경과 여부 확인
+			if (map.needsMonthlyRecheck()) {
+
+				// 한달 지났으면 API 재조회 후 매핑 정보 갱신
+				String refreshed = fetchBuildingCodeFromApi(longitude, latitude);
+
+				if (refreshed != null) {
+					// 재조회 결과가 있다면, 매핑 정보 갱신
+					map.updateBuildingMgmtNo(refreshed);
+					placeBuildingMapRepository.save(map);
+					return refreshed;
+				} else {
+					// 재조회 결과가 없다면, 기존 매핑 정보 유지
+					log.warn("VWorld 재조회 결과가 없습니다. 기존 매핑 정보(kakaoPlaceId = {}, 건물관리번호 = {})를 유지하겠습니다",
+						kakaoPlaceId, map.getBuildingMgmtNo());
+					return map.getBuildingMgmtNo();
+				}
+			} else {
+				// 한달 안 지났으면 기존 매핑 정보 사용
+				return map.getBuildingMgmtNo();
+			}
+		} else {
+			// 기존 매핑 정보가 없으면 API 조회 후 매핑 정보 저장
+			String resolved = fetchBuildingCodeFromApi(longitude, latitude);
+			if (resolved == null) {
+				// API 조회 결과가 없으면 임시로 카카오 장소 ID 값 저장
+				resolved = "KAKAO_PLACE_ID_" + kakaoPlaceId;
+				log.warn("VWorld API: lon={}, lat={}에 건물 정보가 없습니다.", longitude, latitude);
+			}
+
+			// 새 매핑 정보 저장
+			PlaceBuildingMap newMap = PlaceBuildingMap.of(kakaoPlaceId, latitude, longitude, resolved, false);
+			placeBuildingMapRepository.save(newMap);
+
+			return resolved;
 		}
-
-		// 조회된 건물 목록
-		List<VWorldResponse.Feature> features = res.result().featureCollection().features();
-
-		// 좌표 기준으로 건물 목록 중에서 가장 가까운 건물의 bd_mgt_sn(건물관리번호) 추출
-		VWorldResponse.Feature closestFeature = getClosestFeature(longitude, latitude, features);
-
-		// 좌표와 가장 가까운 건물의 건물관리번호 반환
-		return closestFeature.properties().bd_mgt_sn();
 	}
 
+	/**
+	 * VWorld API를 호출하여 건물 관리 번호를 조회합니다.
+	 * */
+	private String fetchBuildingCodeFromApi(Double longitude, Double latitude) {
+		VWorldResponse.Response response = vWorldApiClient.searchByPoint(longitude, latitude).response();
+
+		// API 호출 결과가 없으면, null 반환
+		if ("NOT_FOUND".equals(response.status())) {
+			return null;
+		}
+		if (response.result() == null
+			|| response.result().featureCollection() == null
+			|| response.result().featureCollection().features() == null
+			|| response.result().featureCollection().features().isEmpty()) {
+			return null;
+		}
+
+		// 가장 가까운 피처 선택
+		List<VWorldResponse.Feature> features = response.result().featureCollection().features();
+		VWorldResponse.Feature best = getClosestFeature(longitude, latitude, features);
+
+		return best != null && best.properties() != null ? best.properties().bd_mgt_sn() : null;
+	}
+
+	/**
+	 * 주어진 좌표(경도, 위도)에서 가장 가까운 피처를 선택합니다.
+	 * 피처가 좌표를 포함하면 즉시 반환하고, 포함하는 피처가 없으면 가장 가까운 피처를 반환합니다.
+	 * */
 	private VWorldResponse.Feature getClosestFeature(
 		Double longitude, Double latitude,
 		List<VWorldResponse.Feature> features) {
 
+		// 피처 목록이 없으면 null 반환
 		if (features == null || features.isEmpty()) {
 			return null;
 		}
 
+		// 좌표를 Point 객체로 생성
 		Point point = GF.createPoint(new Coordinate(longitude, latitude));
 
 		double minDistance = Double.MAX_VALUE;
 		VWorldResponse.Feature closestFeature = null;
 
+		// 각 피처의 지오메트리를 확인하여 포함 여부 및 거리 계산
 		for (VWorldResponse.Feature feature : features) {
 			VWorldResponse.GeoJsonGeometry geo = feature.geometry();
 			if (geo == null || geo.type() == null || geo.coordinates() == null) continue;
 
+			// GeoJSON 문자열을 Geometry 객체로 변환
 			Geometry g;
 			try {
 				String geoJson = mapper.writeValueAsString(
@@ -79,22 +150,26 @@ public class BuildingCodeResolver {
 			} catch (JsonProcessingException | ParseException e) {
 				continue;
 			}
+			// 지오메트리가 없으면 다음 피처로
 			if (g == null || g.isEmpty()) {
 				continue;
 			}
 
+			// 좌표가 지오메트리 안에 있으면 즉시 반환
 			if (g.covers(point)) {
 				return feature;
 			}
 
+			// 좌표가 지오메트리 안에 없으면 거리 계산
 			double distance = g.distance(point);
+
+			// 가장 가까운 피처 갱신
 			if (distance < minDistance) {
 				minDistance = distance;
 				closestFeature = feature;
 			}
 
 		}
-
 		return closestFeature;
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/BuildingCodeResolver.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BuildingCodeResolver.java
@@ -1,0 +1,100 @@
+package JJinBBang.app.domain.building.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.geojson.GeoJsonReader;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import JJinBBang.app.domain.building.dto.VWorldResponse;
+import JJinBBang.app.domain.building.infra.VWorldApiClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BuildingCodeResolver {
+	private static final GeometryFactory GF = new GeometryFactory(new PrecisionModel(), 4326);
+	private final VWorldApiClient vWorldApiClient;
+	private static final ObjectMapper mapper = new ObjectMapper(); // 추가
+
+	public String resolve(Double longitude, Double latitude, String buildingCode) {
+
+		// VWorld API를 사용하여 좌표 주위 5m 건물 목록 조회
+		VWorldResponse.Response res = vWorldApiClient.searchByPoint(longitude, latitude).response();
+
+		// 건물이 없으면 임시로 buildingCode(카카오 장소 ID) 반환
+		if (res.status().equals("NOT_FOUND")) {
+			log.warn(
+				"VWorld API: 해당 좌표에 건물이 없습니다. longitude={}, latitude={}, 임시 건물 번호({})를 저장합니다.",
+				longitude, latitude, "KAKAO_PLACE_ID_"+buildingCode
+			);
+			return "KAKAO_PLACE_ID_"+buildingCode;
+		}
+
+		// 조회된 건물 목록
+		List<VWorldResponse.Feature> features = res.result().featureCollection().features();
+
+		// 좌표 기준으로 건물 목록 중에서 가장 가까운 건물의 bd_mgt_sn(건물관리번호) 추출
+		VWorldResponse.Feature closestFeature = getClosestFeature(longitude, latitude, features);
+
+		// 좌표와 가장 가까운 건물의 건물관리번호 반환
+		return closestFeature.properties().bd_mgt_sn();
+	}
+
+	private VWorldResponse.Feature getClosestFeature(
+		Double longitude, Double latitude,
+		List<VWorldResponse.Feature> features) {
+
+		if (features == null || features.isEmpty()) {
+			return null;
+		}
+
+		Point point = GF.createPoint(new Coordinate(longitude, latitude));
+
+		double minDistance = Double.MAX_VALUE;
+		VWorldResponse.Feature closestFeature = null;
+
+		for (VWorldResponse.Feature feature : features) {
+			VWorldResponse.GeoJsonGeometry geo = feature.geometry();
+			if (geo == null || geo.type() == null || geo.coordinates() == null) continue;
+
+			Geometry g;
+			try {
+				String geoJson = mapper.writeValueAsString(
+					Map.of("type", geo.type(), "coordinates", geo.coordinates())
+				);
+				GeoJsonReader geoJsonReader = new GeoJsonReader();
+				g = geoJsonReader.read(geoJson);
+			} catch (JsonProcessingException | ParseException e) {
+				continue;
+			}
+			if (g == null || g.isEmpty()) {
+				continue;
+			}
+
+			if (g.covers(point)) {
+				return feature;
+			}
+
+			double distance = g.distance(point);
+			if (distance < minDistance) {
+				minDistance = distance;
+				closestFeature = feature;
+			}
+
+		}
+
+		return closestFeature;
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -3,6 +3,7 @@ package JJinBBang.app.domain.building.service;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.locationtech.jts.geom.*;
 
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -40,6 +41,7 @@ public class ReviewServiceImpl implements ReviewService {
 	private final BuildingKeywordCountsRepository buildingKeywordCountsRepository;
 	private final CampusesRepository campusesRepository;
 	private final S3Service s3Service;
+	private final BuildingCodeResolver buildingCodeResolver;
 
 	/**
      * 특정 건물 또는 공인중개사에 대한 리뷰 목록을 페이징 조회
@@ -213,7 +215,7 @@ public class ReviewServiceImpl implements ReviewService {
                 .orElseThrow(CampusNotFoundException::missingCampus);
 
         // 2) 건물 로드/생성
-        Buildings building = findOrCreateBuilding(dto.buildingRequest(), campus);
+        Buildings building = findOrCreateDormitory(dto.buildingRequest(), campus);
 
 
         // 3) DormReviews 엔티티 저장
@@ -245,7 +247,20 @@ public class ReviewServiceImpl implements ReviewService {
         return saved.getId();
     }
 
-    /**
+	private Buildings findOrCreateDormitory(BuildingRequest buildingRequest, Campuses campus) {
+		// 카카오 장소 ID를 건물관리번호로 변환
+		String resolvedCode = buildingCodeResolver.resolve(
+			buildingRequest.longitude(),
+			buildingRequest.latitude(),
+			buildingRequest.buildingCode()
+		);
+
+		BuildingRequest updatedRequest = buildingRequest.updateBuildingCode(resolvedCode);
+
+		return findOrCreateBuilding(updatedRequest, campus);
+	}
+
+	/**
      * 공인중개사 리뷰 생성 로직
      * 1) 공인중개사 조회 또는 생성
      * 2) AgencyReviews 저장

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -121,7 +121,7 @@ mail-auth:
 logging:
   level:
     org.hibernate.sql: debug
-    org.hibernate.typ e: trace
+    org.hibernate.type: trace
     org.springframework.data.mongodb.core.MongoTemplate: DEBUG
 
 
@@ -135,3 +135,8 @@ app:
 user:
   deletion:
     grace-days: 30 # 사용자가 탈퇴한 후, 해당 사용자의 데이터가 삭제되기까지의 기간 (일 단위)
+
+vworld:
+  base-url: https://api.vworld.kr/req/data
+  api-key: ${vworld.api-key}
+  buffer-meter: 5 # 버퍼 영역 (단위: m)


### PR DESCRIPTION
## 📌 이슈 번호
- #231

## 💬 리뷰 포인트
- JTS Topology Suite 의존성 추가 및 VWorld API 연동을 위한 코드 구현
- `BuildingRequest`에 건물관리번호(bd_mgt_sn) 갱신 메서드(`updateBuildingCode`) 추가  
- `VWorldRequest`, `VWorldResponse`, `WorldApiClient`, `WorldApiClientImpl` 등 VWorld API 호출을 위한 DTO/클라이언트 클래스 생성  
- 카카오 장소 ID ↔ 건물관리번호 매핑정보를 저장하는 PlaceBuildingMap 엔티티 및 Repository 추가
- BuildingCodeResolver에서 매핑 정보를 우선 사용하고, 수동 수정 여부 및 한 달 경과 여부를 확인해 재검증하도록 구현
- 리뷰 생성 시 VWorld API에서 얻은 건물관리번호를 사용하도록 `ReviewServiceImpl` 로직 수정  
- `application.yml`에 VWorld API 관련 설정 (`base-url`, `api-key`, `buffer-meter`) 추가

## 🚀 상세 설명
### 1. 의존성 및 설정
- `build.gradle`에 JTS Topology Suite(`org.locationtech.jts-core`, `org.locationtech.jts-io`) 라이브러리를 추가하여 GeoJSON 파싱과 거리 계산이 가능하도록 했습니다.
- `application.yml`에 VWorld API 호출에 필요한 기본 URL, API 키, 버퍼 반경(미터)을 설정했습니다. 

### 2. BuildingRequest 수정
- `BuildingRequest` 에 `updateBuildingCode(String buildingCode)` 메서드를 추가했습니다. 
- 이 메서드는 기존 필드를 보존하면서 새로운 건물관리번호를 수정한 `BuildingRequest` 인스턴스를 생성합니다. 
- 이를 통해 vworld api 호출하여 얻은 건물관리번호를 기존 BuildingRequest DTO에 반영할 수 있습니다.

### 3. VWorld API 연동
- **DTO:** `VWorldRequest` 레코드는 VWorld 2D 데이터 API를 호출하기 위한 요청 DTO입니다. 
  - 좌표 요청을 생성할 수 있는 `of`/`byPoint` 팩토리 메서드를 추가했습니다.
  - vworld API 요청을 위해 DTO를 쿼리파라미터로 변경하는 `toQueryParams()` 메서드를 구현했습니다.

- **WorldApiClient:** 좌표를 전달받아 VWorld API를 호출하는 `searchByPoint` 메서드를 선언합니다.  
  - `RestTemplate`과 `UriComponentsBuilder`를 이용해 VWorld API를 호출합니다. 
  - 애플리케이션 설정 값(`base-url`, `api-key`, `buffer-meter`)을 주입받아 쿼리 파라미터를 구성하고, 
  - 응답을 `VWorldResponse`로 매핑합니다.

### 4. PlaceBuildingMap 매핑 테이블 추가
- `PlaceBuildingMap` 엔티티 추가 (PK: `kakao_place_id`, `kakao_lat`, `kakao_lng`, `building_mgmt_no`, `manual_override`, `created_at`, `updated_at`)  
   - 카카오 장소 ID ↔ 건물관리번호 매핑 정보를 저장하는 테이블을 추가하여 VWorld API 호출 줄여 응답 시간을 줄이도록 했습니다
  - 자동 매핑된 정보는 한달이 지나면, 재검증합니다
   - manual_overide 값이 참인 경우, 재검증하지 않습니다
- `needsMonthlyRecheck()` 메서드 구현
   - 매핑 정보가 수정되고 한 달 경과 여부를 확인하는 메서드 입니다.
- `updateBuildingMgmtNo(...)` 메서드 구현
  - 매핑 정보를 수정하는 메서드 입니다.
- `PlaceBuildingMapRepository` 추가 (`JpaRepository<PlaceBuildingMap, String>`)  
  - DB에 저장된 매핑정보를 조회하기 위함입니다
 
### 5. BuildingCodeResolver 및 ReviewService 수정
- 기숙사 유형 리뷰 작성 시 BuildingCodeResolver.resolve(...)를 호출하여 건물관리번호를 얻습니다.
- BuildingCodeResolver.resolve(...): VWorld API를 호출하여 응답 받은 건물 정보 중 가장 가까운 건물의 `bd_mgt_sn`(건물관리번호)을 찾습니다. 
- 기존 매핑 정보(PlaceBuildingMap)가 존재하면 우선 사용하며, 수동 정정 여부 및 한 달 경과 여부를 확인해 필요 시 VWorld API 재조회 후 갱신합니다.  
- 기존 매핑이 없으면 VWorld API로 조회 후 `PlaceBuildingMap`에 저장하고 반환합니다.  
- 좌표가 건물 내부에 있는 경우 즉시 선택하고, 아니면 가장 가까운 건물을 선택합니다.
- 조회 결과가 없는 경우에는 기존 카카오 장소 ID에 `KAKAO_PLACE_ID_` 프리픽스를 붙인 임시 코드를 사용해 저장합니다.  
- 이 프리픽스가 붙인 건물은 수동으로 찾아서 건물관리번호를 채우도록 하겠습니다.
- 수정된 `findOrCreateDormitory`  로직에서 `BuildingRequest.updateBuildingCode(...)`를 이용해 업데이트된 건물관리번호를 반영합니다.

### 6. 기타
- `application.yml`의 로그 설정에서 `org.hibernate.type`의 이름 오타를 수정했습니다.  

## 📸 스크린샷

## 📢 노트
- VWorld API 연동을 위해 `vworld.api-key` 값을 `application-prod.yml` 에 설정해야 합니다. 
- 새로운 엔티티 PlaceBuildingCodeMap 가 추가됩니다.

### 작동 흐름

리뷰가 생성될 때 `ReviewServiceImpl`은 먼저 사용자가 선택한 위치(카카오 장소 ID, 위도·경도)를 받아 건물관리번호를 얻어야 합니다.  이를 위해 `BuildingCodeResolver.resolve(longitude, latitude, kakaoPlaceId)`를 호출하게 됩니다.  

`BuildingCodeResolver`는 가장 먼저 `PlaceBuildingMapRepository`를 통해 카카오 장소 ID와 건물관리번호 매핑 정보가 이미 존재하는지 확인합니다.  

- 매핑 정보가 있고 운영자가 `manual_override = true`로 설정한 경우  
  - 외부 API를 호출하지 않고 저장된 `building_mgmt_no`를 그대로 사용합니다.
- 자동 매핑된 정보라면 마지막 갱신 이후 한 달이 지났는지(`needsMonthlyRecheck()`) 확인합니다.  
  - 한 달 이상 경과 시 VWorld API를 재조회하여 최신 건물관리번호로 갱신하고 저장합니다.  
  - 한 달이 지나지 않았다면 기존 값 그대로 반환합니다.

매핑 정보가 없다면 `BuildingCodeResolver`는 `WorldApiClient.searchByPoint()`를 통해 VWorld API를 호출합니다.  

- 응답으로 들어온 건물들 중 좌표가 건물 안에 있다면 즉시 이 건물을 선택합니다.  
- 포함된 건물이 없으면 가장 가까운 건물을 찾아 `bd_mgt_sn`을 추출합니다.  
- VWorld API에서 결과를 받으면 새로운 `PlaceBuildingMap` 엔티티를 생성하여 DB에 저장하고,  
- 결과가 없으면 `"KAKAO_PLACE_ID_{kakaoPlaceId}"` 형태의 임시 코드를 저장해 반환합니다.  

`ReviewServiceImpl`은 이렇게 반환된 건물관리번호(또는 임시 코드)를 `BuildingRequest.updateBuildingCode(...)`를 통해 리뷰작성요청 DTO에 반영한 뒤,  
이후 `findOrCreateDormitory` 등의 도메인 로직에서 건물관리번호를 사용해 리뷰를 저장합니다.  
