### PR TITLE
[Feat #286]: ReviewSummaryResponse에 이미지 수 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/ReviewSummaryResponse.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/ReviewSummaryResponse.java
@@ -28,8 +28,9 @@ public class ReviewSummaryResponse {
 
 		private final ReviewInfo reviewInfo;
 		private final String image;
+		private final Integer imageCount;
 
-		public static ReviewSummaryResponse of(Reviews review, Boolean like) {
+		public static ReviewSummaryResponse of(Reviews review, Boolean like, Integer imageCount) {
 			GeneralReviewInfo generalReviewInfo = null;
 			DormitoryReviewInfo dormitoryReviewInfo = null;
 			AgencyReviewInfo agencyReviewInfo = null;
@@ -50,6 +51,7 @@ public class ReviewSummaryResponse {
 				.agencyReviewInfo(agencyReviewInfo)
 				.reviewInfo(ReviewInfo.of(review))
 				.image(review.getThumbnailImage())
+				.imageCount(imageCount)
 				.build();
 		}
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/ReviewDetailsRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/ReviewDetailsRepository.java
@@ -1,5 +1,7 @@
 package JJinBBang.app.domain.building.repository;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.bson.types.ObjectId;
@@ -14,4 +16,6 @@ public interface ReviewDetailsRepository extends MongoRepository<ReviewDetails, 
 	Optional<ReviewDetails> findByReviewId(Long reviewId);
 
     void deleteByReviewId(Long reviewId);
+
+	List<ReviewDetails> findAllByReviewIdIn(List<Long> reviewIds);
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -3,6 +3,9 @@ package JJinBBang.app.domain.building.service;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.locationtech.jts.geom.*;
 
 import org.springframework.data.domain.Page;
@@ -76,25 +79,28 @@ public class ReviewServiceImpl implements ReviewService {
             reviewPage = reviewsRepository.findAllByBuilding(building, pageRequest);
         }
 
-        // 3) 각 리뷰를 ReviewSummaryResponse로 변환하여 반환
-        return PaginatedResponse.of(
-                reviewPage,
-                review -> {
-                    // 3.1) 좋아요 여부 확인
-					boolean liked = review.getReviewLikes().stream()
-						.anyMatch(like -> like.getUser() != null
-							&& user != null
-							&& like.getUser().getUserId().equals(user.getUserId()));
+		// 3-1. 리뷰 ID 목록 추출
+		List<Long> reviewIds = reviewPage.getContent().stream()
+			.map(Reviews::getId)
+			.toList();
 
-					// 3.2) 이미지 개수 조회
-					ReviewDetails details = reviewDetailsRepository.findByReviewId(review.getId())
-							.orElseThrow(ReviewInternalServerErrorException::missingReviewDetailException);
-					Integer imageCount = details.getImageCount();
+		// 3-2. 한 번의 쿼리로 모든 ReviewDetails 조회 후 Map으로 변환
+		Map<Long, Integer> imageCountMap = reviewDetailsRepository.findAllByReviewIdIn(reviewIds).stream()
+			.collect(Collectors.toMap(ReviewDetails::getReviewId, ReviewDetails::getImageCount));
 
-                    // 3.3) 요약 응답 생성
-                    return ReviewSummaryResponse.of(review, liked, imageCount);
-                }
-        );
+		// 3-3. PaginatedResponse 생성 시 Map 사용
+		return PaginatedResponse.of(
+			reviewPage,
+			review -> {
+				boolean liked = review.getReviewLikes().stream()
+					.anyMatch(like -> like.getUser() != null
+						&& user != null
+						&& like.getUser().getUserId().equals(user.getUserId()));
+
+				Integer imageCount = imageCountMap.getOrDefault(review.getId(), 0);
+				return ReviewSummaryResponse.of(review, liked, imageCount);
+			}
+		);
     }
 
     /**

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -86,8 +86,13 @@ public class ReviewServiceImpl implements ReviewService {
 							&& user != null
 							&& like.getUser().getUserId().equals(user.getUserId()));
 
+					// 3.2) 이미지 개수 조회
+					ReviewDetails details = reviewDetailsRepository.findByReviewId(review.getId())
+							.orElseThrow(ReviewInternalServerErrorException::missingReviewDetailException);
+					Integer imageCount = details.getImageCount();
+
                     // 3.3) 요약 응답 생성
-                    return ReviewSummaryResponse.of(review, liked);
+                    return ReviewSummaryResponse.of(review, liked, imageCount);
                 }
         );
     }


### PR DESCRIPTION
## 📌 이슈 번호
- #286 

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요
- 리뷰 목록 조회 시 응답에 각 리뷰의 이미지 수를 추가했습니다.
## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요
- ReviewSummaryResponse에 imageCount를 추가했습니다.
- 리뷰 목록 조회 API 사용 시 응답으로 이미지 수를 볼 수 있습니다.
## 📸 스크린샷

## 📢 노트