### PR TITLE
[FEAT #238] 리뷰 작성/수정 유효성 검사 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/ReviewRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/ReviewRequest.java
@@ -63,17 +63,6 @@ public record ReviewRequest (
 		return true;
 	}
 
-	@AssertTrue(message = "리뷰 유형에 따라 이미지 개수를 올바르게 설정해주세요. 일반/기숙사 리뷰는 2~20장, 중개사 리뷰는 최대 20장입니다.")
-	private boolean isImageCountValid() {
-		int size = imageUrls.size();
-		if (agencyReview != null) {
-			return size <= 20;
-		}
-
-		return size >= 1 && size <= 20;
-	}
-
-
 	// 정확히 하나의 리뷰 섹션만 전송됐는지 검증
 	@AssertTrue(message = "generalReview, dormitoryReview, agencyReview 중 하나만 전송해야 합니다.")
 	private boolean isExactlyOneReview() {
@@ -111,7 +100,7 @@ public record ReviewRequest (
 		return GeneralReviews.builder()
 			.dtype(ReviewType.GENERAL)
 			.likesCount(0)
-			.thumbnailImage(imageUrls.isEmpty() ? null : imageUrls.getFirst())
+			.thumbnailImage(getFirstImageUrl())
 			.content(generalReview.getContent())
 			.tags(keywords.positive().stream().limit(5).toList())
 			.rating(generalReview.getRating())
@@ -132,7 +121,7 @@ public record ReviewRequest (
 				.id(oldReview.getId())
 				.dtype(oldReview.getDtype())
 				.likesCount(oldReview.getLikesCount())
-				.thumbnailImage(imageUrls.isEmpty() ? null : imageUrls.getFirst())
+				.thumbnailImage(getFirstImageUrl())
 				.content(generalReview.getContent())
 				.tags(keywords.positive().stream().limit(5).toList())
 				.rating(generalReview.getRating())
@@ -152,7 +141,7 @@ public record ReviewRequest (
 		return DormReviews.builder()
 			.dtype(ReviewType.DORM)
 			.likesCount(0)
-			.thumbnailImage(imageUrls.isEmpty() ? null : imageUrls.getFirst())
+			.thumbnailImage(getFirstImageUrl())
 			.content(dormitoryReview.getContent())
 			.tags(keywords.positive().stream().limit(5).toList())
 			.rating(dormitoryReview.getRating())
@@ -172,7 +161,7 @@ public record ReviewRequest (
 				.id(oldReview.getId())
 				.dtype(oldReview.getDtype())
 				.likesCount(oldReview.getLikesCount())
-				.thumbnailImage(imageUrls.isEmpty() ? null : imageUrls.getFirst())
+				.thumbnailImage(getFirstImageUrl())
 				.content(dormitoryReview.getContent())
 				.tags(keywords.positive().stream().limit(5).toList())
 				.rating(dormitoryReview.getRating())
@@ -191,7 +180,7 @@ public record ReviewRequest (
 		return AgencyReviews.builder()
 			.dtype(ReviewType.AGENCY)
 			.likesCount(0)
-			.thumbnailImage(imageUrls.isEmpty() ? null : imageUrls.getFirst())
+			.thumbnailImage(getFirstImageUrl())
 			.content(agencyReview.getContent())
 			.tags(keywords.positive().stream().limit(5).toList())
 			.rating(agencyReview.getRating())
@@ -206,7 +195,7 @@ public record ReviewRequest (
 				.id(oldReview.getId())
 				.dtype(oldReview.getDtype())
 				.likesCount(oldReview.getLikesCount())
-				.thumbnailImage(imageUrls.isEmpty() ? null : imageUrls.getFirst())
+				.thumbnailImage(getFirstImageUrl())
 				.content(agencyReview.getContent())
 				.tags(keywords.positive().stream().limit(5).toList())
 				.rating(agencyReview.getRating())
@@ -217,21 +206,37 @@ public record ReviewRequest (
 	}
 
 	public ReviewDetails toReviewDetails(Long reviewId, Long buildingId) {
+		List<String> imgs = safeImageUrls();
+
 		return ReviewDetails.builder()
 				.reviewId(reviewId)
 				.buildingId(buildingId)
-				.images(imageUrls)
-				.imageCount(imageUrls.size())
+				.images(imgs)
+				.imageCount(imgs.size())
 				.keywords(keywords)
 				.build();
 	}
 
 	public ReviewDetails toUpdatedReviewDetails(ReviewDetails oldDetails, Long buildingId) {
+		List<String> imgs = safeImageUrls();
+
 		return oldDetails.toBuilder()
 				.buildingId(buildingId)
-				.images(imageUrls)
-				.imageCount(imageUrls.size())
+				.images(imgs)
+				.imageCount(imgs.size())
 				.keywords(keywords)
 				.build();
+	}
+
+	private List<String> safeImageUrls() {
+		if (imageUrls == null) return List.of();
+		return imageUrls.stream().filter(s -> !s.isBlank()).toList();
+	}
+
+	private String getFirstImageUrl() {
+		List<String> imgs = safeImageUrls();
+		if (imgs.isEmpty())
+			return null;
+		return imgs.getFirst();
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/entity/ReviewDetails.java
+++ b/src/main/java/JJinBBang/app/domain/building/entity/ReviewDetails.java
@@ -34,4 +34,8 @@ public class ReviewDetails {
 	private Integer imageCount;
 
 	private Keywords keywords;
+
+	public boolean hasImages() {
+		return images != null && !images.isEmpty();
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -186,7 +186,8 @@ public class ReviewServiceImpl implements ReviewService {
         building.addRating(saved.getRating());
 
         // 4.3) 이미지 카운트 반영
-		building.incrementImagesCount();
+		if (details.hasImages())
+			building.incrementImagesCount();
 
         // 4.4) 건물 유형 업데이트
 		building.addBuildingType(dto.buildingRequest().type());
@@ -239,7 +240,9 @@ public class ReviewServiceImpl implements ReviewService {
         building.addRating(saved.getRating());
 
         // 6.3) 이미지 카운트 반영
-		building.incrementImagesCount();
+		if (details.hasImages()) {
+			building.incrementImagesCount();
+		}
 
         // 6.4) 건물 엔티티 저장
         buildingsRepository.save(building);
@@ -286,7 +289,7 @@ public class ReviewServiceImpl implements ReviewService {
 		agency.addRating(saved.getRating());
 
 		// 4.3) 이미지 카운트 반영
-		if (details.getImages() != null && !details.getImages().isEmpty()) {
+		if (details.hasImages()) {
 			agency.incrementImagesCount();
 		}
 
@@ -443,15 +446,13 @@ public class ReviewServiceImpl implements ReviewService {
 
 		// 2) 건물 변경 여부 판단
 		if (!oldBuilding.getBuildingCode().equals(newBuilding.getBuildingCode())) {
-			// a) 이전 건물: 평점 제거, 이미지 감소, 키워드 통계 감소
+			// a) 이전 건물: 평점 제거, 키워드 통계 감소
 			oldBuilding.removeRating(oldReview.getRating());
-			oldBuilding.decrementImagesCount();
 			updateKeywordCounts(oldBuilding.getId(), false, oldDetails.getKeywords().positive(),
 				Collections.emptyList());
 
-			// b) 신규 건물: 평점 추가, 이미지 증가, 키워드 통계 증가
+			// b) 신규 건물: 평점 추가, 키워드 통계 증가
 			newBuilding.addRating(dto.generalReview().getRating());
-			newBuilding.incrementImagesCount();
 			updateKeywordCounts(newBuilding.getId(), false, Collections.emptyList(), dto.keywords().positive());
 
 			// c) 리뷰 엔티티 및 상세 정보 갱신 저장
@@ -459,6 +460,10 @@ public class ReviewServiceImpl implements ReviewService {
 			reviewsRepository.save(updatedReview);
 			ReviewDetails updatedDetails = dto.toUpdatedReviewDetails(oldDetails, newBuilding.getId());
 			reviewDetailsRepository.save(updatedDetails);
+
+			// 이미지 변경 처리
+			if (oldDetails.hasImages()) oldBuilding.decrementImagesCount();
+			if (updatedDetails.hasImages()) newBuilding.incrementImagesCount();
 
 			// 삭제할 이미지 삭제
 			deleteRemovedImages(oldDetails.getImages(), updatedDetails.getImages());
@@ -481,10 +486,17 @@ public class ReviewServiceImpl implements ReviewService {
 				dto.keywords().positive());
 
 			// b) 리뷰 엔티티 및 상세 정보 갱신 저장
-			GeneralReviews updatedReview = dto.toUpdatedGeneralReviews(oldReview, newBuilding);
+			GeneralReviews updatedReview = dto.toUpdatedGeneralReviews(oldReview, oldBuilding);
 			reviewsRepository.save(updatedReview);
-			ReviewDetails updatedDetails = dto.toUpdatedReviewDetails(oldDetails, newBuilding.getId());
+			ReviewDetails updatedDetails = dto.toUpdatedReviewDetails(oldDetails, oldBuilding.getId());
 			reviewDetailsRepository.save(updatedDetails);
+
+			// 이미지 증감 반영
+			boolean oldHas = oldDetails.hasImages();
+			boolean nowHas = updatedDetails.hasImages();
+			if (!oldHas && nowHas) oldBuilding.incrementImagesCount();
+			else if (oldHas && !nowHas) oldBuilding.decrementImagesCount();
+
 			// 삭제할 이미지 삭제
 			deleteRemovedImages(oldDetails.getImages(), updatedDetails.getImages());
 
@@ -500,14 +512,19 @@ public class ReviewServiceImpl implements ReviewService {
 	}
 
 	/**
-	 * 기숙사 리뷰 업데이트 로직:
+	 * 기숙사 리뷰 업데이트 로직
 	 * 1) 캠퍼스 검증 및 조회
 	 * 2) 기존/신규 건물 엔티티 로드
 	 * 3) 기존 상세 정보 로드
-	 * 4) 건물 변경 시 평점·이미지·키워드 이동, 동일 건물 시 업데이트
-	 * 5) 리뷰 엔티티 갱신 저장
-	 * 6) 기존 시설 삭제 후 재생성과 저장
-	 * 7) 상세 정보 갱신 저장
+	 * 4) 건물 변경 여부 판단(moved)
+	 *    - moved = true  : 이전 건물 평점/키워드 감소, 신규 건물 평점/키워드 증가
+	 *    - moved = false : 동일 건물 평점/키워드 갱신
+	 * 5) 리뷰 엔티티 및 상세 정보 갱신 저장
+	 * 6) 시설 정보 재설정(기존 삭제 후 요청 기준으로 재생성)
+	 * 7) 이미지 변경 사항 비교 후 이미지 카운트 정확 조정 (null-safe)
+	 *    - moved = true  : oldHas면 이전 건물 decrement, nowHas면 신규 건물 increment
+	 *    - moved = false : (없→있) increment, (있→없) decrement
+	 * 8) 삭제된 이미지 S3 정리(old - new 차집합 삭제)
 	 */
 	private void updateDormitoryReview(DormReviews oldReview, ReviewRequest dto) {
 		// 1) 캠퍼스 검증
@@ -516,31 +533,26 @@ public class ReviewServiceImpl implements ReviewService {
 
 		// 2) 건물 엔티티 로드
 		Buildings oldBuilding = oldReview.getBuilding();
-		Buildings newBuilding = findOrCreateBuilding(dto.buildingRequest(), campus);
+		Buildings newBuilding = findOrCreateDormitory(dto.buildingRequest(), campus);
 
 		// 3) 기존 상세 정보 로드
 		ReviewDetails oldDetails = reviewDetailsRepository.findByReviewId(oldReview.getId())
 			.orElseThrow(ReviewInternalServerErrorException::missingReviewDetailException);
 
-		// 4) 건물 변경 처리
-		if (!oldBuilding.getBuildingCode().equals(newBuilding.getBuildingCode())) {
-			// a) 이전 건물 통계 감소
-			oldBuilding.removeRating(oldReview.getRating());
-			oldBuilding.decrementImagesCount();
-			updateKeywordCounts(oldBuilding.getId(), false, oldDetails.getKeywords().positive(),
-				Collections.emptyList());
+		boolean moved = !oldBuilding.getBuildingCode().equals(newBuilding.getBuildingCode());
 
-			// b) 신규 건물 통계 증가
+		if (moved) {
+			// a) 이전 건물 통계 감소(평점/키워드) ― 이미지 카운트는 나중에 old/new 비교로 처리
+			oldBuilding.removeRating(oldReview.getRating());
+			updateKeywordCounts(oldBuilding.getId(), false, oldDetails.getKeywords().positive(), Collections.emptyList());
+
+			// b) 신규 건물 통계 증가(평점/키워드)
 			newBuilding.addRating(dto.dormitoryReview().getRating());
-			newBuilding.incrementImagesCount();
 			updateKeywordCounts(newBuilding.getId(), false, Collections.emptyList(), dto.keywords().positive());
-			buildingsRepository.saveAll(List.of(oldBuilding, newBuilding));
 		} else {
-			// 동일 건물: 평점·키워드 업데이트
+			// 동일 건물: 평점·키워드만 선반영
 			oldBuilding.updateRating(oldReview.getRating(), dto.dormitoryReview().getRating());
-			updateKeywordCounts(oldBuilding.getId(), false, oldDetails.getKeywords().positive(),
-				dto.keywords().positive());
-			buildingsRepository.save(oldBuilding);
+			updateKeywordCounts(oldBuilding.getId(), false, oldDetails.getKeywords().positive(), dto.keywords().positive());
 		}
 
 		// 5) 리뷰 엔티티 갱신 저장
@@ -556,7 +568,23 @@ public class ReviewServiceImpl implements ReviewService {
 		ReviewDetails updatedDetails = dto.toUpdatedReviewDetails(oldDetails, newBuilding.getId());
 		reviewDetailsRepository.save(updatedDetails);
 
-		// 삭제할 이미지 삭제
+		boolean oldHas = oldDetails.getImages() != null && !oldDetails.getImages().isEmpty();
+		boolean nowHas = updatedDetails.getImages() != null && !updatedDetails.getImages().isEmpty();
+
+		if (moved) {
+			if (oldHas) oldBuilding.decrementImagesCount();
+			if (nowHas) newBuilding.incrementImagesCount();
+			buildingsRepository.saveAll(List.of(oldBuilding, newBuilding));
+		} else {
+			if (!oldHas && nowHas) {
+				oldBuilding.incrementImagesCount();
+			} else if (oldHas && !nowHas) {
+				oldBuilding.decrementImagesCount();
+			}
+			buildingsRepository.save(oldBuilding);
+		}
+
+		// 삭제할 이미지 실제 삭제 (old - new)
 		deleteRemovedImages(oldDetails.getImages(), updatedDetails.getImages());
 	}
 
@@ -662,15 +690,18 @@ public class ReviewServiceImpl implements ReviewService {
         // b)평점 제거
         building.removeRating(review.getRating());
 
-        // c)이미지 카운트 감소
-		building.decrementImagesCount();
+   		if (detail.hasImages()) {
+			building.decrementImagesCount();
+		}
 
         // d)키워드 통계 감소
         updateKeywordCounts(building.getId(), false,
                 detail.getKeywords().positive(), Collections.emptyList());
 
 		// 리뷰 데이터 삭제
-		detail.getImages().forEach(s3Service::deleteFile);
+		if (detail.hasImages()) {
+			detail.getImages().forEach(s3Service::deleteFile);
+		}
 
 		// e)연관 데이터 삭제
 		reviewDetailsRepository.delete(detail);
@@ -698,7 +729,8 @@ public class ReviewServiceImpl implements ReviewService {
         // 평점 제거
         building.removeRating(review.getRating());
         // 이미지 카운트 감소
-		building.decrementImagesCount();
+		if (detail.hasImages())
+			building.decrementImagesCount();
 
         // 키워드 통계 감소
         updateKeywordCounts(building.getId(), false,
@@ -709,7 +741,8 @@ public class ReviewServiceImpl implements ReviewService {
         dormitoryFacilitiesRepository.deleteAllByDormitoryReview(review);
 
 		// 리뷰 데이터 삭제
-		detail.getImages().forEach(s3Service::deleteFile);
+		if (detail.hasImages())
+			detail.getImages().forEach(s3Service::deleteFile);
 
 		// e)연관 데이터 삭제
 		reviewDetailsRepository.delete(detail);
@@ -733,7 +766,7 @@ public class ReviewServiceImpl implements ReviewService {
         // b) 평점 제거
         agency.removeRating(review.getRating());
         // 이미지 카운트 감소
-		if (detail.getImages() != null && !detail.getImages().isEmpty()) {
+		if (detail.hasImages()) {
 			agency.decrementImagesCount();
 		}
 
@@ -743,7 +776,7 @@ public class ReviewServiceImpl implements ReviewService {
         agenciesRepository.save(agency);
 
 		// 리뷰 데이터 삭제
-		if (detail.getImages() != null) {
+		if (detail.hasImages()) {
 			detail.getImages().forEach(s3Service::deleteFile);
 		}
 


### PR DESCRIPTION
## 📌 이슈 번호

* #238

## 💬 리뷰 포인트

* 이미지 필수 -> 옵션 변경했습니다
* 리뷰 요청에서 이미지 유효성 검사는 null 검사만 합니다. 빈 배열이 와도 괜찮습니다.
* 썸네일·이미지카운트·S3 삭제가 **이미지 있을 때만** 동작하도록 수정했습니다

## 🚀 상세 설명

### 1) 리뷰 요청(ReviewRequest) 이미지 유효성: **Null만 검사(빈 배열 허용)**

* 이미지 개수 검증(`isImageCountValid()`)을 제거하여 최소/최대 장수 제한을 없앴습니다.
* `imageUrls`는 `@NotNull`만 유지합니다. 즉, 빈 배열 `[]`은 허용되고 `null`만 금지됩니다.
* `safeImageUrls()` 메서드를 추가해 `null/blank` 항목을 제거하고, `imageCount`는 `safeImageUrls().size()`로 계산합니다.
* 썸네일은 `getFirstImageUrl()`로 결정하며, 유효 이미지가 없으면 `null`을 저장합니다. 모든 `toXXXReviews()`/`toUpdatedXXXReviews()`에 동일하게 적용했습니다.

### 2) ReviewServiceImpl에서 썸네일·이미지카운트·S3 삭제는 **이미지 있을 때만** 처리

* 썸네일은 항상 `getFirstImageUrl()` 결과를 사용하며, 유효 이미지가 없으면 `null`로 남깁니다.
* 이미지 카운트 증감은 `ReviewDetails.hasImages()` 및 이전/현재 이미지 존재 여부 비교를 통해서만 수행합니다.

  * 대상(건물/중개사)이 변경되면, 이전 대상이 가진 이미지를 이전 대상에서 삭제 후 신규 대상에서 추가시킵니다.
* S3 삭제는 `deleteRemovedImages(old, new)`로 변경 전 이미지와 변경 후 이미지를 비교하여 삭제된 이미지만 s3에서 삭제합니다

## 📸 스크린샷

<img width="1148" height="666" alt="스크린샷 2025-10-13 155751" src="https://github.com/user-attachments/assets/171ff3e9-c8a9-4561-8016-700b6c5df513" />
<p align="center"><em>리뷰 작성</em></p>

<img width="1138" height="629" alt="스크린샷 2025-10-13 155820" src="https://github.com/user-attachments/assets/58ae7c04-5124-4865-911a-25f3edd86406" />
<p align="center"><em>리뷰 수정</em></p>

<img width="1154" height="627" alt="스크린샷 2025-10-13 155833" src="https://github.com/user-attachments/assets/ff12c963-8360-4bc9-8190-ff274a5109c0" />
<p align="center"><em>리뷰 삭제</em></p>

## 📢 노트


* 이미지 업로드는 선택 사항. 유효 이미지가 있을 때만 썸네일/카운트가 반영됩니다.
