### PR TITLE
Feat[#245]: 지도 마커/검색 API 캠퍼스 필터 개선

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryCustom.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryCustom.java
@@ -16,8 +16,7 @@ public interface BuildingsRepositoryCustom {
 		Integer depositMin, Integer depositMax,
 		Integer monthlyRentMin, Integer monthlyRentMax,
 		Boolean inMaintenanceCost,
-		List<KeywordType> reviewKeywords,
-		List<Long> campusIds
+		List<KeywordType> reviewKeywords
 	);
 
 	List<Buildings> searchBuildings(
@@ -27,7 +26,6 @@ public interface BuildingsRepositoryCustom {
 		Integer depositMin, Integer depositMax,
 		Integer monthlyRentMin, Integer monthlyRentMax,
 		Boolean inMaintenanceCost,
-		List<KeywordType> reviewKeywords,
-		List<Long> campusIds
+		List<KeywordType> reviewKeywords
 	);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
@@ -35,8 +35,7 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		Integer depositMin, Integer depositMax,
 		Integer monthlyRentMin, Integer monthlyRentMax,
 		Boolean inMaintenanceCost,
-		List<KeywordType> reviewKeywords,
-		List<Long> campusIds
+		List<KeywordType> reviewKeywords
 	) {
 		QBuildings b = QBuildings.buildings;
 		QCampuses c = QCampuses.campuses;
@@ -59,13 +58,7 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 			builder.and(typeBuilder);
 		}
 
-		// 3. 캠퍼스 필터
-		// 3. 캠퍼스 필터
-		if (campusIds != null && !campusIds.isEmpty()) {
-			builder.and(b.campus.id.in(campusIds));
-		}
-
-		// 4. Treat()를 이용한 GeneralReviews 전용 조인
+		// 3. Treat()를 이용한 GeneralReviews 전용 조인
 		PathBuilder<GeneralReviews> grPath = new PathBuilder<>(GeneralReviews.class, "generalReview");
 		QGeneralReviews treated = new QGeneralReviews(grPath);
 
@@ -76,7 +69,7 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 			.leftJoin(b.campus, c).fetchJoin()
 			.where(builder);
 
-		// 5. 계약 조건 필터
+		// 4. 계약 조건 필터
 		if (contractType != null) {
 			query.where(treated.contractType.eq(contractType));
 		}
@@ -107,8 +100,7 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		Integer depositMin, Integer depositMax,
 		Integer monthlyRentMin, Integer monthlyRentMax,
 		Boolean inMaintenanceCost,
-		List<KeywordType> reviewKeywords,
-		List<Long> campusIds
+		List<KeywordType> reviewKeywords
 	) {
 		QBuildings b = QBuildings.buildings;
 		QCampuses c = QCampuses.campuses;
@@ -131,10 +123,6 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 				typeBuilder.or(b.buildingType.containsIgnoreCase(type.name()));
 			}
 			builder.and(typeBuilder);
-		}
-
-		if (campusIds != null && !campusIds.isEmpty()) {
-			builder.and(b.campus.id.in(campusIds));
 		}
 
 		PathBuilder<GeneralReviews> grPath = new PathBuilder<>(GeneralReviews.class, "generalReview");

--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -46,7 +46,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class MapServiceImpl implements MapService{
-    private static final double DEFAULT_CAMPUS_RADIUS_METERS = 5_000d;
+    private static final double DEFAULT_CAMPUS_RADIUS_METERS = 2_000d;
     private static final double EARTH_RADIUS_METERS = 6_371_000d;
 
     private final BuildingsRepository buildingsRepository;

--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -22,7 +22,9 @@ import JJinBBang.app.domain.map.exception.MapNotFoundException;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.common.dto.InfoDto;
 import org.springframework.stereotype.Service;
+import JJinBBang.app.domain.common.entity.Campuses;
 
+import JJinBBang.app.domain.common.repository.CampusesRepository;
 import JJinBBang.app.domain.building.entity.Buildings;
 import JJinBBang.app.domain.common.dto.item.Filters;
 import JJinBBang.app.domain.map.dto.item.Bounds;
@@ -44,13 +46,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class MapServiceImpl implements MapService{
-	private final BuildingsRepository buildingsRepository;
-	private final ReviewsRepository reviewsRepository;
-	private final BuildingLikesRepository buildingLikesRepository;
-	private final ReviewLikesRepository reviewLikesRepository;
-	private final AgenciesRepository agenciesRepository;
-	private final AgencyLikesRepository agencyLikesRepository;
-	private final SearchInfo searchInfo;
+    private static final double DEFAULT_CAMPUS_RADIUS_METERS = 5_000d;
+    private static final double EARTH_RADIUS_METERS = 6_371_000d;
+
+    private final BuildingsRepository buildingsRepository;
+    private final ReviewsRepository reviewsRepository;
+    private final BuildingLikesRepository buildingLikesRepository;
+    private final ReviewLikesRepository reviewLikesRepository;
+    private final AgenciesRepository agenciesRepository;
+    private final AgencyLikesRepository agencyLikesRepository;
+    private final CampusesRepository campusesRepository;
+    private final SearchInfo searchInfo;;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -66,32 +72,61 @@ public class MapServiceImpl implements MapService{
 		ContractType contractType = parseContractType(filters.contractType());
 
 		// 모든 조건 기반으로 건물 리스트를 먼저 조회
-		List<Buildings> buildings = buildingsRepository.findMarkersWithinBounds(
-			bounds.neLat(), bounds.neLng(),
-			bounds.swLat(), bounds.swLng(),
-			filters.buildType(), contractType,
-			filters.depositMin(), filters.depositMax(),
-			filters.monthlyRentMin(), filters.monthlyRentMax(),
-			filters.inMaintenanceCost(),
-			filters.reviewKeyword(),
-			filters.campus()
-		);
+        List<Long> campusFilters = filters.campus();
+        boolean hasCampusFilters = campusFilters != null && !campusFilters.isEmpty();
+        List<Buildings> buildings = buildingsRepository.findMarkersWithinBounds(
+                bounds.neLat(), bounds.neLng(),
+                bounds.swLat(), bounds.swLng(),
+                filters.buildType(), contractType,
+                filters.depositMin(), filters.depositMax(),
+                filters.monthlyRentMin(), filters.monthlyRentMax(),
+                filters.inMaintenanceCost(),
+                filters.reviewKeyword(),
+                hasCampusFilters ? null : campusFilters
+        );
 
-		boolean includeAgency = filters.buildType() == null
-			|| filters.buildType().contains(BuildingType.ALL)
-			|| filters.buildType().contains(BuildingType.AGENCY);
+        boolean includeAgency = filters.buildType() == null
+                || filters.buildType().contains(BuildingType.ALL)
+                || filters.buildType().contains(BuildingType.AGENCY);
 
-		List<Agencies> agencies = includeAgency
-			? agenciesRepository.findMarkersWithinBounds(
-			bounds.neLat(), bounds.neLng(),
-			bounds.swLat(), bounds.swLng()
-		)
-			: List.of();
+        List<Agencies> agencies = includeAgency
+                ? agenciesRepository.findMarkersWithinBounds(
+                bounds.neLat(), bounds.neLng(),
+                bounds.swLat(), bounds.swLng()
+        )
+                : List.of();
 
-		if (buildings.isEmpty() && agencies.isEmpty()) {
-			if (filters.viewType() == ViewType.REVIEW) {
-				throw MapNoContentException.notFoundReview();
-			} else {
+        if (hasCampusFilters) {
+            List<Campuses> campuses = campusesRepository.findAllById(campusFilters);
+            if (campuses.isEmpty()) {
+                buildings = List.of();
+                agencies = includeAgency ? List.of() : agencies;
+            } else {
+                double radiusMeters = resolveCampusRadiusMeters(filters);
+                buildings = buildings.stream()
+                        .filter(b -> isWithinCampusRadius(
+                                b.getBuildingLat(),
+                                b.getBuildingLot(),
+                                campuses,
+                                radiusMeters))
+                        .toList();
+
+                if (includeAgency) {
+                    agencies = agencies.stream()
+                            .filter(a -> isWithinCampusRadius(
+                                    a.getAgencyLat(),
+                                    a.getAgencyLot(),
+                                    campuses,
+                                    radiusMeters))
+                            .toList();
+                }
+            }
+        }
+
+        if (buildings.isEmpty() && agencies.isEmpty()) {
+            if (filters.viewType() == ViewType.REVIEW) {
+                throw MapNoContentException.notFoundReview();
+            } else {
 				throw MapNoContentException.notFoundBuilding();
 			}
 		}
@@ -151,21 +186,48 @@ public class MapServiceImpl implements MapService{
 
 		ContractType contractType = parseContractType(filters.contractType());
 
-		List<Buildings> buildings = buildingsRepository.searchBuildings(
-			request.keyword(),
-			filters.buildType(), contractType,
-			filters.depositMin(), filters.depositMax(),
-			filters.monthlyRentMin(), filters.monthlyRentMax(),
-			filters.inMaintenanceCost(),
-			filters.reviewKeyword(),
-			filters.campus()
-		);
+        List<Long> campusFilters = filters.campus();
+        boolean hasCampusFilters = campusFilters != null && !campusFilters.isEmpty();
+        List<Buildings> buildings = buildingsRepository.searchBuildings(
+                request.keyword(),
+                filters.buildType(), contractType,
+                filters.depositMin(), filters.depositMax(),
+                filters.monthlyRentMin(), filters.monthlyRentMax(),
+                filters.inMaintenanceCost(),
+                filters.reviewKeyword(),
+                hasCampusFilters ? null : campusFilters
+        );
 
-		List<Agencies> agencies = agenciesRepository.searchAgencies(request.keyword());
+        List<Agencies> agencies = agenciesRepository.searchAgencies(request.keyword());
 
-		if (buildings.isEmpty() && agencies.isEmpty()) {
-			throw MapNoContentException.searchFailed();
-		}
+        if (hasCampusFilters) {
+            List<Campuses> campuses = campusesRepository.findAllById(campusFilters);
+            if (campuses.isEmpty()) {
+                buildings = List.of();
+                agencies = List.of();
+            } else {
+                double radiusMeters = resolveCampusRadiusMeters(filters);
+                buildings = buildings.stream()
+                        .filter(b -> isWithinCampusRadius(
+                                b.getBuildingLat(),
+                                b.getBuildingLot(),
+                                campuses,
+                                radiusMeters))
+                        .toList();
+
+                agencies = agencies.stream()
+                        .filter(a -> isWithinCampusRadius(
+                                a.getAgencyLat(),
+                                a.getAgencyLot(),
+                                campuses,
+                                radiusMeters))
+                        .toList();
+            }
+        }
+
+        if (buildings.isEmpty() && agencies.isEmpty()) {
+            throw MapNoContentException.searchFailed();
+        }
 
 		List<SearchInfoDto> items = new ArrayList<>();
 		for (Buildings b : buildings) {
@@ -309,6 +371,37 @@ public class MapServiceImpl implements MapService{
 			.items(paged)
 			.build();
 	}
+
+    private double resolveCampusRadiusMeters(Filters filters) {
+        return DEFAULT_CAMPUS_RADIUS_METERS;
+    }
+
+    private boolean isWithinCampusRadius(Double lat, Double lng, List<Campuses> campuses, double radiusMeters) {
+        if (lat == null || lng == null) {
+            return false;
+        }
+
+        return campuses.stream().anyMatch(campus -> {
+            Double campusLat = campus.getCampusLat();
+            Double campusLot = campus.getCampusLot();
+            if (campusLat == null || campusLot == null) {
+                return false;
+            }
+            return calculateDistanceMeters(lat, lng, campusLat, campusLot) <= radiusMeters;
+        });
+    }
+
+    private double calculateDistanceMeters(double lat1, double lng1, double lat2, double lng2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return EARTH_RADIUS_METERS * c;
+    }
 
 	private Comparator<SearchInfoDto> getSearchComparator(SortType sort, ViewType type) {
 		return switch (sort) {

--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -56,7 +56,7 @@ public class MapServiceImpl implements MapService{
     private final AgenciesRepository agenciesRepository;
     private final AgencyLikesRepository agencyLikesRepository;
     private final CampusesRepository campusesRepository;
-    private final SearchInfo searchInfo;;
+    private final SearchInfo searchInfo;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -81,8 +81,7 @@ public class MapServiceImpl implements MapService{
                 filters.depositMin(), filters.depositMax(),
                 filters.monthlyRentMin(), filters.monthlyRentMax(),
                 filters.inMaintenanceCost(),
-                filters.reviewKeyword(),
-                hasCampusFilters ? null : campusFilters
+                filters.reviewKeyword()
         );
 
         boolean includeAgency = filters.buildType() == null
@@ -194,8 +193,7 @@ public class MapServiceImpl implements MapService{
                 filters.depositMin(), filters.depositMax(),
                 filters.monthlyRentMin(), filters.monthlyRentMax(),
                 filters.inMaintenanceCost(),
-                filters.reviewKeyword(),
-                hasCampusFilters ? null : campusFilters
+                filters.reviewKeyword()
         );
 
         List<Agencies> agencies = agenciesRepository.searchAgencies(request.keyword());


### PR DESCRIPTION
## 📌 이슈 번호
> #245

## 💬 리뷰 포인트
- campus id 기반 조회를 직접 매핑에서 캠퍼스 중심 반경 2km로 전환
- bounds 1차 필터 + 반경 필터 결합 

## 🚀 상세 설명
변경 배경
- 기존에는 request의 campus id로 직접 매핑된 건물만 반환해 일부 건물,기숙사/공인중개사 등 인접 객체가 누락됨
- 이제 campus id가 존재하면 해당 캠퍼스 좌표 중심 반경 2km 내의 마커만 반환

수정한 API
- 지도 검색 API
- 지도 검색 API

동작
- bounds로 선조회 → campus id가 있으면 반경 2km 필터 추가 적용
- 보기유형(ViewType)별 마커 생성만 분기하고 조회 파이프라인은 단일화
- AGENCY 포함 시에만 공인중개사 포함

## 📸 스크린샷
<img width="508" height="864" alt="image" src="https://github.com/user-attachments/assets/40fc1555-4552-453f-9823-1b2dc3f634a0" />

## 📢 노트
반경 값은 구성값을 따로 request로 받거나 범위 yml화 예정