### PR TITLE
🐛 Fix[#278]: 찐 후기(리뷰 키워드) 필터링 로직 개선 및 공인중개사 필터 적용

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/AgenciesRepositoryCustom.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/AgenciesRepositoryCustom.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.domain.building.repository.custom;
 
+import JJinBBang.app.global.common.enums.KeywordType;
 import java.util.List;
 import JJinBBang.app.domain.building.entity.Agencies;
 
@@ -7,7 +8,7 @@ public interface AgenciesRepositoryCustom {
 	List<Agencies> searchAgencies(String keyword);
 
 	List<Agencies> findMarkersWithinBounds(
-		Double neLat, Double neLng,
-		Double swLat, Double swLng
-	);
+			Double neLat, Double neLng,
+			Double swLat, Double swLng,
+			List<KeywordType> reviewKeywords);
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/AgenciesRepositoryImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/AgenciesRepositoryImpl.java
@@ -5,8 +5,11 @@ import JJinBBang.app.domain.building.entity.QAgencies;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import JJinBBang.app.global.common.enums.KeywordType;
+import JJinBBang.app.domain.building.entity.QReviews;
 
 import java.util.List;
+
 @RequiredArgsConstructor
 public class AgenciesRepositoryImpl implements AgenciesRepositoryCustom {
 
@@ -19,28 +22,37 @@ public class AgenciesRepositoryImpl implements AgenciesRepositoryCustom {
 		BooleanBuilder builder = new BooleanBuilder();
 		if (keyword != null && !keyword.isEmpty()) {
 			builder.and(a.name.containsIgnoreCase(keyword)
-				.or(a.address.containsIgnoreCase(keyword)));
+					.or(a.address.containsIgnoreCase(keyword)));
 		}
 
 		return queryFactory.selectFrom(a)
-			.where(builder)
-			.fetch();
+				.where(builder)
+				.fetch();
 	}
 
 	@Override
 	public List<Agencies> findMarkersWithinBounds(
-		Double neLat, Double neLng,
-		Double swLat, Double swLng
-	) {
+			Double neLat, Double neLng,
+			Double swLat, Double swLng,
+			List<KeywordType> reviewKeywords) {
 		QAgencies a = QAgencies.agencies;
+		QReviews r = QReviews.reviews;
 
 		BooleanBuilder builder = new BooleanBuilder();
 		builder.and(a.agencyLat.between(swLat, neLat));
 		builder.and(a.agencyLot.between(swLng, neLng));
 
+		if (reviewKeywords != null && !reviewKeywords.isEmpty()) {
+			BooleanBuilder keywordBuilder = new BooleanBuilder();
+			for (KeywordType kw : reviewKeywords) {
+				keywordBuilder.and(r.tags.contains(kw.name()));
+			}
+			builder.and(keywordBuilder);
+		}
+
 		return queryFactory.selectFrom(a)
-			.leftJoin(a.reviews).fetchJoin()
-			.where(builder)
-			.fetch();
+				.leftJoin(a.reviews, r).fetchJoin()
+				.where(builder)
+				.fetch();
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/custom/BuildingsRepositoryImpl.java
@@ -28,15 +28,14 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 
 	@Override
 	public List<Buildings> findMarkersWithinBounds(
-		Double neLat, Double neLng,
-		Double swLat, Double swLng,
-		List<BuildingType> buildTypes,
-		ContractType contractType,
-		Integer depositMin, Integer depositMax,
-		Integer monthlyRentMin, Integer monthlyRentMax,
-		Boolean inMaintenanceCost,
-		List<KeywordType> reviewKeywords
-	) {
+			Double neLat, Double neLng,
+			Double swLat, Double swLng,
+			List<BuildingType> buildTypes,
+			ContractType contractType,
+			Integer depositMin, Integer depositMax,
+			Integer monthlyRentMin, Integer monthlyRentMax,
+			Boolean inMaintenanceCost,
+			List<KeywordType> reviewKeywords) {
 		QBuildings b = QBuildings.buildings;
 		QCampuses c = QCampuses.campuses;
 		QReviews r = QReviews.reviews;
@@ -63,11 +62,11 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		QGeneralReviews treated = new QGeneralReviews(grPath);
 
 		JPAQuery<Buildings> query = queryFactory.selectDistinct(b)
-			.from(b)
-			.leftJoin(b.reviews, r).fetchJoin()
-			.leftJoin(treated).on(r.id.eq(treated.id))
-			.leftJoin(b.campus, c).fetchJoin()
-			.where(builder);
+				.from(b)
+				.leftJoin(b.reviews, r).fetchJoin()
+				.leftJoin(treated).on(r.id.eq(treated.id))
+				.leftJoin(b.campus, c).fetchJoin()
+				.where(builder);
 
 		// 4. 계약 조건 필터
 		if (contractType != null) {
@@ -85,8 +84,17 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		if (monthlyRentMax != null) {
 			query.where(treated.price.loe(monthlyRentMax));
 		}
+
 		if (inMaintenanceCost != null && inMaintenanceCost) {
 			query.where(treated.maintenanceCost.isNotNull());
+		}
+
+		if (reviewKeywords != null && !reviewKeywords.isEmpty()) {
+			BooleanBuilder keywordBuilder = new BooleanBuilder();
+			for (KeywordType kw : reviewKeywords) {
+				keywordBuilder.and(r.tags.contains(kw.name()));
+			}
+			query.where(keywordBuilder);
 		}
 
 		return query.fetch();
@@ -94,14 +102,13 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 
 	@Override
 	public List<Buildings> searchBuildings(
-		String keyword,
-		List<BuildingType> buildTypes,
-		ContractType contractType,
-		Integer depositMin, Integer depositMax,
-		Integer monthlyRentMin, Integer monthlyRentMax,
-		Boolean inMaintenanceCost,
-		List<KeywordType> reviewKeywords
-	) {
+			String keyword,
+			List<BuildingType> buildTypes,
+			ContractType contractType,
+			Integer depositMin, Integer depositMax,
+			Integer monthlyRentMin, Integer monthlyRentMax,
+			Boolean inMaintenanceCost,
+			List<KeywordType> reviewKeywords) {
 		QBuildings b = QBuildings.buildings;
 		QCampuses c = QCampuses.campuses;
 		QReviews r = QReviews.reviews;
@@ -112,9 +119,9 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 
 		if (keyword != null && !keyword.isEmpty()) {
 			builder.and(b.buildingName.containsIgnoreCase(keyword)
-				.or(b.buildingAddress.containsIgnoreCase(keyword))
-				.or(a.name.containsIgnoreCase(keyword))
-				.or(a.address.containsIgnoreCase(keyword)));
+					.or(b.buildingAddress.containsIgnoreCase(keyword))
+					.or(a.name.containsIgnoreCase(keyword))
+					.or(a.address.containsIgnoreCase(keyword)));
 		}
 
 		if (buildTypes != null && !buildTypes.contains(BuildingType.ALL)) {
@@ -129,12 +136,12 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		QGeneralReviews treated = new QGeneralReviews(grPath);
 
 		JPAQuery<Buildings> query = queryFactory.selectDistinct(b)
-			.from(b)
-			.leftJoin(b.reviews, r).fetchJoin()
-			.leftJoin(treated).on(r.id.eq(treated.id))
-			.leftJoin(b.campus, c).fetchJoin()
-			.leftJoin(a).on(b.buildingCode.stringValue().eq(a.agencySerial))
-			.where(builder);
+				.from(b)
+				.leftJoin(b.reviews, r).fetchJoin()
+				.leftJoin(treated).on(r.id.eq(treated.id))
+				.leftJoin(b.campus, c).fetchJoin()
+				.leftJoin(a).on(b.buildingCode.stringValue().eq(a.agencySerial))
+				.where(builder);
 
 		if (contractType != null) {
 			query.where(treated.contractType.eq(contractType));
@@ -151,8 +158,17 @@ public class BuildingsRepositoryImpl implements BuildingsRepositoryCustom {
 		if (monthlyRentMax != null) {
 			query.where(treated.price.loe(monthlyRentMax));
 		}
+
 		if (inMaintenanceCost != null && inMaintenanceCost) {
 			query.where(treated.maintenanceCost.isNotNull());
+		}
+
+		if (reviewKeywords != null && !reviewKeywords.isEmpty()) {
+			BooleanBuilder keywordBuilder = new BooleanBuilder();
+			for (KeywordType kw : reviewKeywords) {
+				keywordBuilder.and(r.tags.contains(kw.name()));
+			}
+			query.where(keywordBuilder);
 		}
 
 		return query.fetch();

--- a/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/map/service/MapServiceImpl.java
@@ -45,18 +45,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class MapServiceImpl implements MapService{
-    private static final double DEFAULT_CAMPUS_RADIUS_METERS = 2_000d;
-    private static final double EARTH_RADIUS_METERS = 6_371_000d;
+public class MapServiceImpl implements MapService {
+	private static final double DEFAULT_CAMPUS_RADIUS_METERS = 2_000d;
+	private static final double EARTH_RADIUS_METERS = 6_371_000d;
 
-    private final BuildingsRepository buildingsRepository;
-    private final ReviewsRepository reviewsRepository;
-    private final BuildingLikesRepository buildingLikesRepository;
-    private final ReviewLikesRepository reviewLikesRepository;
-    private final AgenciesRepository agenciesRepository;
-    private final AgencyLikesRepository agencyLikesRepository;
-    private final CampusesRepository campusesRepository;
-    private final SearchInfo searchInfo;
+	private final BuildingsRepository buildingsRepository;
+	private final ReviewsRepository reviewsRepository;
+	private final BuildingLikesRepository buildingLikesRepository;
+	private final ReviewLikesRepository reviewLikesRepository;
+	private final AgenciesRepository agenciesRepository;
+	private final AgencyLikesRepository agencyLikesRepository;
+	private final CampusesRepository campusesRepository;
+	private final SearchInfo searchInfo;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -72,60 +72,59 @@ public class MapServiceImpl implements MapService{
 		ContractType contractType = parseContractType(filters.contractType());
 
 		// 모든 조건 기반으로 건물 리스트를 먼저 조회
-        List<Long> campusFilters = filters.campus();
-        boolean hasCampusFilters = campusFilters != null && !campusFilters.isEmpty();
-        List<Buildings> buildings = buildingsRepository.findMarkersWithinBounds(
-                bounds.neLat(), bounds.neLng(),
-                bounds.swLat(), bounds.swLng(),
-                filters.buildType(), contractType,
-                filters.depositMin(), filters.depositMax(),
-                filters.monthlyRentMin(), filters.monthlyRentMax(),
-                filters.inMaintenanceCost(),
-                filters.reviewKeyword()
-        );
+		List<Long> campusFilters = filters.campus();
+		boolean hasCampusFilters = campusFilters != null && !campusFilters.isEmpty();
+		List<Buildings> buildings = buildingsRepository.findMarkersWithinBounds(
+				bounds.neLat(), bounds.neLng(),
+				bounds.swLat(), bounds.swLng(),
+				filters.buildType(), contractType,
+				filters.depositMin(), filters.depositMax(),
+				filters.monthlyRentMin(), filters.monthlyRentMax(),
+				filters.inMaintenanceCost(),
+				filters.reviewKeyword());
 
-        boolean includeAgency = filters.buildType() == null
-                || filters.buildType().contains(BuildingType.ALL)
-                || filters.buildType().contains(BuildingType.AGENCY);
+		boolean includeAgency = filters.buildType() == null
+				|| filters.buildType().contains(BuildingType.ALL)
+				|| filters.buildType().contains(BuildingType.AGENCY);
 
-        List<Agencies> agencies = includeAgency
-                ? agenciesRepository.findMarkersWithinBounds(
-                bounds.neLat(), bounds.neLng(),
-                bounds.swLat(), bounds.swLng()
-        )
-                : List.of();
+		List<Agencies> agencies = includeAgency
+				? agenciesRepository.findMarkersWithinBounds(
+						bounds.neLat(), bounds.neLng(),
+						bounds.swLat(), bounds.swLng(),
+						filters.reviewKeyword())
+				: List.of();
 
-        if (hasCampusFilters) {
-            List<Campuses> campuses = campusesRepository.findAllById(campusFilters);
-            if (campuses.isEmpty()) {
-                buildings = List.of();
-                agencies = includeAgency ? List.of() : agencies;
-            } else {
-                double radiusMeters = resolveCampusRadiusMeters(filters);
-                buildings = buildings.stream()
-                        .filter(b -> isWithinCampusRadius(
-                                b.getBuildingLat(),
-                                b.getBuildingLot(),
-                                campuses,
-                                radiusMeters))
-                        .toList();
+		if (hasCampusFilters) {
+			List<Campuses> campuses = campusesRepository.findAllById(campusFilters);
+			if (campuses.isEmpty()) {
+				buildings = List.of();
+				agencies = includeAgency ? List.of() : agencies;
+			} else {
+				double radiusMeters = resolveCampusRadiusMeters(filters);
+				buildings = buildings.stream()
+						.filter(b -> isWithinCampusRadius(
+								b.getBuildingLat(),
+								b.getBuildingLot(),
+								campuses,
+								radiusMeters))
+						.toList();
 
-                if (includeAgency) {
-                    agencies = agencies.stream()
-                            .filter(a -> isWithinCampusRadius(
-                                    a.getAgencyLat(),
-                                    a.getAgencyLot(),
-                                    campuses,
-                                    radiusMeters))
-                            .toList();
-                }
-            }
-        }
+				if (includeAgency) {
+					agencies = agencies.stream()
+							.filter(a -> isWithinCampusRadius(
+									a.getAgencyLat(),
+									a.getAgencyLot(),
+									campuses,
+									radiusMeters))
+							.toList();
+				}
+			}
+		}
 
-        if (buildings.isEmpty() && agencies.isEmpty()) {
-            if (filters.viewType() == ViewType.REVIEW) {
-                throw MapNoContentException.notFoundReview();
-            } else {
+		if (buildings.isEmpty() && agencies.isEmpty()) {
+			if (filters.viewType() == ViewType.REVIEW) {
+				throw MapNoContentException.notFoundReview();
+			} else {
 				throw MapNoContentException.notFoundBuilding();
 			}
 		}
@@ -134,38 +133,35 @@ public class MapServiceImpl implements MapService{
 
 		if (filters.viewType() == ViewType.REVIEW) {
 			// 건물에 딸린 리뷰 ID별로 마커 생성
-			buildings.forEach(b ->
-				b.getReviews().forEach(r ->
-					markers.add(MarkerInfo.fromReview(
-						r.getId(),
-						b.getBuildingType().get(0),
-						b.getBuildingLat(),
-						b.getBuildingLot()))));
+			buildings.forEach(b -> b.getReviews().stream()
+					.filter(r -> isReviewMatchingKeywords(r, filters.reviewKeyword()))
+					.forEach(r -> markers.add(MarkerInfo.fromReview(
+							r.getId(),
+							b.getBuildingType().get(0),
+							b.getBuildingLat(),
+							b.getBuildingLot()))));
 
-			agencies.forEach(a ->
-				a.getReviews().forEach(r ->
-					markers.add(MarkerInfo.fromReview(
-						r.getId(),
-						BuildingType.AGENCY,
-						a.getAgencyLat(),
-						a.getAgencyLot()))));
+			agencies.forEach(a -> a.getReviews().stream()
+					.filter(r -> isReviewMatchingKeywords(r, filters.reviewKeyword()))
+					.forEach(r -> markers.add(MarkerInfo.fromReview(
+							r.getId(),
+							BuildingType.AGENCY,
+							a.getAgencyLat(),
+							a.getAgencyLot()))));
 		} else {
-			buildings.forEach(b ->
-				markers.add(MarkerInfo.fromBuidling(
-                        b.getId(),
-                        b.getBuildingType().get(0),
-                        b.getBuildingLat(),
-                        b.getBuildingLot(),
-                        b.getReviewCount() > 0
-                )));
+			buildings.forEach(b -> markers.add(MarkerInfo.fromBuidling(
+					b.getId(),
+					b.getBuildingType().get(0),
+					b.getBuildingLat(),
+					b.getBuildingLot(),
+					b.getReviewCount() > 0)));
 
-			agencies.forEach(a ->
-				markers.add(MarkerInfo.fromBuidling(
+			agencies.forEach(a -> markers.add(MarkerInfo.fromBuidling(
 					a.getAgencyId(),
 					BuildingType.AGENCY,
 					a.getAgencyLat(),
 					a.getAgencyLot(),
-           a.getReviewCount() > 0)));
+					a.getReviewCount() > 0)));
 		}
 
 		return markers;
@@ -185,65 +181,66 @@ public class MapServiceImpl implements MapService{
 
 		ContractType contractType = parseContractType(filters.contractType());
 
-        List<Long> campusFilters = filters.campus();
-        boolean hasCampusFilters = campusFilters != null && !campusFilters.isEmpty();
-        List<Buildings> buildings = buildingsRepository.searchBuildings(
-                request.keyword(),
-                filters.buildType(), contractType,
-                filters.depositMin(), filters.depositMax(),
-                filters.monthlyRentMin(), filters.monthlyRentMax(),
-                filters.inMaintenanceCost(),
-                filters.reviewKeyword()
-        );
+		List<Long> campusFilters = filters.campus();
+		boolean hasCampusFilters = campusFilters != null && !campusFilters.isEmpty();
+		List<Buildings> buildings = buildingsRepository.searchBuildings(
+				request.keyword(),
+				filters.buildType(), contractType,
+				filters.depositMin(), filters.depositMax(),
+				filters.monthlyRentMin(), filters.monthlyRentMax(),
+				filters.inMaintenanceCost(),
+				filters.reviewKeyword());
 
-        List<Agencies> agencies = agenciesRepository.searchAgencies(request.keyword());
+		List<Agencies> agencies = agenciesRepository.searchAgencies(request.keyword());
 
-        if (hasCampusFilters) {
-            List<Campuses> campuses = campusesRepository.findAllById(campusFilters);
-            if (campuses.isEmpty()) {
-                buildings = List.of();
-                agencies = List.of();
-            } else {
-                double radiusMeters = resolveCampusRadiusMeters(filters);
-                buildings = buildings.stream()
-                        .filter(b -> isWithinCampusRadius(
-                                b.getBuildingLat(),
-                                b.getBuildingLot(),
-                                campuses,
-                                radiusMeters))
-                        .toList();
+		if (hasCampusFilters) {
+			List<Campuses> campuses = campusesRepository.findAllById(campusFilters);
+			if (campuses.isEmpty()) {
+				buildings = List.of();
+				agencies = List.of();
+			} else {
+				double radiusMeters = resolveCampusRadiusMeters(filters);
+				buildings = buildings.stream()
+						.filter(b -> isWithinCampusRadius(
+								b.getBuildingLat(),
+								b.getBuildingLot(),
+								campuses,
+								radiusMeters))
+						.toList();
 
-                agencies = agencies.stream()
-                        .filter(a -> isWithinCampusRadius(
-                                a.getAgencyLat(),
-                                a.getAgencyLot(),
-                                campuses,
-                                radiusMeters))
-                        .toList();
-            }
-        }
+				agencies = agencies.stream()
+						.filter(a -> isWithinCampusRadius(
+								a.getAgencyLat(),
+								a.getAgencyLot(),
+								campuses,
+								radiusMeters))
+						.toList();
+			}
+		}
 
-        if (buildings.isEmpty() && agencies.isEmpty()) {
-            throw MapNoContentException.searchFailed();
-        }
+		if (buildings.isEmpty() && agencies.isEmpty()) {
+			throw MapNoContentException.searchFailed();
+		}
 
 		List<SearchInfoDto> items = new ArrayList<>();
 		for (Buildings b : buildings) {
 			if (filters.viewType() == ViewType.REVIEW) {
-				b.getReviews().forEach(r -> {
-					boolean liked = user != null && reviewLikesRepository
-						.findByReviewIdAndUserUserId(r.getId(), user.getUserId())
-						.isPresent();
-					try {
-						items.add(searchInfo.reviewSearchWithBound(r.getId(), liked));
-					} catch (Exception e) {
-						throw MapNotFoundException.notFoundReview();
-					}
-				});
+				b.getReviews().stream()
+						.filter(r -> isReviewMatchingKeywords(r, filters.reviewKeyword()))
+						.forEach(r -> {
+							boolean liked = user != null && reviewLikesRepository
+									.findByReviewIdAndUserUserId(r.getId(), user.getUserId())
+									.isPresent();
+							try {
+								items.add(searchInfo.reviewSearchWithBound(r.getId(), liked));
+							} catch (Exception e) {
+								throw MapNotFoundException.notFoundReview();
+							}
+						});
 			} else {
 				boolean liked = user != null && buildingLikesRepository
-					.findByBuildingAndUser(b, user)
-					.isPresent();
+						.findByBuildingAndUser(b, user)
+						.isPresent();
 				items.add(searchInfo.buildingSearchWithBound(b.getId(), liked));
 			}
 		}
@@ -267,11 +264,11 @@ public class MapServiceImpl implements MapService{
 		List<SearchInfoDto> paged = items.subList(from, to);
 
 		return PaginatedResponse.<SearchInfoDto>builder()
-			.num(paged.size())
-			.page(request.page())
-			.itemNum((long) items.size())
-			.items(paged)
-			.build();
+				.num(paged.size())
+				.page(request.page())
+				.itemNum((long) items.size())
+				.items(paged)
+				.build();
 	}
 
 	@Override
@@ -299,8 +296,8 @@ public class MapServiceImpl implements MapService{
 		if (request.type() == ViewType.REVIEW) {
 			for (Long id : ids) {
 				boolean liked = user != null && reviewLikesRepository
-					.findByReviewIdAndUserUserId(id, user.getUserId())
-					.isPresent();
+						.findByReviewIdAndUserUserId(id, user.getUserId())
+						.isPresent();
 				try {
 					items.add(searchInfo.reviewSearch(id, liked));
 				} catch (Exception e) {
@@ -317,10 +314,10 @@ public class MapServiceImpl implements MapService{
 			if (!noBuildingIds) {
 				for (Long id : ids) {
 					Buildings building = buildingsRepository.findById(id)
-						.orElseThrow(MapNotFoundException::notFoundBuilding);
+							.orElseThrow(MapNotFoundException::notFoundBuilding);
 					boolean liked = user != null && buildingLikesRepository
-						.findByBuildingAndUser(building, user)
-						.isPresent();
+							.findByBuildingAndUser(building, user)
+							.isPresent();
 					buildingItems.add(searchInfo.buildingSearch(id, liked));
 				}
 			}
@@ -329,10 +326,10 @@ public class MapServiceImpl implements MapService{
 			if (!noAgencyIds) {
 				for (Long id : agencyIds) {
 					Agencies agency = agenciesRepository.findById(id)
-						.orElseThrow(MapNotFoundException::notFoundAgency);
+							.orElseThrow(MapNotFoundException::notFoundAgency);
 					boolean liked = user != null && agencyLikesRepository
-						.findByAgencyAndUser(agency, user)
-						.isPresent();
+							.findByAgencyAndUser(agency, user)
+							.isPresent();
 					agencyItems.add(searchInfo.agencySearch(id, liked));
 				}
 			}
@@ -363,49 +360,52 @@ public class MapServiceImpl implements MapService{
 		List<InfoDto> paged = items.subList(from, to);
 
 		return PaginatedResponse.<InfoDto>builder()
-			.num(paged.size())
-			.page(request.page())
-			.itemNum((long) items.size())
-			.items(paged)
-			.build();
+				.num(paged.size())
+				.page(request.page())
+				.itemNum((long) items.size())
+				.items(paged)
+				.build();
 	}
 
-    private double resolveCampusRadiusMeters(Filters filters) {
-        return DEFAULT_CAMPUS_RADIUS_METERS;
-    }
+	private double resolveCampusRadiusMeters(Filters filters) {
+		return DEFAULT_CAMPUS_RADIUS_METERS;
+	}
 
-    private boolean isWithinCampusRadius(Double lat, Double lng, List<Campuses> campuses, double radiusMeters) {
-        if (lat == null || lng == null) {
-            return false;
-        }
+	private boolean isWithinCampusRadius(Double lat, Double lng, List<Campuses> campuses, double radiusMeters) {
+		if (lat == null || lng == null) {
+			return false;
+		}
 
-        return campuses.stream().anyMatch(campus -> {
-            Double campusLat = campus.getCampusLat();
-            Double campusLot = campus.getCampusLot();
-            if (campusLat == null || campusLot == null) {
-                return false;
-            }
-            return calculateDistanceMeters(lat, lng, campusLat, campusLot) <= radiusMeters;
-        });
-    }
+		return campuses.stream().anyMatch(campus -> {
+			Double campusLat = campus.getCampusLat();
+			Double campusLot = campus.getCampusLot();
+			if (campusLat == null || campusLot == null) {
+				return false;
+			}
+			return calculateDistanceMeters(lat, lng, campusLat, campusLot) <= radiusMeters;
+		});
+	}
 
-    private double calculateDistanceMeters(double lat1, double lng1, double lat2, double lng2) {
-        double dLat = Math.toRadians(lat2 - lat1);
-        double dLng = Math.toRadians(lng2 - lng1);
+	private double calculateDistanceMeters(double lat1, double lng1, double lat2, double lng2) {
+		double dLat = Math.toRadians(lat2 - lat1);
+		double dLng = Math.toRadians(lng2 - lng1);
 
-        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
-                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
-                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+		double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+				+ Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+						* Math.sin(dLng / 2) * Math.sin(dLng / 2);
+		double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 
-        return EARTH_RADIUS_METERS * c;
-    }
+		return EARTH_RADIUS_METERS * c;
+	}
 
 	private Comparator<SearchInfoDto> getSearchComparator(SortType sort, ViewType type) {
 		return switch (sort) {
 			case LIKES -> Comparator.<SearchInfoDto, Integer>comparing(dto -> extractLikeCount(dto)).reversed();
-			case STARS -> Comparator.comparing((SearchInfoDto dto) -> extractRating(dto), Comparator.nullsLast(BigDecimal::compareTo)).reversed();
-			case LATEST -> Comparator.comparing((SearchInfoDto dto) -> extractUpdatedAt(dto), Comparator.nullsLast(LocalDateTime::compareTo)).reversed();
+			case STARS -> Comparator
+					.comparing((SearchInfoDto dto) -> extractRating(dto), Comparator.nullsLast(BigDecimal::compareTo))
+					.reversed();
+			case LATEST -> Comparator.comparing((SearchInfoDto dto) -> extractUpdatedAt(dto),
+					Comparator.nullsLast(LocalDateTime::compareTo)).reversed();
 			case RCMND -> {
 				if (type == ViewType.BUILDING) {
 					yield Comparator.<SearchInfoDto, Integer>comparing(dto -> extractReviewCount(dto)).reversed();
@@ -419,8 +419,12 @@ public class MapServiceImpl implements MapService{
 	private Comparator<InfoDto> getComparator(SortType sort, ViewType type) {
 		return switch (sort) {
 			case LIKES -> Comparator.<InfoDto, Integer>comparing(dto -> extractLikeCount(dto)).reversed();
-			case STARS -> Comparator.comparing((InfoDto dto) -> extractRating(dto), Comparator.nullsLast(BigDecimal::compareTo)).reversed();
-			case LATEST -> Comparator.comparing((InfoDto dto) -> extractUpdatedAt(dto), Comparator.nullsLast(LocalDateTime::compareTo)).reversed();
+			case STARS ->
+				Comparator.comparing((InfoDto dto) -> extractRating(dto), Comparator.nullsLast(BigDecimal::compareTo))
+						.reversed();
+			case LATEST -> Comparator
+					.comparing((InfoDto dto) -> extractUpdatedAt(dto), Comparator.nullsLast(LocalDateTime::compareTo))
+					.reversed();
 			case RCMND -> {
 				if (type == ViewType.BUILDING) {
 					yield Comparator.<InfoDto, Integer>comparing(dto -> extractReviewCount(dto)).reversed();
@@ -514,8 +518,6 @@ public class MapServiceImpl implements MapService{
 		return dto.reviewInfo() != null ? dto.reviewInfo().updateAt() : null;
 	}
 
-
-
 	// Validation 메서드
 	// 위도/경도 범위, 필터링 조건, 키워드 개수 등 유효성 검사
 
@@ -553,5 +555,21 @@ public class MapServiceImpl implements MapService{
 			case "ALL" -> null;
 			default -> null;
 		};
+	}
+
+	private boolean isReviewMatchingKeywords(JJinBBang.app.domain.building.entity.Reviews review,
+			List<KeywordType> keywords) {
+		if (keywords == null || keywords.isEmpty()) {
+			return true;
+		}
+		if (review.getTags() == null || review.getTags().isEmpty()) {
+			return false;
+		}
+		for (KeywordType keyword : keywords) {
+			if (!review.getTags().contains(keyword)) {
+				return false;
+			}
+		}
+		return true;
 	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
#278

## 💬 리뷰 포인트
- 지도 마커 조회 시 `reviewKeyword`(찐 후기 필터)가 공인중개사(Agencies) 조회에는 적용되지 않던 버그를 수정했습니다.
- 키워드 필터링 로직을 기존 OR(하나라도 포함)에서 **AND(선택한 키워드 모두 포함)** 방식으로 변경했습니다.
- Repository와 Service 양쪽 모두에 로직을 적용하여 데이터 정확성을 보장했습니다.

## 🚀 상세 설명
### 1. 공인중개사 필터링 미적용 수정
- 기존 AgenciesRepository에는 reviewKeyword 파라미터를 받는 로직이 없어, 필터 선택 시에도 관련 없는 공인중개사 마커가 노출되는 문제가 있었습니다 분명 만들어뒀었는데 ㅠ
- AgenciesRepositoryCustom 및 Impl에 필터링 로직을 추가하여 이 문제를 해결했습니다.

### 2. 필터링 로직 변경 (OR -> AND)
- 사용자가 여러 개의 키워드를 선택했을 때, 모든 키워드를 포함하는 리뷰가 있는 곳만 검색되도록 했습니다.
- BuildingsRepositoryImpl, AgenciesRepositoryImpl의 QueryDSL 조건과 MapServiceImpl의 검증 로직을 모두 수정했습니다.

### 3. Service 레이어 이중 검증
- JPA Fetch Join 특성상 연관된 모든 리뷰를 가져오는 경우가 있어, Service 레이어에서 `isReviewMatchingKeywords` 메서드를 통해 키워드 조건에 맞지 않는 리뷰는 마커 생성에서 제외하도록 처리했습니다

## 📸 스크린샷
<img width="979" height="595" alt="image" src="https://github.com/user-attachments/assets/a032e9c6-75b6-41af-8909-48439d60b29f" />

## 📢 노트
다시 코드를 보니 리팩토링이 필요한 부분도 많고, 주석도 예쁘게 좀 달아둬야할꺼같아서 리팩토링 수행하도록 하겠슴다
