### PR TITLE
[FIX #265] 복합키(EmbeddedId)를 사용하는 엔티티의 Repository ID 타입 불일치 문제 해결

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/repository/AgencyLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/AgencyLikesRepository.java
@@ -1,16 +1,17 @@
 package JJinBBang.app.domain.building.repository;
 
 import JJinBBang.app.domain.building.entity.Agencies;
+import JJinBBang.app.domain.building.entity.AgencyLikeId;
 import JJinBBang.app.domain.building.entity.AgencyLikes;
 import JJinBBang.app.domain.user.entity.Users;
 
 import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface AgencyLikesRepository extends CrudRepository<AgencyLikes, Long> {
+public interface AgencyLikesRepository extends JpaRepository<AgencyLikes, AgencyLikeId> {
     Optional<AgencyLikes> findByAgencyAndUser(Agencies agency, Users user);
 
     Boolean existsByAgencyAndUser(Agencies agencies, Users users);

--- a/src/main/java/JJinBBang/app/domain/building/repository/DormitoryFacilitiesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/DormitoryFacilitiesRepository.java
@@ -1,11 +1,12 @@
 package JJinBBang.app.domain.building.repository;
 
+import JJinBBang.app.domain.building.entity.DormFacilityId;
 import JJinBBang.app.domain.building.entity.DormReviews;
 import JJinBBang.app.domain.building.entity.DormitoryFacilities;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface DormitoryFacilitiesRepository extends JpaRepository<DormitoryFacilities, Long> {
+public interface DormitoryFacilitiesRepository extends JpaRepository<DormitoryFacilities, DormFacilityId> {
     void deleteAllByDormitoryReview(DormReviews oldReview);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/ReviewLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/ReviewLikesRepository.java
@@ -1,16 +1,17 @@
 package JJinBBang.app.domain.building.repository;
 
+import JJinBBang.app.domain.building.entity.ReviewLikeId;
 import JJinBBang.app.domain.building.entity.ReviewLikes;
 import JJinBBang.app.domain.building.entity.Reviews;
 import JJinBBang.app.domain.user.entity.Users;
 
 import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface ReviewLikesRepository extends CrudRepository<ReviewLikes, Long> {
+public interface ReviewLikesRepository extends JpaRepository<ReviewLikes, ReviewLikeId> {
     Optional<ReviewLikes> findByReviewAndUser(Reviews reviews, Users user);
     Optional<ReviewLikes> findByReviewIdAndUserUserId(Long reviewId, Long userId);
     Boolean existsByReviewAndUser(Reviews reviews, Users user);


### PR DESCRIPTION
## 📌 이슈 번호
- #265 

## 💬 리뷰 포인트
- 복합키를 사용하는 엔티티들의 Repository ID 타입을 `Long` → 임베디드 ID 클래스로 수정했습니다.

## 🚀 상세 설명
- `AgencyLikesRepository`
  - `JpaRepository<AgencyLikes, AgencyLikeId>` 로 변경
- `DormitoryFacilitiesRepository`
  - `JpaRepository<DormitoryFacilities, DormFacilityId>` 로 변경
- `ReviewLikesRepository`
  - `JpaRepository<ReviewLikes, ReviewLikeId>` 로 변경


## 📸 스크린샷

## 📢 노트
