### PR TITLE
[Fix #271] 건물상세보기 좋아요 상태 표시 문제 해결

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/service/AgencyServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/AgencyServiceImpl.java
@@ -48,7 +48,7 @@ public class AgencyServiceImpl implements AgencyService{
 
         // 2) 좋아요 여부 계산
         Boolean liked = agency.getAgencyLikes().stream()
-                .anyMatch(like -> like.getUser().equals(user));
+                .anyMatch(like -> like.getUser().getUserId().equals(user.getUserId()));
 
         // 3) 키워드 조회 - 없으면 새 엔티티
         BuildingKeywordCounts buildingKeywordCounts = buildingKeywordCountRepository

--- a/src/main/java/JJinBBang/app/domain/building/service/BuildingServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BuildingServiceImpl.java
@@ -31,7 +31,7 @@ public class BuildingServiceImpl implements BuildingService {
 
 		// 2) 좋아요 여부
 		Boolean liked = building.getBuildingLikes().stream()
-				.anyMatch(like -> like.getUser().equals(user));
+				.anyMatch(like -> like.getUser().getUserId().equals(user.getUserId()));
 
 		// 3) 키워드 조회 - 없으면 새 엔티티
 		BuildingKeywordCounts buildingKeywordCounts = buildingKeywordCountRepository


### PR DESCRIPTION
## 📌 이슈 번호
- #271 

## 💬 리뷰 포인트
- 건물/중개사 상세에서 좋아요 여부 판단 시 `User` 객체 비교 → `userId` 비교로 수정

## 🚀 상세 설명
- 건물/중개사 상세에서 좋아요 여부 판단 시 `User` 객체 비교 → `userId` 비교로 수정해  
  실제로 좋아요한 경우에도 상세에서 좋아요가 꺼져 보이던 문제를 해결했습니다.

## 📸 스크린샷
<img width="832" height="573" alt="image" src="https://github.com/user-attachments/assets/da4bcb37-e604-4697-a7f8-961facea5865" />

## 📢 노트