### PR TITLE
[FEAT #262] 상호명으로 개설등록번호 조회 API 구현

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/config/VWorldConfig.java
+++ b/src/main/java/JJinBBang/app/domain/building/config/VWorldConfig.java
@@ -1,0 +1,29 @@
+package JJinBBang.app.domain.building.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class VWorldConfig {
+	@Value("${vworld.geocode.core-pool-size:4}")
+	private int geocodeCorePoolSize;
+	@Value("${vworld.geocode.max-pool-size:4}")
+	private int geocodeMaxPoolSize;
+	@Value("${vworld.geocode.queue-capacity:100}")
+	private int geocodeQueueCapacity;
+
+	@Bean
+	public Executor geocodeExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(geocodeCorePoolSize);   // 1 vCPU 기준 시작은 4개 정도면 적당
+		executor.setMaxPoolSize(geocodeMaxPoolSize);
+		executor.setQueueCapacity(geocodeQueueCapacity);
+		executor.setThreadNamePrefix("geocode-");
+		executor.initialize();
+		return executor;
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/controller/AgencyController.java
+++ b/src/main/java/JJinBBang/app/domain/building/controller/AgencyController.java
@@ -1,0 +1,36 @@
+package JJinBBang.app.domain.building.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import JJinBBang.app.domain.building.dto.AgencySearchRequest;
+import JJinBBang.app.domain.building.dto.AgencySearchResponse;
+import JJinBBang.app.domain.building.service.AgencyService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/agency")
+@RequiredArgsConstructor
+public class AgencyController {
+
+	private final AgencyService agencyService;
+
+	/**
+	 * 공인중개사 상호 검색
+	 * GET /api/v1/building/agency/search?agencyName={agencyName}&num={num}&page={page}
+	 * @param request AgencySearchRequest
+	 * @return ResponseEntity<AgencySearchResponse>
+	 */
+	@GetMapping("/search")
+	public ResponseEntity<AgencySearchResponse> searchAgencyList(
+		@Valid AgencySearchRequest request
+	) {
+		 AgencySearchResponse response = agencyService.getAgencyList(request);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/AgencySearchItem.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/AgencySearchItem.java
@@ -1,0 +1,35 @@
+package JJinBBang.app.domain.building.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AgencySearchItem(
+	String registerNumber, // 개설등록번호
+	String companyName, // 상호명
+	String brokerName, // 중개사명
+	String roadAddress, // 도로명주소
+	String jibunAddress, // 지번주소
+	Double latitude, // 위도
+	Double longitude // 경도
+) {
+
+	public static AgencySearchItem of (
+		String registerNumber,
+		String companyName,
+		String brokerName,
+		String roadAddress,
+		String jibunAddress,
+		Double latitude,
+		Double longitude
+	) {
+		return AgencySearchItem.builder()
+			.registerNumber(registerNumber)
+			.companyName(companyName)
+			.brokerName(brokerName)
+			.roadAddress(roadAddress)
+			.jibunAddress(jibunAddress)
+			.latitude(latitude)
+			.longitude(longitude)
+			.build();
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/AgencySearchRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/AgencySearchRequest.java
@@ -1,0 +1,23 @@
+package JJinBBang.app.domain.building.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record AgencySearchRequest(
+	@NotBlank(message = "agencyName은 비어 있을 수 없습니다.")
+	String agencyName, // 공인중개사 상호명, 필수값
+	@Min(1)	@Max(10)
+	Integer num, // 한 페이지당 검색 건수 기본값 10
+	Integer page // 페이지 번호 1부터 시작
+) {
+
+	public AgencySearchRequest {
+		if (num == null) {
+			num = 10;      // 기본 num
+		}
+		if (page == null || page < 1) {
+			page = 1;      // 기본 page
+		}
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/AgencySearchResponse.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/AgencySearchResponse.java
@@ -1,0 +1,23 @@
+package JJinBBang.app.domain.building.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record AgencySearchResponse(
+	List<AgencySearchItem> items,
+	Integer num,
+	Integer page,
+	Integer totalCount
+) {
+
+	public static AgencySearchResponse of(List<AgencySearchItem> items, Integer num, Integer page, Integer totalCount) {
+		return AgencySearchResponse.builder()
+			.items(items)
+			.num(num)
+			.page(page)
+			.totalCount(totalCount)
+			.build();
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/VWorldAddressToCoordRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/VWorldAddressToCoordRequest.java
@@ -1,0 +1,87 @@
+package JJinBBang.app.domain.building.dto;
+
+import org.springframework.util.MultiValueMap;
+
+import lombok.Builder;
+
+/**
+ * vworld Geocoder API (주소 → 좌표, getCoord)의 요청 파라미터 DTO.
+ * 이걸 가지고 쿼리스트링을 만들어서 호출하면 됨.
+ */
+@Builder
+public record VWorldAddressToCoordRequest(
+	String service,      // 기본값: "address"
+	String version,      // 기본값: "2.0"
+	String request,      // 기본값: "GetCoord" 또는 "getCoord"
+	String format,       // 기본값: "json"
+	String errorFormat,  // 생략 가능 (null이면 format과 동일)
+	String type,         // "ROAD" (도로명) 또는 "PARCEL" (지번) (필수)
+	String address,      // 검색할 주소 문자열 (필수)
+	Boolean refine,      // 기본값: true
+	Boolean simple,      // 기본값: false
+	String crs,          // 기본값: "epsg:4326"
+	String callback      // JSONP 쓸 때만, 보통 null
+) {
+
+	/**
+	 * 도로명주소용 편의 팩토리.
+	 * - service=address
+	 * - version=2.0
+	 * - request=getCoord
+	 * - format=json
+	 * - refine=true
+	 * - simple=false
+	 * - crs=epsg:4326
+	 */
+	public static VWorldAddressToCoordRequest road(String address) {
+		return VWorldAddressToCoordRequest.builder()
+			.service("address")
+			.version("2.0")
+			.request("getCoord")
+			.format("json")
+			.type("ROAD")
+			.address(address)
+			.refine(true)
+			.simple(false)
+			.crs("epsg:4326")
+			.build();
+	}
+
+	/**
+	 * 지번주소용 편의 팩토리 (type=PARCEL).
+	 */
+	public static VWorldAddressToCoordRequest parcel(String address) {
+		return VWorldAddressToCoordRequest.builder()
+			.service("address")
+			.version("2.0")
+			.request("getCoord")
+			.format("json")
+			.type("PARCEL")
+			.address(address)
+			.refine(true)
+			.simple(false)
+			.crs("epsg:4326")
+			.build();
+	}
+
+	public MultiValueMap<String, String> toQueryParams(String apiKey) {
+		MultiValueMap<String, String> map = new org.springframework.util.LinkedMultiValueMap<>();
+		map.add("service", service);
+		map.add("version", version);
+		map.add("request", request);
+		map.add("key", apiKey);
+		map.add("format", format);
+		if (errorFormat != null) {
+			map.add("errorFormat", errorFormat);
+		}
+		map.add("type", type);
+		map.add("address", address);
+		map.add("refine", refine.toString());
+		map.add("simple", simple.toString());
+		map.add("crs", crs);
+		if (callback != null) {
+			map.add("callback", callback);
+		}
+		return map;
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/VWorldAddressToCoordResponse.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/VWorldAddressToCoordResponse.java
@@ -1,0 +1,131 @@
+package JJinBBang.app.domain.building.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VWorldAddressToCoordResponse(
+
+	@JsonProperty("response")
+	Body response   // ← 안쪽 진짜 payload
+
+) {
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Body(
+		@JsonProperty("service")
+		Service service,
+
+		@JsonProperty("status")
+		String status,          // OK / NOT_FOUND / ERROR
+
+		@JsonProperty("input")
+		Input input,            // simple=true면 생략될 수 있음
+
+		@JsonProperty("refined")
+		Refined refined,        // refine=false 또는 simple=true면 생략될 수 있음
+
+		@JsonProperty("result")
+		Result result,          // 정상일 때 좌표 정보
+
+		@JsonProperty("error")
+		Error error             // status=ERROR일 때만 존재
+	) {
+
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Service(
+		@JsonProperty("name")
+		String name,
+
+		@JsonProperty("version")
+		String version,
+
+		@JsonProperty("operation")
+		String operation,
+
+		@JsonProperty("time")
+		String time
+	) {
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Input(
+		@JsonProperty("type")
+		String type,      // ROAD / PARCEL
+		@JsonProperty("address")
+		String address
+	) {
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Refined(
+		@JsonProperty("text")
+		String text,      // 정제된 전체 주소 문자열
+		@JsonProperty("structure")
+		Structure structure
+	) {
+		@JsonIgnoreProperties(ignoreUnknown = true)
+		public record Structure(
+			@JsonProperty("level0")
+			String level0,   // 국가
+
+			@JsonProperty("level1")
+			String level1,   // 시·도
+
+			@JsonProperty("level2")
+			String level2,   // 시·군·구
+
+			@JsonProperty("level3")
+			String level3,   // (일반구)구
+
+			@JsonProperty("level4L")
+			String level4L,  // (도로) 도로명 / (지번) 법정동 명
+
+			@JsonProperty("level4A")
+			String level4A,  // (도로) 행정동 명
+
+			@JsonProperty("level4AC")
+			String level4AC, // (도로) 행정동 코드
+
+			@JsonProperty("level5")
+			String level5,   // (도로) 길 / (지번) 번지
+
+			@JsonProperty("detail")
+			String detail    // 상세주소
+		) {
+		}
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Result(
+		@JsonProperty("crs")
+		String crs,      // EPSG:4326 등
+
+		@JsonProperty("point")
+		Point point
+	) {
+		@JsonIgnoreProperties(ignoreUnknown = true)
+		public record Point(
+			@JsonProperty("x")
+			double x,      // 경도
+			@JsonProperty("y")
+			double y       // 위도
+		) {
+		}
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record Error(
+		@JsonProperty("level")
+		int level,
+
+		@JsonProperty("code")
+		String code,
+
+		@JsonProperty("text")
+		String text
+	) {
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/VWorldEBOfficeRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/VWorldEBOfficeRequest.java
@@ -1,0 +1,33 @@
+package JJinBBang.app.domain.building.dto;
+
+import org.springframework.util.MultiValueMap;
+
+import lombok.Builder;
+
+@Builder
+public record VWorldEBOfficeRequest(
+	String bsnmCmpnm, // 사업자상호
+	Integer numOfRows, // 검색건수
+	Integer pageNo, // 페이지번호
+	String format // 응답문서형식(xml, json)
+) {
+	public static VWorldEBOfficeRequest of(String agencyName, Integer num, Integer page) {
+		return VWorldEBOfficeRequest.builder()
+			.bsnmCmpnm(agencyName)
+			.numOfRows(num)
+			.pageNo(page)
+			.format("json")
+			.build();
+	}
+
+	public MultiValueMap<String, String> toQueryParams(String apiKey, String domain) {
+		MultiValueMap<String, String> map = new org.springframework.util.LinkedMultiValueMap<>();
+		map.add("bsnmCmpnm", bsnmCmpnm);
+		map.add("numOfRows", numOfRows.toString());
+		map.add("pageNo", pageNo.toString());
+		map.add("format", format);
+		map.add("key", apiKey);
+		map.add("domain", domain);
+		return map;
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/VWorldEBOfficeResponse.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/VWorldEBOfficeResponse.java
@@ -1,0 +1,112 @@
+package JJinBBang.app.domain.building.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record VWorldEBOfficeResponse(
+	@JsonProperty("EDOffices")
+	EDOffices edOffices,
+
+	@JsonProperty("response")
+	ResponseMeta response
+) {
+
+	/**
+	 * 레코드가 1개 이상일 때 내려오는 EDOffices 블록
+	 */
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record EDOffices(
+		@JsonProperty("field")
+		List<EDOfficeField> field,
+
+		@JsonProperty("pageNo")
+		Integer pageNo,
+
+		@JsonProperty("resultCode")
+		String resultCode,
+
+		@JsonProperty("totalCount")
+		Integer totalCount,
+
+		@JsonProperty("numOfRows")
+		Integer numOfRows,
+
+		@JsonProperty("resultMsg")
+		String resultMsg
+	) {
+	}
+
+	/**
+	 * 레코드가 0개일 때 내려오는 response 블록
+	 */
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record ResponseMeta(
+		@JsonProperty("pageNo")
+		Integer pageNo,
+
+		@JsonProperty("resultCode")
+		String resultCode,
+
+		@JsonProperty("totalCount")
+		Integer totalCount,
+
+		@JsonProperty("numOfRows")
+		Integer numOfRows,
+
+		@JsonProperty("resultMsg")
+		String resultMsg
+	) {
+	}
+
+	/**
+	 * 실제 중개사무소 한 건 (EDOffices.field 의 원소)
+	 */
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public record EDOfficeField(
+		@JsonProperty("jurirno") // 등록번호
+		String jurirno,
+
+		@JsonProperty("brkrNm") // 중개업자명
+		String brkrNm,
+
+		@JsonProperty("ldCode") // 시군구코드
+		String ldCode,
+
+		@JsonProperty("ldCodeNm") // 시군구명
+		String ldCodeNm,
+
+		@JsonProperty("registDe") // 등록일자
+		String registDe,
+
+		@JsonProperty("sttusSeCodeNm") // 상태구분명
+		String sttusSeCodeNm,
+
+		@JsonProperty("rdnmadrcode") // 도로명주소코드
+		String rdnmadrcode,
+
+		@JsonProperty("mnnmadr") // 지번주소
+		String mnnmadr,
+
+		@JsonProperty("rdnmadr") // 도로명주소
+		String rdnmadr,
+
+		@JsonProperty("estbsBeginDe") // 보증설정시작일
+		String estbsBeginDe,
+
+		@JsonProperty("lastUpdtDt") // 데이터기준일자
+		String lastUpdtDt,
+
+		@JsonProperty("estbsEndDe") // 보증설정종료일
+		String estbsEndDe,
+
+		@JsonProperty("sttusSeCode") // 상태구분코드
+		String sttusSeCode,
+
+		@JsonProperty("bsnmCmpnm") // 사업자상호
+		String bsnmCmpnm
+	) {
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/VWorldWfsRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/VWorldWfsRequest.java
@@ -8,7 +8,7 @@ import org.springframework.util.MultiValueMap;
 import lombok.Builder;
 
 @Builder
-public record VWorldRequest(
+public record VWorldWfsRequest(
 	String request,     // 요청 서비스 오퍼레이션 (GetFeature, GetFeatureType)
 	String key,			// 발급받은 api key
 	Integer size,      	// 한 페이지에 출력될 응답결과 건수	(숫자, default(10), min(1), max(1000))
@@ -19,12 +19,12 @@ public record VWorldRequest(
 ) {
 
 	/** 기본값을 채운 빌더성 팩토리 */
-	public static VWorldRequest of(
+	public static VWorldWfsRequest of(
 		String apiKey,
 		String geomFilter,
 		Integer buffer
 	) {
-		return new VWorldRequest(
+		return new VWorldWfsRequest(
 			"GetFeature",
 			Objects.requireNonNull(apiKey),
 			1000,
@@ -36,7 +36,7 @@ public record VWorldRequest(
 	}
 
 	/** 포인트 + 버퍼(m)로 조회 (경위도 순서: lon, lat) */
-	public static VWorldRequest byPoint(String apiKey, double lon, double lat, int bufferMeters) {
+	public static VWorldWfsRequest byPoint(String apiKey, double lon, double lat, int bufferMeters) {
 		String gf = "POINT(" + lon + " " + lat + ")";
 		return of(apiKey, gf, bufferMeters);
 	}

--- a/src/main/java/JJinBBang/app/domain/building/dto/VWorldWfsResponse.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/VWorldWfsResponse.java
@@ -5,7 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /** vworld 2D Data API - 도로명주소 건물(spbd) 응답 DTO */
-public record VWorldResponse(
+public record VWorldWfsResponse(
 	@JsonProperty("response") Response response
 ) {
 

--- a/src/main/java/JJinBBang/app/domain/building/exception/AgencyInternalServerErrorException.java
+++ b/src/main/java/JJinBBang/app/domain/building/exception/AgencyInternalServerErrorException.java
@@ -1,0 +1,11 @@
+package JJinBBang.app.domain.building.exception;
+
+public class AgencyInternalServerErrorException extends RuntimeException {
+	public AgencyInternalServerErrorException(String message) {
+		super(message);
+	}
+
+	public static AgencyInternalServerErrorException getAgencyInternalServerError() {
+		return new AgencyInternalServerErrorException("공인중개사 조회 작업 중 내부 서버 오류가 발생했습니다.");
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/exception/AgencyServiceUnavailableException.java
+++ b/src/main/java/JJinBBang/app/domain/building/exception/AgencyServiceUnavailableException.java
@@ -1,0 +1,14 @@
+package JJinBBang.app.domain.building.exception;
+
+
+import JJinBBang.app.global.error.exception.ServiceUnavailableGroupException;
+
+public class AgencyServiceUnavailableException extends ServiceUnavailableGroupException {
+	public AgencyServiceUnavailableException(String message) {
+		super(message);
+	}
+
+	public static AgencyServiceUnavailableException getAgencyServiceOverloaded() {
+		return new AgencyServiceUnavailableException("공인중개사 조회 작업이 과부화되었습니다. 잠시 후 다시 시도해주세요.");
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/infra/VWorldApiClient.java
+++ b/src/main/java/JJinBBang/app/domain/building/infra/VWorldApiClient.java
@@ -1,7 +1,15 @@
 package JJinBBang.app.domain.building.infra;
 
-import JJinBBang.app.domain.building.dto.VWorldResponse;
+import JJinBBang.app.domain.building.dto.VWorldAddressToCoordRequest;
+import JJinBBang.app.domain.building.dto.VWorldAddressToCoordResponse;
+import JJinBBang.app.domain.building.dto.VWorldEBOfficeRequest;
+import JJinBBang.app.domain.building.dto.VWorldEBOfficeResponse;
+import JJinBBang.app.domain.building.dto.VWorldWfsResponse;
 
 public interface VWorldApiClient {
-	VWorldResponse searchByPoint(Double longitude, Double latitude);
+	VWorldWfsResponse searchBuildingByPoint(Double longitude, Double latitude);
+
+	VWorldEBOfficeResponse searchAgencies(VWorldEBOfficeRequest vWorldRequest);
+
+	VWorldAddressToCoordResponse geocode(VWorldAddressToCoordRequest request);
 }

--- a/src/main/java/JJinBBang/app/domain/building/infra/VWorldApiClientImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/infra/VWorldApiClientImpl.java
@@ -1,14 +1,19 @@
 package JJinBBang.app.domain.building.infra;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import JJinBBang.app.domain.building.dto.VWorldRequest;
-import JJinBBang.app.domain.building.dto.VWorldResponse;
+import JJinBBang.app.domain.building.dto.VWorldAddressToCoordRequest;
+import JJinBBang.app.domain.building.dto.VWorldAddressToCoordResponse;
+import JJinBBang.app.domain.building.dto.VWorldEBOfficeRequest;
+import JJinBBang.app.domain.building.dto.VWorldEBOfficeResponse;
+import JJinBBang.app.domain.building.dto.VWorldWfsRequest;
+import JJinBBang.app.domain.building.dto.VWorldWfsResponse;
 
 @Component
 public class VWorldApiClientImpl implements VWorldApiClient {
@@ -19,27 +24,55 @@ public class VWorldApiClientImpl implements VWorldApiClient {
 	private String apiKey;
 	@Value("${vworld.buffer-meter:5}")
 	private Integer bufferMeter;
+	@Value("${vworld.domain}")
+	private String domain;
 
 	@Override
-	public VWorldResponse searchByPoint(Double longitude, Double latitude) {
-		VWorldRequest request = VWorldRequest.byPoint(
+	public VWorldWfsResponse searchBuildingByPoint(Double longitude, Double latitude) {
+		VWorldWfsRequest request = VWorldWfsRequest.byPoint(
 			apiKey,
 			longitude,
 			latitude,
 			bufferMeter
 		);
 
-		return search(request);
+		return searchWfs(request);
 	}
 
-	private VWorldResponse search(VWorldRequest request) {
+	@Override
+	public VWorldEBOfficeResponse searchAgencies(VWorldEBOfficeRequest vWorldRequest) {
 		RestTemplate restTemplate = new RestTemplate();
 
-		URI uri = UriComponentsBuilder.fromUriString(this.baseUrl)
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUrl+"/ned/data/getEBOfficeInfo")
+			.queryParams(vWorldRequest.toQueryParams(apiKey, domain))
+			.build()
+			.encode(StandardCharsets.UTF_8)          // ✅ 한글 쿼리 파라미터 인코딩
+			.toUri();
+
+		return restTemplate.getForObject(uri, VWorldEBOfficeResponse.class);
+	}
+
+	@Override
+	public VWorldAddressToCoordResponse geocode(VWorldAddressToCoordRequest request) {
+		RestTemplate restTemplate = new RestTemplate();
+
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUrl+"/req/address")
+			.queryParams(request.toQueryParams(apiKey))
+			.build()
+			.encode(StandardCharsets.UTF_8)          // ✅ 한글 쿼리 파라미터 인코딩
+			.toUri();
+
+		return restTemplate.getForObject(uri, VWorldAddressToCoordResponse.class);
+	}
+
+	private VWorldWfsResponse searchWfs(VWorldWfsRequest request) {
+		RestTemplate restTemplate = new RestTemplate();
+
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUrl+"/req/data")
 			.queryParams(request.toQueryParams())
 			.build()
 			.toUri();
 
-		return restTemplate.getForObject(uri, VWorldResponse.class);
+		return restTemplate.getForObject(uri, VWorldWfsResponse.class);
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/AgencyService.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/AgencyService.java
@@ -1,8 +1,12 @@
 package JJinBBang.app.domain.building.service;
 
+import JJinBBang.app.domain.building.dto.AgencySearchRequest;
+import JJinBBang.app.domain.building.dto.AgencySearchResponse;
 import JJinBBang.app.domain.building.dto.BuildingDetailResponse;
 import JJinBBang.app.domain.user.entity.Users;
 
 public interface AgencyService {
     BuildingDetailResponse getAgencyDetail(Long buildingId, Users user);
+
+	AgencySearchResponse getAgencyList(AgencySearchRequest request);
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/AgencyServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/AgencyServiceImpl.java
@@ -1,26 +1,43 @@
 package JJinBBang.app.domain.building.service;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import JJinBBang.app.domain.building.document.BuildingKeywordCounts;
+import JJinBBang.app.domain.building.dto.AgencySearchItem;
+import JJinBBang.app.domain.building.dto.AgencySearchRequest;
+import JJinBBang.app.domain.building.dto.AgencySearchResponse;
 import JJinBBang.app.domain.building.dto.BuildingDetailResponse;
 import JJinBBang.app.domain.building.dto.KeywordCount;
+import JJinBBang.app.domain.building.dto.VWorldAddressToCoordRequest;
+import JJinBBang.app.domain.building.dto.VWorldAddressToCoordResponse;
+import JJinBBang.app.domain.building.dto.VWorldEBOfficeRequest;
+import JJinBBang.app.domain.building.dto.VWorldEBOfficeResponse;
 import JJinBBang.app.domain.building.entity.Agencies;
+import JJinBBang.app.domain.building.exception.AgencyInternalServerErrorException;
+import JJinBBang.app.domain.building.exception.AgencyServiceUnavailableException;
 import JJinBBang.app.domain.building.exception.BuildingNullException;
+import JJinBBang.app.domain.building.infra.VWorldApiClient;
 import JJinBBang.app.domain.building.repository.AgenciesRepository;
 import JJinBBang.app.domain.building.repository.BuildingKeywordCountsRepository;
 import JJinBBang.app.domain.user.entity.Users;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class AgencyServiceImpl implements AgencyService{
     private final AgenciesRepository agenciesRepository;
     private final BuildingKeywordCountsRepository buildingKeywordCountRepository;
+	private final VWorldApiClient vWorldApiClient;
+	private final Executor geocodeExecutor;
 
     @Override
     @Transactional(readOnly = true)
@@ -56,4 +73,64 @@ public class AgencyServiceImpl implements AgencyService{
 
         return BuildingDetailResponse.ofAgency(agency, liked, top5Positive);
     }
+
+	@Override
+	public AgencySearchResponse getAgencyList(AgencySearchRequest request) {
+		// VWorld API 에서 중개사무소 정보 조회
+		VWorldEBOfficeRequest vWorldRequest = VWorldEBOfficeRequest.of(request.agencyName(), request.num(),
+			request.page());
+		VWorldEBOfficeResponse vWorldResponse = vWorldApiClient.searchAgencies(vWorldRequest);
+
+		VWorldEBOfficeResponse.EDOffices edOffices = vWorldResponse.edOffices();
+		// 중개사무소 정보가 없으면 빈 리스트 반환
+		if (edOffices == null) {
+			return AgencySearchResponse.of(new ArrayList<>(), request.num(), request.page(), 0);
+		}
+		// 각 중개사무소의 주소를 좌표로 변환하고 AgencySearchItem 생성
+		List<AgencySearchItem> items = getAgencySearchItems(edOffices);
+
+		return AgencySearchResponse.of(items, edOffices.numOfRows(), edOffices.pageNo(), edOffices.totalCount());
+	}
+
+	private List<AgencySearchItem> getAgencySearchItems(VWorldEBOfficeResponse.EDOffices edOffices) {
+		// 비동기 작업을 사용하여 각 중개사무소의 주소를 좌표로 변환
+		List<CompletableFuture<AgencySearchItem>> futures;
+		try {
+			futures = edOffices.field().stream()
+				.map(field -> CompletableFuture.supplyAsync(() -> {
+					// 지번주소를 좌표로 변환하는 VWorld API 호출
+					VWorldAddressToCoordRequest addressToCoordRequest = VWorldAddressToCoordRequest.parcel(
+						field.mnnmadr());
+					VWorldAddressToCoordResponse addressToCoordResponse = vWorldApiClient.geocode(
+						addressToCoordRequest);
+
+					// AgencySearchItem 생성
+					return AgencySearchItem.of(
+						field.jurirno(),
+						field.bsnmCmpnm(),
+						field.brkrNm(),
+						field.rdnmadr(),
+						field.mnnmadr(),
+						addressToCoordResponse.response().result().point().x(),
+						addressToCoordResponse.response().result().point().y()
+					);
+				}, geocodeExecutor))
+				.toList();
+		} catch (RejectedExecutionException e) {
+			// Executor가 작업을 수락하지 못하는 경우 처리
+			throw AgencyServiceUnavailableException.getAgencyServiceOverloaded();
+		}
+
+		List<AgencySearchItem> items;
+		try {
+			// 모든 비동기 작업이 완료될 때까지 대기하고 결과 수집
+			items = futures.stream()
+				.map(CompletableFuture::join)
+				.toList();
+		} catch (CompletionException e) {
+			// 비동기 작업 중 예외가 발생한 경우 처리
+			throw AgencyInternalServerErrorException.getAgencyInternalServerError();
+		}
+		return items;
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/BuildingCodeResolver.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BuildingCodeResolver.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import JJinBBang.app.domain.building.dto.VWorldResponse;
+import JJinBBang.app.domain.building.dto.VWorldWfsResponse;
 import JJinBBang.app.domain.building.entity.PlaceBuildingMap;
 import JJinBBang.app.domain.building.infra.VWorldApiClient;
 import JJinBBang.app.domain.building.repository.PlaceBuildingMapRepository;
@@ -95,7 +95,7 @@ public class BuildingCodeResolver {
 	 * VWorld API를 호출하여 건물 관리 번호를 조회합니다.
 	 * */
 	private String fetchBuildingCodeFromApi(Double longitude, Double latitude) {
-		VWorldResponse.Response response = vWorldApiClient.searchByPoint(longitude, latitude).response();
+		VWorldWfsResponse.Response response = vWorldApiClient.searchBuildingByPoint(longitude, latitude).response();
 
 		// API 호출 결과가 없으면, null 반환
 		if ("NOT_FOUND".equals(response.status())) {
@@ -109,8 +109,8 @@ public class BuildingCodeResolver {
 		}
 
 		// 가장 가까운 피처 선택
-		List<VWorldResponse.Feature> features = response.result().featureCollection().features();
-		VWorldResponse.Feature best = getClosestFeature(longitude, latitude, features);
+		List<VWorldWfsResponse.Feature> features = response.result().featureCollection().features();
+		VWorldWfsResponse.Feature best = getClosestFeature(longitude, latitude, features);
 
 		return best != null && best.properties() != null ? best.properties().bd_mgt_sn() : null;
 	}
@@ -119,9 +119,9 @@ public class BuildingCodeResolver {
 	 * 주어진 좌표(경도, 위도)에서 가장 가까운 피처를 선택합니다.
 	 * 피처가 좌표를 포함하면 즉시 반환하고, 포함하는 피처가 없으면 가장 가까운 피처를 반환합니다.
 	 * */
-	private VWorldResponse.Feature getClosestFeature(
+	private VWorldWfsResponse.Feature getClosestFeature(
 		Double longitude, Double latitude,
-		List<VWorldResponse.Feature> features) {
+		List<VWorldWfsResponse.Feature> features) {
 
 		// 피처 목록이 없으면 null 반환
 		if (features == null || features.isEmpty()) {
@@ -132,11 +132,11 @@ public class BuildingCodeResolver {
 		Point point = GF.createPoint(new Coordinate(longitude, latitude));
 
 		double minDistance = Double.MAX_VALUE;
-		VWorldResponse.Feature closestFeature = null;
+		VWorldWfsResponse.Feature closestFeature = null;
 
 		// 각 피처의 지오메트리를 확인하여 포함 여부 및 거리 계산
-		for (VWorldResponse.Feature feature : features) {
-			VWorldResponse.GeoJsonGeometry geo = feature.geometry();
+		for (VWorldWfsResponse.Feature feature : features) {
+			VWorldWfsResponse.GeoJsonGeometry geo = feature.geometry();
 			if (geo == null || geo.type() == null || geo.coordinates() == null) continue;
 
 			// GeoJSON 문자열을 Geometry 객체로 변환

--- a/src/main/java/JJinBBang/app/global/error/ControllerAdvice.java
+++ b/src/main/java/JJinBBang/app/global/error/ControllerAdvice.java
@@ -83,6 +83,12 @@ public class ControllerAdvice {
 		return createErrorResponse(e, HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
+	// 503, ServiceUnavailableGroupException
+	@ExceptionHandler({ServiceUnavailableGroupException.class})
+	public ResponseEntity<ErrorResponse> handleServiceUnavailable(RuntimeException e) {
+		return createErrorResponse(e, HttpStatus.SERVICE_UNAVAILABLE);
+	}
+
 	// 메서드 인자 문제 생겼을 때
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(

--- a/src/main/java/JJinBBang/app/global/error/exception/ServiceUnavailableGroupException.java
+++ b/src/main/java/JJinBBang/app/global/error/exception/ServiceUnavailableGroupException.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.global.error.exception;
+
+public class ServiceUnavailableGroupException extends RuntimeException {
+	public  ServiceUnavailableGroupException(String message) {
+		super(message);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -154,9 +154,14 @@ user:
     grace-days: 30 # 사용자가 탈퇴한 후, 해당 사용자의 데이터가 삭제되기까지의 기간 (일 단위)
 
 vworld:
-  base-url: https://api.vworld.kr/req/data
+  base-url: https://api.vworld.kr
   api-key: ${vworld.api-key}
   buffer-meter: 5 # 버퍼 영역 (단위: m)
+  domain: https://jjinbbang.kr
+  geocode:
+    core-pool-size: 4
+    max-pool-size: 4
+    queue-capacity: 100
 
 google:
   credentials:


### PR DESCRIPTION
## 📌 이슈 번호
- #262

## 💬 리뷰 포인트
- VWorld 중개사무소 검색 API 및 지오코딩 API 연동
- `/api/v1/agency/search` 엔드포인트 추가
- 공인중개사 검색 시 지오코딩을 `CompletableFuture + 전용 Executor`로  지오코딩 쓰레드풀 만들어서 요청 병렬 처리
- 서비스 과부하(지오코딩 풀 포화) / 내부 오류 상황을 각각 503 / 500으로 나눠 처리

## 🚀 상세 설명

### 1. 공인중개사 상호 검색 API 추가

- `GET /api/v1/agency/search`
  - 요청: `AgencySearchRequest`
    - `agencyName` (필수, 공인중개사 상호)
    - `num` (선택, 페이지당 개수, 기본 10, 1~10 사이)
    - `page` (선택, 기본 1)
  - 응답: `AgencySearchResponse`
    - 중개사 목록(`AgencySearchItem`) + `num`, `page`, `totalCount`
    - 각 아이템에 도로명/지번 주소와 위도/경도, 개설등록번호, 사업자상호, 중개업자명 포함
- `AgencyController`, `AgencyService`, `AgencyServiceImpl`에 검색 로직을 추가했습니다.

### 2. VWorld API 연동 확장

  - 중개사무소 검색(API) 추가
    - 상호명으로 중개사무소 정보 조회하는 API
    - 일일 최대 요청 수: (10억 - 1) 건
  - 주소 → 좌표 변환(geocode API) 추가
    - 중개사무소 검색 API에 없던 좌표를 추가하기 위해 추가
    - 일일 최대 요청 수: 4만건

### 3. 지오코딩 병렬 처리 & 전용 쓰레드풀

- 검색된 중개사무소의 지번 주소를 VWorld geocode API로 좌표 변환할 때,
  - `CompletableFuture.supplyAsync(..., geocodeExecutor)`를 사용해 병렬로 호출하도록 구현했습니다.
- `VWorldConfig`에서 전용 `Executor`를 Bean으로 등록:
  - `ThreadPoolTaskExecutor` 기반
  - 지오코딩을 위한 쓰레드 풀 구성
  - 기본값: 기본 쓰레드 수 4/최대 쓰레드 수 4, 대기열 크기 100
- 응답 시간을 줄이기 위함입니다.

### 4. 에러 응답 분리 (503 / 500)
- 서비스 과부하 / 일시적인 사용 불가 상황을 구분하기 위해 예외를 나눴습니다.
  - `ServiceUnavailableGroupException` (503 공통 베이스) + `ControllerAdvice` 핸들러 추가
  - `AgencyServiceUnavailableException`  
      → 지오코딩용 Executor가 더 이상 작업을 받을 수 없을 때 사용 (503)
   - `AgencyInternalServerErrorException`  
      → 지오코딩 처리 중 예기치 못한 오류가 발생했을 때 사용 (500)

## 📸 스크린샷
<img width="846" height="856" alt="image" src="https://github.com/user-attachments/assets/983d9a20-91aa-4b0c-87e6-6a7cbe84f2fd" />
<p align="center"><sub><b>성공</b></sub></p>

<img width="863" height="510" alt="image" src="https://github.com/user-attachments/assets/7fa7b169-2ff6-42ed-b075-ed6fcce9d078" />
<p align="center"><sub><b>1 이상, 10 이하가 아닌 경우 400 반환</b></sub></p>

<img width="834" height="480" alt="image" src="https://github.com/user-attachments/assets/d916c977-2022-4918-8208-e426c4fa604a" />
<p align="center"><sub><b>대기열보다 더 많은 작업 요청 시 503 반환 (테스트를 위해 임시로 제약 완화)</b></sub></p>

## 📢 노트
- 추후 트래픽/스펙 변경에 따라 쓰레드풀∙제한값을 조정할 수 있습니다.
