### PR TITLE
fix[#288]: RedisTemplate<String, Object> 빈 추가로 RedisPendingUserReposi…

### DIFF
--- a/src/main/java/JJinBBang/app/global/config/RedisConfig.java
+++ b/src/main/java/JJinBBang/app/global/config/RedisConfig.java
@@ -23,7 +23,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
     @Bean
-    public RedisTemplate<String, EmailAuthInfo> redisTemplate(RedisConnectionFactory factory) {
+    public RedisTemplate<String, EmailAuthInfo> emailAuthRedisTemplate(RedisConnectionFactory factory) {
         RedisTemplate<String, EmailAuthInfo> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);
 
@@ -44,6 +44,27 @@ public class RedisConfig {
         return template;
     }
 
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        // key: String serializer
+        template.setKeySerializer(new StringRedisSerializer());
+
+        // value: JSON serializer for Object (PendingUser 등 일반 객체용)
+        ObjectMapper om = new ObjectMapper();
+        om.registerModule(new JavaTimeModule());
+        om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        Jackson2JsonRedisSerializer<Object> serializer =
+                new Jackson2JsonRedisSerializer<>(om, Object.class);
+
+        template.setValueSerializer(serializer);
+        template.setHashValueSerializer(serializer);
+        template.afterPropertiesSet();
+        return template;
+    }
 
     @Bean
     public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory factory) {

--- a/src/main/java/JJinBBang/app/global/mail/repository/RedisEmailAuthCodeRepository.java
+++ b/src/main/java/JJinBBang/app/global/mail/repository/RedisEmailAuthCodeRepository.java
@@ -2,8 +2,8 @@ package JJinBBang.app.global.mail.repository;
 
 import JJinBBang.app.global.mail.dto.EmailAuthInfo;
 import JJinBBang.app.global.mail.properties.MailAuthProperties;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -15,13 +15,19 @@ import java.util.concurrent.TimeUnit;
 @Repository
 @ConditionalOnProperty( // 조건부 빈 등록 (application.yml의 app.storage.mode 속성에 따라 redis 모드일 때만 활성화)
 		prefix = "app.repository", name = "mode", havingValue = "redis")
-@RequiredArgsConstructor
 public class RedisEmailAuthCodeRepository implements EmailAuthCodeRepository {
 
 	private static final String KEY_PREFIX = "emailAuth:";
 
 	private final RedisTemplate<String, EmailAuthInfo> redisTemplate;
 	private final MailAuthProperties props;
+
+	public RedisEmailAuthCodeRepository(
+			@Qualifier("emailAuthRedisTemplate") RedisTemplate<String, EmailAuthInfo> redisTemplate,
+			MailAuthProperties props) {
+		this.redisTemplate = redisTemplate;
+		this.props = props;
+	}
 
 	private String makeKey(Long userId) {
 		return KEY_PREFIX + userId;


### PR DESCRIPTION
## 📌 이슈 번호
- #288 

## 💬 리뷰 포인트
- `RedisConfig`에 `RedisTemplate<String, Object>` 빈 추가
- `EmailAuthInfo`용 `RedisTemplate`을 `emailAuthRedisTemplate`으로 이름 변경
- `RedisEmailAuthCodeRepository`에 `@Qualifier` 적용

## 🚀 상세 설명
`RedisPendingUserRepository`가 `RedisTemplate<String, Object>` 타입의 빈을 필요로 하는데, `RedisConfig`에는 `RedisTemplate<String, EmailAuthInfo>` 빈만 존재하여 애플리케이션 시작 시 의존성 주입 실패가 발생했습니다.

이를 해결하기 위해:
1. `RedisConfig`에 `PendingUser` 등 일반 객체를 직렬화할 수 있는 `RedisTemplate<String, Object>` 빈을 추가했습니다.
2. 기존 `EmailAuthInfo`용 `RedisTemplate`의 이름을 `emailAuthRedisTemplate`으로 변경하여 타입 충돌을 방지했습니다.
3. `RedisEmailAuthCodeRepository`에서 생성자에 `@Qualifier("emailAuthRedisTemplate")`를 적용하여 올바른 빈을 주입받도록 수정했습니다.

## 📸 스크린샷

## 📢 노트
