### PR TITLE
fix[#276]: 회원탈퇴 유저 기록 삭제 오류 수정 - ReportLikes 처리 로직 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/repository/ReportLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/common/repository/ReportLikesRepository.java
@@ -4,8 +4,14 @@ import JJinBBang.app.domain.common.entity.ReportLikeId;
 import JJinBBang.app.domain.common.entity.ReportLikes;
 import JJinBBang.app.domain.common.entity.Reports;
 import JJinBBang.app.domain.user.entity.Users;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface ReportLikesRepository extends JpaRepository<ReportLikes, ReportLikeId> {
     boolean existsByReportAndUser(Reports report, Users user);
+
+    @EntityGraph(attributePaths = {"report"})
+    List<ReportLikes> findAllByUser_UserId(Long userId);
 }

--- a/src/main/java/JJinBBang/app/domain/user/entity/Users.java
+++ b/src/main/java/JJinBBang/app/domain/user/entity/Users.java
@@ -11,6 +11,7 @@ import JJinBBang.app.domain.building.entity.BuildingLikes;
 import JJinBBang.app.domain.building.entity.ReviewLikes;
 import JJinBBang.app.domain.building.entity.Reviews;
 import JJinBBang.app.domain.common.entity.Universities;
+import JJinBBang.app.domain.common.entity.ReportLikes;
 import JJinBBang.app.domain.user.enums.UserRole;
 import JJinBBang.app.global.common.enums.Provider;
 import JJinBBang.app.global.common.enums.VerificationStatus;
@@ -88,6 +89,10 @@ public class Users extends BaseEntity {
 	// 유저 -> 공인중개사-좋아요
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
 	private List<AgencyLikes> agencyLikes = new ArrayList<>();
+
+	// 유저 -> 리포트-좋아요
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+	private List<ReportLikes> reportLikes = new ArrayList<>();
 
 	@Builder
 	private Users(

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -203,7 +203,13 @@ public class UsersServiceImpl implements UsersService {
 		// 3-4) 리포트 좋아요
 		List<ReportLikes> reportLikes = reportLikesRepository.findAllByUser_UserId(targetUserId);
 		reportLikes.forEach(rl -> rl.getReport().decreaseLikeCount());
-		reportLikesRepository.deleteAll(reportLikes);
+		reportLikesRepository.deleteAllInBatch(reportLikes);
+
+		// 3-x) Users 엔티티 컬렉션 정리 (양방향 연관관계 재-persist 방지)
+		user.getBuildingLikes().clear();
+		user.getReviewLikes().clear();
+		user.getAgencyLikes().clear();
+		user.getReportLikes().clear();
 
 		// 4) 유저 탈퇴일 기록 (스케줄러가 N일 뒤 영구 삭제)
 		user.delete(); // 내부에서 disabledAt = now 등

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -8,8 +8,9 @@ import JJinBBang.app.domain.building.entity.BuildingLikes;
 import JJinBBang.app.domain.building.entity.ReviewLikes;
 import JJinBBang.app.domain.building.repository.*;
 import JJinBBang.app.domain.common.entity.Universities;
+import JJinBBang.app.domain.common.entity.ReportLikes;
+import JJinBBang.app.domain.common.repository.ReportLikesRepository;
 import JJinBBang.app.domain.user.dto.UserInfoResponseDto;
-import JJinBBang.app.domain.user.exception.OpinionException;
 import JJinBBang.app.domain.user.exception.UniversityNotFoundException;
 import JJinBBang.app.domain.user.repository.UniversityRepository;
 import JJinBBang.app.global.common.enums.UnregisterReason;
@@ -26,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 @Slf4j
@@ -45,6 +45,7 @@ public class UsersServiceImpl implements UsersService {
 	private final UniversityRepository universityRepository;
 	private final BuildingLikesRepository buildingLikesRepository;
 	private final AgencyLikesRepository agencyLikesRepository;
+	private final ReportLikesRepository reportLikesRepository;
 
 
 	@Override
@@ -198,6 +199,11 @@ public class UsersServiceImpl implements UsersService {
 		List<AgencyLikes> agencyLikes = agencyLikesRepository.findAllByUser_UserId(targetUserId);
 		agencyLikes.forEach(al -> al.getAgency().decrementLikeCount());
 		agencyLikesRepository.deleteAll(agencyLikes);
+
+		// 3-4) 리포트 좋아요
+		List<ReportLikes> reportLikes = reportLikesRepository.findAllByUser_UserId(targetUserId);
+		reportLikes.forEach(rl -> rl.getReport().decreaseLikeCount());
+		reportLikesRepository.deleteAll(reportLikes);
 
 		// 4) 유저 탈퇴일 기록 (스케줄러가 N일 뒤 영구 삭제)
 		user.delete(); // 내부에서 disabledAt = now 등


### PR DESCRIPTION
## 📌 이슈 번호
> #276

## 💬 리뷰 포인트
> 회원탈퇴 시 ReportLikes 삭제 및 카운터 보정 로직이 누락되어 있었습니다. 이를 추가했습니다.

## 🚀 상세 설명
**문제점**
- 회원탈퇴 시 ReportLikes가 삭제되지 않아 데이터 무결성 문제 발생
- Report의 좋아요 카운터가 실제 데이터와 불일치

**수정 내용**
1. `ReportLikesRepository`에 `findAllByUser_UserId` 메서드 추가
2. `UsersServiceImpl.deleteUser()`에 ReportLikes 삭제 및 카운터 보정 로직 추가
3. `Users` 엔티티에 ReportLikes 관계 매핑 추가

## 📸 스크린샷

## 📢 노트
