### PR TITLE
[Feat #269] 찐빵 리포트(콘텐츠) 기능 구현

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
@@ -36,7 +36,8 @@ public class ReportController {
             @AuthenticationPrincipal Users user,
             @PathVariable Long reportId
     ) {
-        return new ResTemplate<>(HttpStatus.OK, "리포트 조회 성공", null);
+        ReportInfoResponse data = reportService.getReportDetail(user, reportId);
+        return new ResTemplate<>(HttpStatus.OK, "리포트 조회 성공", data);
     }
 
     @PostMapping("/like/{reportId}")

--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
@@ -45,6 +45,7 @@ public class ReportController {
             @AuthenticationPrincipal Users user,
             @PathVariable Long reportId
     ) {
+        reportService.addLike(user, reportId);
         return new ResTemplate<>(HttpStatus.OK, "리포트 좋아요 추가 성공", null);
     }
 
@@ -53,6 +54,7 @@ public class ReportController {
             @AuthenticationPrincipal Users user,
             @PathVariable Long reportId
     ) {
+        reportService.deleteLike(user, reportId);
         return new ResTemplate<>(HttpStatus.OK, "리포트 좋아요 삭제 성공", null);
     }
 }

--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
@@ -1,0 +1,57 @@
+package JJinBBang.app.domain.common.controller;
+
+import JJinBBang.app.domain.common.dto.response.ReportInfoResponse;
+import JJinBBang.app.domain.common.dto.response.ReportListResponse;
+import JJinBBang.app.domain.common.service.ReportService;
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.global.template.ResTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/report")
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @GetMapping("")
+    public ResTemplate<ReportListResponse> getReportList(
+            @RequestParam(name = "category") String category,
+            @RequestParam(name = "cursor", required = false) Integer cursor,
+            @RequestParam(name = "size", required = false) Integer size
+    ) {
+        int currentCursor = (cursor != null) ? cursor : 0;
+        int pageSize = (size != null) ? size : 10;
+
+        ReportListResponse data = reportService.getReportList(category.toUpperCase(), currentCursor, pageSize);
+
+        return new ResTemplate<>(HttpStatus.OK, "리포트 목록 조회 성공", data);
+    }
+
+    @GetMapping("{reportId}")
+    public ResTemplate<ReportInfoResponse> getReportDetail(
+            @AuthenticationPrincipal Users user,
+            @PathVariable Long reportId
+    ) {
+        return new ResTemplate<>(HttpStatus.OK, "리포트 조회 성공", null);
+    }
+
+    @PostMapping("/like/{reportId}")
+    public ResTemplate<?> addReportLike(
+            @AuthenticationPrincipal Users user,
+            @PathVariable Long reportId
+    ) {
+        return new ResTemplate<>(HttpStatus.OK, "리포트 좋아요 추가 성공", null);
+    }
+
+    @DeleteMapping("/like/{reportId}")
+    public ResTemplate<?> deleteReportLike(
+            @AuthenticationPrincipal Users user,
+            @PathVariable Long reportId
+    ) {
+        return new ResTemplate<>(HttpStatus.OK, "리포트 좋아요 삭제 성공", null);
+    }
+}

--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
@@ -57,4 +57,12 @@ public class ReportController {
         reportService.deleteLike(user, reportId);
         return new ResTemplate<>(HttpStatus.OK, "리포트 좋아요 삭제 성공", null);
     }
+
+    @PatchMapping("/share/{reportId}")
+    public ResTemplate<?> addReportShareCount(
+            @PathVariable Long reportId
+    ) {
+        reportService.addShareCount(reportId);
+        return new ResTemplate<>(HttpStatus.OK, "공유수 추가 성공", null);
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
@@ -20,13 +20,14 @@ public class ReportController {
     @GetMapping("")
     public ResTemplate<ReportListResponse> getReportList(
             @RequestParam(name = "category") String category,
-            @RequestParam(name = "cursor", required = false) Integer cursor,
+            @RequestParam(name = "cursor", required = false) Long cursor,
             @RequestParam(name = "size", required = false) Integer size
     ) {
-        int currentCursor = (cursor != null) ? cursor : 0;
-        int pageSize = (size != null) ? size : 10;
-
-        ReportListResponse data = reportService.getReportList(category.toUpperCase(), currentCursor, pageSize);
+        ReportListResponse data = reportService.getReportList(
+                category != null ?category.toUpperCase() : null,
+                cursor,
+                (size != null && size > 0) ? size : 10
+        );
 
         return new ResTemplate<>(HttpStatus.OK, "리포트 목록 조회 성공", data);
     }

--- a/src/main/java/JJinBBang/app/domain/common/dto/response/ReportInfoResponse.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/response/ReportInfoResponse.java
@@ -1,0 +1,18 @@
+package JJinBBang.app.domain.common.dto.response;
+
+import JJinBBang.app.domain.common.enums.ReportCategory;
+
+import java.time.LocalDateTime;
+
+public record ReportInfoResponse(
+        Long id,
+        ReportCategory category,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        Integer likeCount,
+        Integer viewCount,
+        Integer shareCount,
+        boolean isLiked
+) {
+}

--- a/src/main/java/JJinBBang/app/domain/common/dto/response/ReportListResponse.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/response/ReportListResponse.java
@@ -1,0 +1,12 @@
+package JJinBBang.app.domain.common.dto.response;
+
+import JJinBBang.app.global.common.dto.CursorPaginationInfo;
+import JJinBBang.app.global.common.dto.ReportInfo;
+
+import java.util.List;
+
+public record ReportListResponse(
+        List<ReportInfo> reportList,
+        CursorPaginationInfo pageInfo
+) {
+}

--- a/src/main/java/JJinBBang/app/domain/common/entity/ReportLikeId.java
+++ b/src/main/java/JJinBBang/app/domain/common/entity/ReportLikeId.java
@@ -1,0 +1,29 @@
+package JJinBBang.app.domain.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReportLikeId implements Serializable {
+
+    @Column(name = "report_id")
+    private Long reportId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    // 복합키 생성
+    public static ReportLikeId of(Long reportId, Long userId) {
+        if (reportId == null || userId == null)
+            throw new IllegalArgumentException("reportId and userId can not be null");
+
+        return new ReportLikeId(reportId, userId);
+    }
+}

--- a/src/main/java/JJinBBang/app/domain/common/entity/ReportLikes.java
+++ b/src/main/java/JJinBBang/app/domain/common/entity/ReportLikes.java
@@ -33,8 +33,6 @@ public class ReportLikes {
         reportLikes.report = report;
         reportLikes.user = user;
 
-        report.getReportLikes().add(reportLikes);
-
         return reportLikes;
     }
 }

--- a/src/main/java/JJinBBang/app/domain/common/entity/ReportLikes.java
+++ b/src/main/java/JJinBBang/app/domain/common/entity/ReportLikes.java
@@ -1,0 +1,40 @@
+package JJinBBang.app.domain.common.entity;
+
+import JJinBBang.app.domain.user.entity.Users;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportLikes {
+
+    @EmbeddedId
+    private ReportLikeId id;
+
+    @MapsId("reportId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private Reports report; // target: 찐빵 리포트
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user; // target: 사용자
+
+    public static ReportLikes create(Reports report, Users user) {
+
+        ReportLikeId reportLikeId = ReportLikeId.of(report.getId(), user.getUserId());
+
+        ReportLikes reportLikes = new ReportLikes();
+        reportLikes.id = reportLikeId;
+        reportLikes.report = report;
+        reportLikes.user = user;
+
+        report.getReportLikes().add(reportLikes);
+
+        return reportLikes;
+    }
+}

--- a/src/main/java/JJinBBang/app/domain/common/entity/Reports.java
+++ b/src/main/java/JJinBBang/app/domain/common/entity/Reports.java
@@ -44,4 +44,20 @@ public class Reports extends BaseEntity {
 
     @OneToMany(mappedBy = "report", cascade = CascadeType.ALL)
     private List<ReportLikes> reportLikes = new ArrayList<>();
+
+    public void increaseViewCount() {
+        this.viewCount++;
+    }
+
+    public void increaseShareCount() {
+        this.shareCount++;
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) this.likeCount--;
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/common/entity/Reports.java
+++ b/src/main/java/JJinBBang/app/domain/common/entity/Reports.java
@@ -1,0 +1,47 @@
+package JJinBBang.app.domain.common.entity;
+
+import JJinBBang.app.domain.common.enums.ReportCategory;
+import JJinBBang.app.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reports extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long id; // 리포트 id
+
+    @Column(name = "cover_image", nullable = false, length = 2083)
+    private String coverImage; // 대표 이미지
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private ReportCategory category; // 리포트 분류 (부동산, 자취꿀팁, ...)
+
+    @Column(name = "title", nullable = false, length = 400)
+    private String title; // 리포트 제목
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content; // 리포트 본문
+
+    @Column(name = "share_count", nullable = false)
+    private int shareCount = 0; // 공유 수
+
+    @Column(name = "like_count", nullable = false)
+    private int likeCount = 0; // 좋아요 수
+
+    @Column(name = "view_count", nullable = false)
+    private int viewCount = 0; // 조회 수
+
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL)
+    private List<ReportLikes> reportLikes = new ArrayList<>();
+}

--- a/src/main/java/JJinBBang/app/domain/common/enums/ReportCategory.java
+++ b/src/main/java/JJinBBang/app/domain/common/enums/ReportCategory.java
@@ -1,0 +1,9 @@
+package JJinBBang.app.domain.common.enums;
+
+public enum ReportCategory {
+    REAL_ESTATE,
+    LIVING_TIPS,
+    CAMPUS_LIFE,
+    MOVING_TIPS,
+    INTERVIEW
+}

--- a/src/main/java/JJinBBang/app/domain/common/enums/ReportCategory.java
+++ b/src/main/java/JJinBBang/app/domain/common/enums/ReportCategory.java
@@ -1,9 +1,17 @@
 package JJinBBang.app.domain.common.enums;
 
 public enum ReportCategory {
-    REAL_ESTATE,
-    LIVING_TIPS,
-    CAMPUS_LIFE,
-    MOVING_TIPS,
-    INTERVIEW
+    REAL_ESTATE, // 부동산
+    TIPS, // 자취 꿀팁
+    CAMPUS_LIFE, // 대학 생활
+    MOVING, // 이사 관련
+    INTERVIEW; // 인터뷰
+
+    public static ReportCategory from(String value) {
+        try {
+            return ReportCategory.valueOf(value.trim().toUpperCase());
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/common/exception/ReportInvalidException.java
+++ b/src/main/java/JJinBBang/app/domain/common/exception/ReportInvalidException.java
@@ -1,0 +1,15 @@
+package JJinBBang.app.domain.common.exception;
+
+import JJinBBang.app.global.error.exception.InvalidGroupException;
+
+public class ReportInvalidException extends InvalidGroupException {
+    public ReportInvalidException(String message) {
+        super(message);
+    }
+
+    public static ReportInvalidException invalidCategory() {return new ReportInvalidException("잘못된 카테고리 입니다.");}
+
+    public static ReportInvalidException invalidCursor() {return new ReportInvalidException("cursor는 항상 0 이상입니다.");}
+
+    public static ReportInvalidException invalidSize() {return new ReportInvalidException("size는 항상 0 이상입니다.");}
+}

--- a/src/main/java/JJinBBang/app/domain/common/exception/ReportNotFoundGroupException.java
+++ b/src/main/java/JJinBBang/app/domain/common/exception/ReportNotFoundGroupException.java
@@ -1,0 +1,11 @@
+package JJinBBang.app.domain.common.exception;
+
+import JJinBBang.app.global.error.exception.NotFoundGroupException;
+
+public class ReportNotFoundGroupException extends NotFoundGroupException {
+    public ReportNotFoundGroupException(String message) {
+        super(message);
+    }
+
+    public static ReportNotFoundGroupException reportNotFound() {return new ReportNotFoundGroupException("해당 리포트를 찾을 수 없습니다.");}
+}

--- a/src/main/java/JJinBBang/app/domain/common/repository/ReportLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/common/repository/ReportLikesRepository.java
@@ -1,4 +1,4 @@
-package JJinBBang.app.domain.common.service;
+package JJinBBang.app.domain.common.repository;
 
 import JJinBBang.app.domain.common.entity.ReportLikeId;
 import JJinBBang.app.domain.common.entity.ReportLikes;
@@ -6,6 +6,6 @@ import JJinBBang.app.domain.common.entity.Reports;
 import JJinBBang.app.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-interface ReportLikesRepository extends JpaRepository<ReportLikes, ReportLikeId> {
+public interface ReportLikesRepository extends JpaRepository<ReportLikes, ReportLikeId> {
     boolean existsByReportAndUser(Reports report, Users user);
 }

--- a/src/main/java/JJinBBang/app/domain/common/repository/ReportRepository.java
+++ b/src/main/java/JJinBBang/app/domain/common/repository/ReportRepository.java
@@ -1,0 +1,11 @@
+package JJinBBang.app.domain.common.repository;
+
+import JJinBBang.app.domain.common.entity.Reports;
+import JJinBBang.app.domain.common.enums.ReportCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<Reports, Long> {
+    Page<Reports> findByCategory(ReportCategory reportCategory, Pageable pageable);
+}

--- a/src/main/java/JJinBBang/app/domain/common/repository/ReportRepository.java
+++ b/src/main/java/JJinBBang/app/domain/common/repository/ReportRepository.java
@@ -6,6 +6,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReportRepository extends JpaRepository<Reports, Long> {
     Page<Reports> findByCategory(ReportCategory reportCategory, Pageable pageable);
+
+    List<Reports> findByIdLessThanOrderByIdDesc(Long idIsLessThan, Pageable pageable);
+
+    List<Reports> findByCategoryAndIdLessThanOrderByIdDesc(ReportCategory category, Long idIsLessThan, Pageable pageable);
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportLikesRepository.java
@@ -1,0 +1,11 @@
+package JJinBBang.app.domain.common.service;
+
+import JJinBBang.app.domain.common.entity.ReportLikeId;
+import JJinBBang.app.domain.common.entity.ReportLikes;
+import JJinBBang.app.domain.common.entity.Reports;
+import JJinBBang.app.domain.user.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface ReportLikesRepository extends JpaRepository<ReportLikes, ReportLikeId> {
+    boolean existsByReportAndUser(Reports report, Users user);
+}

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.domain.common.service;
+
+import JJinBBang.app.domain.common.dto.response.ReportListResponse;
+
+public interface ReportService {
+    ReportListResponse getReportList(String category, int cursor, int size);
+}

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
@@ -6,7 +6,7 @@ import JJinBBang.app.domain.user.entity.Users;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface ReportService {
-    ReportListResponse getReportList(String category, int cursor, int size);
+    ReportListResponse getReportList(String category, Long cursor, int size);
 
     @Transactional
     ReportInfoResponse getReportDetail(Users user, Long reportId);

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
@@ -16,4 +16,7 @@ public interface ReportService {
 
     @Transactional
     void deleteLike(Users user, Long reportId);
+
+    @Transactional
+    void addShareCount(Long reportId);
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
@@ -1,7 +1,13 @@
 package JJinBBang.app.domain.common.service;
 
+import JJinBBang.app.domain.common.dto.response.ReportInfoResponse;
 import JJinBBang.app.domain.common.dto.response.ReportListResponse;
+import JJinBBang.app.domain.user.entity.Users;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ReportService {
     ReportListResponse getReportList(String category, int cursor, int size);
+
+    @Transactional
+    ReportInfoResponse getReportDetail(Users user, Long reportId);
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
@@ -10,4 +10,10 @@ public interface ReportService {
 
     @Transactional
     ReportInfoResponse getReportDetail(Users user, Long reportId);
+
+    @Transactional
+    void addLike(Users user, Long reportId);
+
+    @Transactional
+    void deleteLike(Users user, Long reportId);
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
@@ -1,0 +1,80 @@
+package JJinBBang.app.domain.common.service;
+
+import JJinBBang.app.domain.common.dto.response.ReportListResponse;
+import JJinBBang.app.domain.common.entity.Reports;
+import JJinBBang.app.domain.common.enums.ReportCategory;
+import JJinBBang.app.domain.common.exception.ReportInvalidException;
+import JJinBBang.app.domain.common.repository.ReportRepository;
+import JJinBBang.app.global.common.dto.CursorPaginationInfo;
+import JJinBBang.app.global.common.dto.ReportInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReportServiceImpl implements ReportService {
+
+    private final ReportRepository reportRepository;
+
+    /**
+     * 리포트 데이터 목록 조회
+     *
+     * @param category 빈 경우 전체 데이터로 조회 (enum 타입으로 정의)
+     * @param cursor pagination cursor
+     * @param size pagination 조회 크기
+     * @return
+     */
+    @Override
+    public ReportListResponse getReportList(String category, int cursor, int size) {
+
+        if (cursor < 0) throw ReportInvalidException.invalidCursor();
+        if (size < 0) throw ReportInvalidException.invalidSize();
+
+        Pageable pageable = PageRequest.of(
+                cursor, size, Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        // category 기반 리포트 데이터 조회
+        Page<Reports> page;
+
+        if (category == null || category.isBlank()) {
+            page = reportRepository.findAll(pageable);
+        } else {
+            final ReportCategory reportCategory;
+
+            try {
+                reportCategory = ReportCategory.valueOf(category);
+            } catch (IllegalArgumentException e) {
+                throw ReportInvalidException.invalidCategory();
+            }
+
+            page = reportRepository.findByCategory(reportCategory, pageable);
+        }
+
+        // 리포트 데이터 매핑
+        List<ReportInfo> reports = page.getContent().stream()
+                .map(report -> new ReportInfo(
+                        report.getId(),
+                        report.getCoverImage(),
+                        report.getCategory(),
+                        report.getTitle(),
+                        report.getCreatedAt(),
+                        report.getLikeCount(),
+                        report.getViewCount()
+                ))
+                .toList();
+
+        // pagination 데이터 업데이트
+        Integer nextCursor = page.hasNext() ? cursor + 1 : null;
+        CursorPaginationInfo cursorInfo = new CursorPaginationInfo(nextCursor, page.hasNext());
+
+        return new ReportListResponse(reports, cursorInfo);
+    }
+}

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
@@ -2,10 +2,13 @@ package JJinBBang.app.domain.common.service;
 
 import JJinBBang.app.domain.common.dto.response.ReportInfoResponse;
 import JJinBBang.app.domain.common.dto.response.ReportListResponse;
+import JJinBBang.app.domain.common.entity.ReportLikeId;
+import JJinBBang.app.domain.common.entity.ReportLikes;
 import JJinBBang.app.domain.common.entity.Reports;
 import JJinBBang.app.domain.common.enums.ReportCategory;
 import JJinBBang.app.domain.common.exception.ReportInvalidException;
 import JJinBBang.app.domain.common.exception.ReportNotFoundGroupException;
+import JJinBBang.app.domain.common.repository.ReportLikesRepository;
 import JJinBBang.app.domain.common.repository.ReportRepository;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.common.dto.CursorPaginationInfo;
@@ -116,5 +119,57 @@ public class ReportServiceImpl implements ReportService {
                 report.getShareCount(),
                 isLiked
         );
+    }
+
+    /**
+     * 리포트 좋아요 추가
+     *
+     * @param user
+     * @param reportId
+     */
+    @Transactional
+    @Override
+    public void addLike(Users user, Long reportId) {
+
+        // 리포트 조회
+        Reports report = reportRepository.findById(reportId)
+                .orElseThrow(ReportNotFoundGroupException::reportNotFound);
+
+        // 좋아요 어부 확인
+        boolean isLiked = reportLikesRepository.existsByReportAndUser(report, user);
+        if (isLiked) throw new IllegalArgumentException("이미 좋아요 누름");
+
+        // 좋아요 추가
+        ReportLikes reportLikes = ReportLikes.create(report, user);
+        reportLikesRepository.save(reportLikes);
+
+        // 좋아요 수 +1
+        report.increaseLikeCount();
+    }
+
+
+    /**
+     * 리포트 좋아요 제거
+     *
+     * @param user
+     * @param reportId
+     */
+    @Transactional
+    @Override
+    public void deleteLike(Users user, Long reportId) {
+
+        // 좋아요 ID 조회
+        ReportLikeId reportLikeId = ReportLikeId.of(reportId, user.getUserId());
+
+        // 좋아요 여부 확인
+        ReportLikes reportLikes = reportLikesRepository.findById(reportLikeId)
+                .orElseThrow(ReportNotFoundGroupException::reportNotFound);
+
+        // 좋아요 삭제
+        reportLikesRepository.delete(reportLikes);
+
+        // 좋아요 수 -1
+        Reports report = reportLikes.getReport();
+        report.decreaseLikeCount();
     }
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
@@ -172,4 +172,19 @@ public class ReportServiceImpl implements ReportService {
         Reports report = reportLikes.getReport();
         report.decreaseLikeCount();
     }
+
+
+    /**
+     * 공유수 추가
+     *
+     * @param reportId
+     */
+    @Transactional
+    @Override
+    public void addShareCount(Long reportId) {
+        Reports report = reportRepository.findById(reportId)
+                .orElseThrow(ReportNotFoundGroupException::reportNotFound);
+
+        report.increaseShareCount();
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
@@ -40,34 +40,52 @@ public class ReportServiceImpl implements ReportService {
      * @return
      */
     @Override
-    public ReportListResponse getReportList(String category, int cursor, int size) {
+    public ReportListResponse getReportList(String category, Long cursor, int size) {
 
-        if (cursor < 0) throw ReportInvalidException.invalidCursor();
-        if (size < 0) throw ReportInvalidException.invalidSize();
+        if (size <= 0) throw ReportInvalidException.invalidSize();
 
         Pageable pageable = PageRequest.of(
-                cursor, size, Sort.by(Sort.Direction.DESC, "createdAt")
+                0, size + 1, Sort.by(Sort.Direction.DESC, "id")
         );
 
-        // category 기반 리포트 데이터 조회
-        Page<Reports> page;
-
+        // category 검증
+        final ReportCategory reportCategory;
         if (category == null || category.isBlank()) {
-            page = reportRepository.findAll(pageable);
+            reportCategory = null;
         } else {
-            final ReportCategory reportCategory;
-
             try {
                 reportCategory = ReportCategory.valueOf(category);
             } catch (IllegalArgumentException e) {
                 throw ReportInvalidException.invalidCategory();
             }
-
-            page = reportRepository.findByCategory(reportCategory, pageable);
         }
 
+        List<Reports> resultList;
+
+        // 첫 페이지
+        if (cursor == null) {
+            if (reportCategory == null) {
+                Page<Reports> page = reportRepository.findAll(pageable);
+                resultList = page.getContent();
+            }  else {
+                Page<Reports> page = reportRepository.findByCategory(reportCategory, pageable);
+                resultList = page.getContent();
+            }
+        // 다음 페이지
+        } else {
+            if (reportCategory == null) {
+                resultList = reportRepository.findByIdLessThanOrderByIdDesc(cursor, pageable);
+            } else {
+                resultList = reportRepository.findByCategoryAndIdLessThanOrderByIdDesc(reportCategory, cursor, pageable);
+            }
+        }
+
+        // hasNext 판별
+        boolean hasNext = resultList.size() > size;
+        if (hasNext) resultList = resultList.subList(0, size);
+
         // 리포트 데이터 매핑
-        List<ReportInfo> reports = page.getContent().stream()
+        List<ReportInfo> reports = resultList.stream()
                 .map(report -> new ReportInfo(
                         report.getId(),
                         report.getCoverImage(),
@@ -79,9 +97,9 @@ public class ReportServiceImpl implements ReportService {
                 ))
                 .toList();
 
-        // pagination 데이터 업데이트
-        Integer nextCursor = page.hasNext() ? cursor + 1 : null;
-        CursorPaginationInfo cursorInfo = new CursorPaginationInfo(nextCursor, page.hasNext());
+        // pagination 데이터 업데이트 (마지막 요소 id 조회)
+        Long nextCursor = hasNext && !resultList.isEmpty() ? resultList.getLast().getId() : null;
+        CursorPaginationInfo cursorInfo = new CursorPaginationInfo(nextCursor, hasNext);
 
         return new ReportListResponse(reports, cursorInfo);
     }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
@@ -1,10 +1,13 @@
 package JJinBBang.app.domain.common.service;
 
+import JJinBBang.app.domain.common.dto.response.ReportInfoResponse;
 import JJinBBang.app.domain.common.dto.response.ReportListResponse;
 import JJinBBang.app.domain.common.entity.Reports;
 import JJinBBang.app.domain.common.enums.ReportCategory;
 import JJinBBang.app.domain.common.exception.ReportInvalidException;
+import JJinBBang.app.domain.common.exception.ReportNotFoundGroupException;
 import JJinBBang.app.domain.common.repository.ReportRepository;
+import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.common.dto.CursorPaginationInfo;
 import JJinBBang.app.global.common.dto.ReportInfo;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +16,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 import java.util.List;
@@ -22,6 +26,7 @@ import java.util.List;
 public class ReportServiceImpl implements ReportService {
 
     private final ReportRepository reportRepository;
+    private final ReportLikesRepository reportLikesRepository;
 
     /**
      * 리포트 데이터 목록 조회
@@ -76,5 +81,40 @@ public class ReportServiceImpl implements ReportService {
         CursorPaginationInfo cursorInfo = new CursorPaginationInfo(nextCursor, page.hasNext());
 
         return new ReportListResponse(reports, cursorInfo);
+    }
+
+
+    /**
+     * 리포트 상세 내용 조회
+     *
+     * @param user 좋아요 여부 조회를 위함
+     * @param reportId 조회하고자 하는 리포트 id
+     * @return
+     */
+    @Transactional
+    @Override
+    public ReportInfoResponse getReportDetail(Users user, Long reportId) {
+
+        // 리포트 조회
+        Reports report = reportRepository.findById(reportId)
+                .orElseThrow(ReportNotFoundGroupException::reportNotFound);
+
+        // 조회수 증가
+        report.increaseViewCount();
+
+        // 좋아요 여부 확인
+        boolean isLiked = user != null && reportLikesRepository.existsByReportAndUser(report, user);
+
+        return new ReportInfoResponse(
+                report.getId(),
+                report.getCategory(),
+                report.getTitle(),
+                report.getContent(),
+                report.getCreatedAt(),
+                report.getLikeCount(),
+                report.getViewCount(), // 증가한 조회수 반환
+                report.getShareCount(),
+                isLiked
+        );
     }
 }

--- a/src/main/java/JJinBBang/app/global/common/dto/CursorPaginationInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/CursorPaginationInfo.java
@@ -1,7 +1,7 @@
 package JJinBBang.app.global.common.dto;
 
 public record CursorPaginationInfo(
-        Integer nextCursor,
+        Long nextCursor,
         boolean hasNext
 ) {
 }

--- a/src/main/java/JJinBBang/app/global/common/dto/CursorPaginationInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/CursorPaginationInfo.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.global.common.dto;
+
+public record CursorPaginationInfo(
+        Integer nextCursor,
+        boolean hasNext
+) {
+}

--- a/src/main/java/JJinBBang/app/global/common/dto/ReportInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/ReportInfo.java
@@ -1,0 +1,16 @@
+package JJinBBang.app.global.common.dto;
+
+import JJinBBang.app.domain.common.enums.ReportCategory;
+
+import java.time.LocalDateTime;
+
+public record ReportInfo(
+        Long id,
+        String coverImage, // 대표 이미지
+        ReportCategory category, // 리포트 분류
+        String title, // 리포트 제목
+        LocalDateTime createdAt, // 작성일
+        Integer likeCount, // 좋아요 수
+        Integer viewCount // 조회 수
+) {
+}


### PR DESCRIPTION
## 📌 이슈 번호
> #269 

## 💬 리뷰 포인트
- Reports, ReportLikes, ReportLikeId 엔티티 생성
- 찐빵 리포트 조회 기능 추가
- 찐빵 리포트 좋아요(추가/삭제) 기능 추가
- 찐빵 리포트 공유 시 공유 수 반영

## 🚀 상세 설명
1. Reports, ReportLikes, ReportLikeId 엔티티
- 복합키 사용
- JPA repository 생성 시 JpaRepository<ReportLikes, ReportLikeId> 형식으로 작성 
2. 찐빵 리포트 조회
- 목록 조회 시 페이지네이션 적용 (커서 방식으로 적용)
    - request
        - cursor : 처음에는 값을 비우고, 다음 요청부터 nextCursor로 받은 값으로 요청합니다.
        - size : 기본값 10으로 하였으나 커스텀 요청 가능합니다.
    - response
        - nextCursor : 다음 요청 시작점입니다. 요청 시 cursor 값으로 요청합니다.
        - hasNext : 다음 데이터 여부를 표시합니다.
- 상세 조회 시 조회 수 업데이트
3. 좋아요, 공유수 관련 기능

## 📢 노트
- 리포트 작성, 수정, 삭제 등의 기능은 월요일(11/24) 업데이트 팀 회의 이후 관리자 기능 관련 스프린트로 진행하겠습니다.