### PR TITLE
[FEAT] 관심목록, 마이페이지, 내 주변찐빵 이미지 갯수 요소 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/UserReviewResponse.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/UserReviewResponse.java
@@ -10,64 +10,77 @@ import JJinBBang.app.global.common.dto.AgencyReviewInfo;
 import JJinBBang.app.global.common.dto.DormitoryReviewInfo;
 import JJinBBang.app.global.common.dto.GeneralReviewInfo;
 import JJinBBang.app.global.common.dto.ReviewInfo;
+import JJinBBang.app.domain.building.exception.ReviewInternalServerErrorException;
 import lombok.Builder;
 
 @Builder
 public record UserReviewResponse(
-        GeneralReviewInfo generalReviewInfo,
-        DormitoryReviewInfo dormitoryReviewInfo,
-        AgencyReviewInfo agencyReviewInfo,
-        ReviewInfo reviewInfo,
-        String image
-) {
-    public static UserReviewResponse fromGeneral(
-            GeneralReviews generalReviews,
-            Users user,
-            String image,
-            ReviewLikesRepository likesRepository,
-            ReviewDetailsRepository reviewDetailsRepository
-    ){
-        boolean liked = likesRepository.findByReviewAndUser(generalReviews, user).isPresent();
+                GeneralReviewInfo generalReviewInfo,
+                DormitoryReviewInfo dormitoryReviewInfo,
+                AgencyReviewInfo agencyReviewInfo,
+                ReviewInfo reviewInfo,
+                String image,
+                Integer imageCount) {
+        public static UserReviewResponse fromGeneral(
+                        GeneralReviews generalReviews,
+                        Users user,
+                        String image,
+                        ReviewLikesRepository likesRepository,
+                        ReviewDetailsRepository reviewDetailsRepository) {
+                boolean liked = likesRepository.findByReviewAndUser(generalReviews, user).isPresent();
+                Integer imageCount = getImageCount(reviewDetailsRepository, generalReviews.getId());
 
-        return UserReviewResponse.builder()
-                .generalReviewInfo(GeneralReviewInfo.of(generalReviews, liked))
-                .reviewInfo(ReviewInfo.of(generalReviews))
-                .image(image)
-                .build();
-    }
+                return UserReviewResponse.builder()
+                                .generalReviewInfo(GeneralReviewInfo.of(generalReviews, liked))
+                                .reviewInfo(ReviewInfo.of(generalReviews))
+                                .image(image)
+                                .imageCount(imageCount)
+                                .build();
+        }
 
-    public static UserReviewResponse fromDormitory(
-            DormReviews dormitoryReviews,
-            Users user,
-            String image,
-            ReviewLikesRepository likesRepository
-    ){
-        boolean liked = likesRepository.findByReviewAndUser(dormitoryReviews, user).isPresent();
+        public static UserReviewResponse fromDormitory(
+                        DormReviews dormitoryReviews,
+                        Users user,
+                        String image,
+                        ReviewLikesRepository likesRepository,
+                        ReviewDetailsRepository reviewDetailsRepository) {
+                boolean liked = likesRepository.findByReviewAndUser(dormitoryReviews, user).isPresent();
+                Integer imageCount = getImageCount(reviewDetailsRepository, dormitoryReviews.getId());
 
-        String campusName = dormitoryReviews
-                .getBuilding()
-                .getCampus()
-                .getCampusName();
+                String campusName = dormitoryReviews
+                                .getBuilding()
+                                .getCampus()
+                                .getCampusName();
 
-        return UserReviewResponse.builder()
-                .dormitoryReviewInfo(DormitoryReviewInfo.of(dormitoryReviews, dormitoryReviews.getBuilding(), campusName, liked))
-                .reviewInfo(ReviewInfo.of(dormitoryReviews))
-                .image(image)
-                .build();
-    }
+                return UserReviewResponse.builder()
+                                .dormitoryReviewInfo(DormitoryReviewInfo.of(dormitoryReviews,
+                                                dormitoryReviews.getBuilding(), campusName, liked))
+                                .reviewInfo(ReviewInfo.of(dormitoryReviews))
+                                .image(image)
+                                .imageCount(imageCount)
+                                .build();
+        }
 
-    public static UserReviewResponse fromAgency(
-            AgencyReviews agencyReviews,
-            Users user,
-            String image,
-            ReviewLikesRepository likesRepository
-    ){
-        boolean liked = likesRepository.findByReviewAndUser(agencyReviews, user).isPresent();
+        public static UserReviewResponse fromAgency(
+                        AgencyReviews agencyReviews,
+                        Users user,
+                        String image,
+                        ReviewLikesRepository likesRepository,
+                        ReviewDetailsRepository reviewDetailsRepository) {
+                boolean liked = likesRepository.findByReviewAndUser(agencyReviews, user).isPresent();
+                Integer imageCount = getImageCount(reviewDetailsRepository, agencyReviews.getId());
 
-        return UserReviewResponse.builder()
-                .agencyReviewInfo(AgencyReviewInfo.of(agencyReviews, agencyReviews.getAgency(), liked))
-                .reviewInfo(ReviewInfo.of(agencyReviews))
-                .image(image)
-                .build();
-    }
+                return UserReviewResponse.builder()
+                                .agencyReviewInfo(AgencyReviewInfo.of(agencyReviews, agencyReviews.getAgency(), liked))
+                                .reviewInfo(ReviewInfo.of(agencyReviews))
+                                .image(image)
+                                .imageCount(imageCount)
+                                .build();
+        }
+
+        private static Integer getImageCount(ReviewDetailsRepository repository, Long reviewId) {
+                return repository.findByReviewId(reviewId)
+                                .orElseThrow(ReviewInternalServerErrorException::missingReviewDetailException)
+                                .getImageCount();
+        }
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
@@ -10,6 +10,7 @@ import JJinBBang.app.domain.common.entity.Campuses;
 import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.global.common.dto.SearchInfoDto;
 import JJinBBang.app.global.common.enums.ViewType;
+import JJinBBang.app.domain.building.exception.ReviewInternalServerErrorException;
 import JJinBBang.app.global.error.exception.UnprocessableGroupException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -26,18 +27,22 @@ public class SearchInfo {
     private final DormReviewsRepository dormReviewsRepository;
     private final ReviewDetailsRepository reviewDetailRepository;
 
-    public InfoDto reviewSearch(Long reviewId, Boolean liked){
+    public InfoDto reviewSearch(Long reviewId, Boolean liked) {
         Reviews item = reviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("Review"));
-        switch (item.getDtype()){
+        switch (item.getDtype()) {
             case ReviewType.GENERAL:
-                GeneralReviews generalReviews = generalReviewsRepository.findById(reviewId).orElseThrow(()-> new BookmarkNotFoundException("GeneralReview"));
-                if(generalReviews.getContractType()==null || generalReviews.getFloor()==null||generalReviews.getArea()==null){
+                GeneralReviews generalReviews = generalReviewsRepository.findById(reviewId)
+                        .orElseThrow(() -> new BookmarkNotFoundException("GeneralReview"));
+                if (generalReviews.getContractType() == null || generalReviews.getFloor() == null
+                        || generalReviews.getArea() == null) {
                     throw new BookmarkNotFoundException("GeneralReview");
                 }
-                return InfoDto.ofGeneralReviewInfo(generalReviews,liked);
+                return InfoDto.ofGeneralReviewInfo(generalReviews, liked, getImageCount(item));
             case ReviewType.DORM:
-                DormReviews dormReviews =dormReviewsRepository.findById(reviewId).orElseThrow(()-> new BookmarkNotFoundException("DormReview"));
-                if(dormReviews.getDormFee()==null||dormReviews.getDormFee()==null||dormReviews.getCapacity()==null){
+                DormReviews dormReviews = dormReviewsRepository.findById(reviewId)
+                        .orElseThrow(() -> new BookmarkNotFoundException("DormReview"));
+                if (dormReviews.getDormFee() == null || dormReviews.getDormFee() == null
+                        || dormReviews.getCapacity() == null) {
                     throw new BookmarkNotFoundException("DormReview");
                 }
 
@@ -45,49 +50,55 @@ public class SearchInfo {
                 Campuses campuses = buildings1.getCampus();
                 Universities universities = campuses.getUniversity();
                 String universityName = universities.getUniversityName();
-                return InfoDto.ofDormitoryReviewInfo(dormReviews, buildings1, universityName,liked);
+                return InfoDto.ofDormitoryReviewInfo(dormReviews, buildings1, universityName, liked,
+                        getImageCount(item));
             case ReviewType.AGENCY:
                 Agencies agencies = item.getAgency();
-                return InfoDto.ofAgencyReviewInfo(item,agencies,liked);
+                return InfoDto.ofAgencyReviewInfo(item, agencies, liked, getImageCount(item));
             default:
                 throw new UnprocessableGroupException("후기 유형 dtype에 이상있습니다.");
         }
     }
 
-    public InfoDto buildingSearch(Long itemId, Boolean liked){
-        Buildings building = buildingsRepository.findById(itemId).orElseThrow(() -> new BookmarkNotFoundException("Building"));
-        Reviews reviews= reviewsRepository.findFirstByBuildingOrderByCreatedAtDesc(building);
+    public InfoDto buildingSearch(Long itemId, Boolean liked) {
+        Buildings building = buildingsRepository.findById(itemId)
+                .orElseThrow(() -> new BookmarkNotFoundException("Building"));
+        Reviews reviews = reviewsRepository.findFirstByBuildingOrderByCreatedAtDesc(building);
         List<BuildingType> typeList = building.getBuildingType();
 
         if (typeList.equals(List.of(BuildingType.DORMITORY))) {
             Campuses campuses = building.getCampus();
             Universities universities = campuses.getUniversity();
             String universityName = universities.getUniversityName();
-            return InfoDto.ofDormitoryBuildingInfo(reviews,building,universityName,liked);
-        }
-        else{
-            return InfoDto.ofGeneralBuildingInfo(reviews,building,liked);
+            return InfoDto.ofDormitoryBuildingInfo(reviews, building, universityName, liked, getImageCount(reviews));
+        } else {
+            return InfoDto.ofGeneralBuildingInfo(reviews, building, liked, getImageCount(reviews));
         }
     }
 
-    public InfoDto agencySearch(Long itemId, Boolean liked){
-        Agencies agencies = agenciesRepository.findById(itemId).orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
-        Reviews reviews = reviewsRepository.findFirstByAgencyAndDtypeOrderByCreatedAtDesc(agencies,ReviewType.AGENCY);
-        return InfoDto.ofAgencyBuildingInfo(reviews,agencies,liked);
+    public InfoDto agencySearch(Long itemId, Boolean liked) {
+        Agencies agencies = agenciesRepository.findById(itemId)
+                .orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
+        Reviews reviews = reviewsRepository.findFirstByAgencyAndDtypeOrderByCreatedAtDesc(agencies, ReviewType.AGENCY);
+        return InfoDto.ofAgencyBuildingInfo(reviews, agencies, liked, getImageCount(reviews));
     }
 
-    public SearchInfoDto reviewSearchWithBound(Long reviewId, Boolean liked){
+    public SearchInfoDto reviewSearchWithBound(Long reviewId, Boolean liked) {
         Reviews item = reviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("Review"));
-        switch (item.getDtype()){
+        switch (item.getDtype()) {
             case ReviewType.GENERAL:
-                GeneralReviews generalReviews = generalReviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("GeneralReview"));
-                if(generalReviews.getContractType()==null || generalReviews.getFloor()==null||generalReviews.getArea()==null){
+                GeneralReviews generalReviews = generalReviewsRepository.findById(reviewId)
+                        .orElseThrow(() -> new BookmarkNotFoundException("GeneralReview"));
+                if (generalReviews.getContractType() == null || generalReviews.getFloor() == null
+                        || generalReviews.getArea() == null) {
                     throw new BookmarkNotFoundException("GeneralReview");
                 }
-                return SearchInfoDto.ofSearchGeneralReviewInfo(generalReviews,liked);
+                return SearchInfoDto.ofSearchGeneralReviewInfo(generalReviews, liked);
             case ReviewType.DORM:
-                DormReviews dormReviews = dormReviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("DormReview"));
-                if(dormReviews.getDormFee()==null||dormReviews.getDormFee()==null||dormReviews.getCapacity()==null){
+                DormReviews dormReviews = dormReviewsRepository.findById(reviewId)
+                        .orElseThrow(() -> new BookmarkNotFoundException("DormReview"));
+                if (dormReviews.getDormFee() == null || dormReviews.getDormFee() == null
+                        || dormReviews.getCapacity() == null) {
                     throw new BookmarkNotFoundException("DormReview");
                 }
                 Buildings building = item.getBuilding();
@@ -97,15 +108,15 @@ public class SearchInfo {
                 return SearchInfoDto.ofSearchDormitoryReviewInfo(dormReviews, building, universityName, liked);
             case ReviewType.AGENCY:
                 Agencies agencies = item.getAgency();
-                return SearchInfoDto.ofSearchAgencyReviewInfo(item,agencies,liked);
+                return SearchInfoDto.ofSearchAgencyReviewInfo(item, agencies, liked);
             default:
                 throw new UnprocessableGroupException("후기 유형 dtype에 이상있습니다.");
         }
     }
 
-    public SearchInfoDto buildingSearchWithBound(Long itemId, Boolean liked){
+    public SearchInfoDto buildingSearchWithBound(Long itemId, Boolean liked) {
         Buildings building = buildingsRepository.findById(itemId)
-            .orElseThrow(() -> new BookmarkNotFoundException("Building"));
+                .orElseThrow(() -> new BookmarkNotFoundException("Building"));
 
         Reviews reviews = reviewsRepository.findFirstByBuildingOrderByCreatedAtDesc(building);
 
@@ -124,18 +135,18 @@ public class SearchInfo {
                 return SearchInfoDto.ofSearchDormitoryBuildingInfo(reviews, building, universityName, liked);
             case AGENCY:
                 Agencies agency = agenciesRepository.findByAgencySerial(building.getBuildingCode())
-                    .orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
+                        .orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
                 Reviews agencyReview = reviewsRepository.findFirstByAgencyAndDtypeOrderByCreatedAtDesc(
-                    agency, ReviewType.AGENCY);
+                        agency, ReviewType.AGENCY);
                 return SearchInfoDto.ofSearchAgencyBuildingInfo(agencyReview, agency, liked);
             default:
                 return SearchInfoDto.ofSearchGeneralBuildingInfo(reviews, building, liked);
         }
     }
 
-    public SearchInfoDto agencySearchWithBound(Long itemId, Boolean liked, ViewType viewType){
+    public SearchInfoDto agencySearchWithBound(Long itemId, Boolean liked, ViewType viewType) {
         Agencies agencies = agenciesRepository.findById(itemId)
-            .orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
+                .orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
         Reviews reviews = reviewsRepository
                 .findFirstByAgencyAndDtypeOrderByCreatedAtDesc(agencies, ReviewType.AGENCY);
         if (viewType == ViewType.REVIEW) {
@@ -146,5 +157,14 @@ public class SearchInfo {
         }
 
         return SearchInfoDto.ofSearchAgencyBuildingInfo(reviews, agencies, liked);
+    }
+
+    private Integer getImageCount(Reviews review) {
+        if (review == null) {
+            return 0;
+        }
+        ReviewDetails details = reviewDetailRepository.findByReviewId(review.getId())
+                .orElseThrow(ReviewInternalServerErrorException::missingReviewDetailException);
+        return details.getImageCount();
     }
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/SearchInfo.java
@@ -27,22 +27,18 @@ public class SearchInfo {
     private final DormReviewsRepository dormReviewsRepository;
     private final ReviewDetailsRepository reviewDetailRepository;
 
-    public InfoDto reviewSearch(Long reviewId, Boolean liked) {
+    public InfoDto reviewSearch(Long reviewId, Boolean liked){
         Reviews item = reviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("Review"));
-        switch (item.getDtype()) {
+        switch (item.getDtype()){
             case ReviewType.GENERAL:
-                GeneralReviews generalReviews = generalReviewsRepository.findById(reviewId)
-                        .orElseThrow(() -> new BookmarkNotFoundException("GeneralReview"));
-                if (generalReviews.getContractType() == null || generalReviews.getFloor() == null
-                        || generalReviews.getArea() == null) {
+                GeneralReviews generalReviews = generalReviewsRepository.findById(reviewId).orElseThrow(()-> new BookmarkNotFoundException("GeneralReview"));
+                if(generalReviews.getContractType()==null || generalReviews.getFloor()==null||generalReviews.getArea()==null){
                     throw new BookmarkNotFoundException("GeneralReview");
                 }
                 return InfoDto.ofGeneralReviewInfo(generalReviews, liked, getImageCount(item));
             case ReviewType.DORM:
-                DormReviews dormReviews = dormReviewsRepository.findById(reviewId)
-                        .orElseThrow(() -> new BookmarkNotFoundException("DormReview"));
-                if (dormReviews.getDormFee() == null || dormReviews.getDormFee() == null
-                        || dormReviews.getCapacity() == null) {
+                DormReviews dormReviews =dormReviewsRepository.findById(reviewId).orElseThrow(()-> new BookmarkNotFoundException("DormReview"));
+                if(dormReviews.getDormFee()==null||dormReviews.getDormFee()==null||dormReviews.getCapacity()==null){
                     throw new BookmarkNotFoundException("DormReview");
                 }
 
@@ -60,10 +56,9 @@ public class SearchInfo {
         }
     }
 
-    public InfoDto buildingSearch(Long itemId, Boolean liked) {
-        Buildings building = buildingsRepository.findById(itemId)
-                .orElseThrow(() -> new BookmarkNotFoundException("Building"));
-        Reviews reviews = reviewsRepository.findFirstByBuildingOrderByCreatedAtDesc(building);
+    public InfoDto buildingSearch(Long itemId, Boolean liked){
+        Buildings building = buildingsRepository.findById(itemId).orElseThrow(() -> new BookmarkNotFoundException("Building"));
+        Reviews reviews= reviewsRepository.findFirstByBuildingOrderByCreatedAtDesc(building);
         List<BuildingType> typeList = building.getBuildingType();
 
         if (typeList.equals(List.of(BuildingType.DORMITORY))) {
@@ -83,22 +78,18 @@ public class SearchInfo {
         return InfoDto.ofAgencyBuildingInfo(reviews, agencies, liked, getImageCount(reviews));
     }
 
-    public SearchInfoDto reviewSearchWithBound(Long reviewId, Boolean liked) {
+    public SearchInfoDto reviewSearchWithBound(Long reviewId, Boolean liked){
         Reviews item = reviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("Review"));
-        switch (item.getDtype()) {
+        switch (item.getDtype()){
             case ReviewType.GENERAL:
-                GeneralReviews generalReviews = generalReviewsRepository.findById(reviewId)
-                        .orElseThrow(() -> new BookmarkNotFoundException("GeneralReview"));
-                if (generalReviews.getContractType() == null || generalReviews.getFloor() == null
-                        || generalReviews.getArea() == null) {
+                GeneralReviews generalReviews = generalReviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("GeneralReview"));
+                if(generalReviews.getContractType()==null || generalReviews.getFloor()==null||generalReviews.getArea()==null){
                     throw new BookmarkNotFoundException("GeneralReview");
                 }
-                return SearchInfoDto.ofSearchGeneralReviewInfo(generalReviews, liked);
+                return SearchInfoDto.ofSearchGeneralReviewInfo(generalReviews,liked);
             case ReviewType.DORM:
-                DormReviews dormReviews = dormReviewsRepository.findById(reviewId)
-                        .orElseThrow(() -> new BookmarkNotFoundException("DormReview"));
-                if (dormReviews.getDormFee() == null || dormReviews.getDormFee() == null
-                        || dormReviews.getCapacity() == null) {
+                DormReviews dormReviews = dormReviewsRepository.findById(reviewId).orElseThrow(() -> new BookmarkNotFoundException("DormReview"));
+                if(dormReviews.getDormFee()==null||dormReviews.getDormFee()==null||dormReviews.getCapacity()==null){
                     throw new BookmarkNotFoundException("DormReview");
                 }
                 Buildings building = item.getBuilding();
@@ -108,13 +99,13 @@ public class SearchInfo {
                 return SearchInfoDto.ofSearchDormitoryReviewInfo(dormReviews, building, universityName, liked);
             case ReviewType.AGENCY:
                 Agencies agencies = item.getAgency();
-                return SearchInfoDto.ofSearchAgencyReviewInfo(item, agencies, liked);
+                return SearchInfoDto.ofSearchAgencyReviewInfo(item,agencies,liked);
             default:
                 throw new UnprocessableGroupException("후기 유형 dtype에 이상있습니다.");
         }
     }
 
-    public SearchInfoDto buildingSearchWithBound(Long itemId, Boolean liked) {
+    public SearchInfoDto buildingSearchWithBound(Long itemId, Boolean liked){
         Buildings building = buildingsRepository.findById(itemId)
                 .orElseThrow(() -> new BookmarkNotFoundException("Building"));
 
@@ -144,7 +135,7 @@ public class SearchInfo {
         }
     }
 
-    public SearchInfoDto agencySearchWithBound(Long itemId, Boolean liked, ViewType viewType) {
+    public SearchInfoDto agencySearchWithBound(Long itemId, Boolean liked, ViewType viewType){
         Agencies agencies = agenciesRepository.findById(itemId)
                 .orElseThrow(() -> new BookmarkNotFoundException("Agencies"));
         Reviews reviews = reviewsRepository

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -50,8 +50,8 @@ public class UsersServiceImpl implements UsersService {
 
 	@Override
 	public boolean existsByProviderId(String providerId) {
-        return usersRepository.findByProviderId(providerId).isPresent();
-    }
+		return usersRepository.findByProviderId(providerId).isPresent();
+	}
 
 	@Override
 	public Users findByProviderId(String providerId) {
@@ -105,18 +105,16 @@ public class UsersServiceImpl implements UsersService {
 						dormReviews,
 						user,
 						buildImageUrl(dormReviews.getId()),
-						reviewLikesRepository
-				)
-		);
+						reviewLikesRepository,
+						reviewDetailsRepository));
 
 		Stream<UserReviewResponse> agencyStream = agencyReviewsPage.stream().map(
 				agencyReviews -> UserReviewResponse.fromAgency(
 						agencyReviews,
 						user,
 						buildImageUrl(agencyReviews.getId()),
-						reviewLikesRepository
-				)
-		);
+						reviewLikesRepository,
+						reviewDetailsRepository));
 
 		Comparator<UserReviewResponse> comparator = Comparator.comparing(r -> r.reviewInfo().updateAt());
 		if ("latest".equalsIgnoreCase(order)) {
@@ -176,7 +174,7 @@ public class UsersServiceImpl implements UsersService {
 		ensureSystemUserExists(user);
 
 		Users systemUser = usersRepository.findByProviderId(SYSTEM_DELETE_ID)
-			.orElseThrow(UserNotFoundException::systemError);
+				.orElseThrow(UserNotFoundException::systemError);
 
 		Long targetUserId = user.getUserId();
 

--- a/src/main/java/JJinBBang/app/global/common/dto/InfoDto.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/InfoDto.java
@@ -6,72 +6,74 @@ import lombok.Builder;
 
 @Builder
 public record InfoDto(
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        GeneralReviewInfo generalReviewInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL) GeneralReviewInfo generalReviewInfo,
 
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        GeneralBuildingInfo generalBuildingInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL) GeneralBuildingInfo generalBuildingInfo,
 
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        DormitoryReviewInfo dormitoryReviewInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL) DormitoryReviewInfo dormitoryReviewInfo,
 
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        DormitoryBuildingInfo dormitoryBuildingInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL) DormitoryBuildingInfo dormitoryBuildingInfo,
 
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        AgencyReviewInfo agencyReviewInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL) AgencyReviewInfo agencyReviewInfo,
 
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        AgencyBuildingInfo agencyBuildingInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL) AgencyBuildingInfo agencyBuildingInfo,
 
         ReviewInfo reviewInfo,
-        String image
-) {
-    public static InfoDto ofGeneralReviewInfo(GeneralReviews generalReview, Boolean liked) {
+        String image,
+        Integer imageCount) {
+    public static InfoDto ofGeneralReviewInfo(GeneralReviews generalReview, Boolean liked, Integer imageCount) {
         return InfoDto.builder()
                 .generalReviewInfo(GeneralReviewInfo.of(generalReview, liked))
                 .reviewInfo(ReviewInfo.of(generalReview))
                 .image(generalReview.getThumbnailImage())
+                .imageCount(imageCount)
                 .build();
     }
 
-    public static InfoDto ofGeneralBuildingInfo(Reviews review, Buildings building, Boolean liked) {
+    public static InfoDto ofGeneralBuildingInfo(Reviews review, Buildings building, Boolean liked, Integer imageCount) {
         return InfoDto.builder()
-                .generalBuildingInfo(GeneralBuildingInfo.of(building,liked))
-                .reviewInfo(ReviewInfo.ofBuilding(review,building))
+                .generalBuildingInfo(GeneralBuildingInfo.of(building, liked))
+                .reviewInfo(ReviewInfo.ofBuilding(review, building))
                 .image(review != null ? review.getThumbnailImage() : null)
+                .imageCount(imageCount)
                 .build();
     }
 
-    public static InfoDto ofDormitoryReviewInfo(DormReviews dormReview, Buildings building, String universityName, Boolean liked) {
+    public static InfoDto ofDormitoryReviewInfo(DormReviews dormReview, Buildings building, String universityName,
+            Boolean liked, Integer imageCount) {
         return InfoDto.builder()
-                .dormitoryReviewInfo(DormitoryReviewInfo.of(dormReview,building,universityName,liked))
+                .dormitoryReviewInfo(DormitoryReviewInfo.of(dormReview, building, universityName, liked))
                 .reviewInfo(ReviewInfo.of(dormReview))
                 .image(dormReview.getThumbnailImage())
+                .imageCount(imageCount)
                 .build();
     }
 
-    public static InfoDto ofDormitoryBuildingInfo(Reviews review, Buildings building, String universityName, Boolean liked) {
+    public static InfoDto ofDormitoryBuildingInfo(Reviews review, Buildings building, String universityName,
+            Boolean liked, Integer imageCount) {
         return InfoDto.builder()
-                .dormitoryBuildingInfo(DormitoryBuildingInfo.of(building,universityName,liked))
-                .reviewInfo(ReviewInfo.ofBuilding(review,building))
+                .dormitoryBuildingInfo(DormitoryBuildingInfo.of(building, universityName, liked))
+                .reviewInfo(ReviewInfo.ofBuilding(review, building))
                 .image(review != null ? review.getThumbnailImage() : null)
+                .imageCount(imageCount)
                 .build();
     }
 
-    public static InfoDto ofAgencyReviewInfo(Reviews review, Agencies agency, Boolean liked) {
+    public static InfoDto ofAgencyReviewInfo(Reviews review, Agencies agency, Boolean liked, Integer imageCount) {
         return InfoDto.builder()
-                .agencyReviewInfo(AgencyReviewInfo.of(review,agency,liked))
+                .agencyReviewInfo(AgencyReviewInfo.of(review, agency, liked))
                 .reviewInfo(ReviewInfo.of(review))
                 .image(review.getThumbnailImage())
+                .imageCount(imageCount)
                 .build();
     }
 
-    public static InfoDto ofAgencyBuildingInfo(Reviews review, Agencies agency, Boolean liked) {
+    public static InfoDto ofAgencyBuildingInfo(Reviews review, Agencies agency, Boolean liked, Integer imageCount) {
         return InfoDto.builder()
-                .agencyBuildingInfo(AgencyBuildingInfo.of(agency,liked))
-                .reviewInfo(ReviewInfo.ofAgency(review,agency))
+                .agencyBuildingInfo(AgencyBuildingInfo.of(agency, liked))
+                .reviewInfo(ReviewInfo.ofAgency(review, agency))
                 .image(review != null ? review.getThumbnailImage() : null)
+                .imageCount(imageCount)
                 .build();
     }
 }

--- a/src/main/java/JJinBBang/app/global/common/dto/InfoDto.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/InfoDto.java
@@ -6,17 +6,23 @@ import lombok.Builder;
 
 @Builder
 public record InfoDto(
-        @JsonInclude(JsonInclude.Include.NON_NULL) GeneralReviewInfo generalReviewInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        GeneralReviewInfo generalReviewInfo,
 
-        @JsonInclude(JsonInclude.Include.NON_NULL) GeneralBuildingInfo generalBuildingInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        GeneralBuildingInfo generalBuildingInfo,
 
-        @JsonInclude(JsonInclude.Include.NON_NULL) DormitoryReviewInfo dormitoryReviewInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        DormitoryReviewInfo dormitoryReviewInfo,
 
-        @JsonInclude(JsonInclude.Include.NON_NULL) DormitoryBuildingInfo dormitoryBuildingInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        DormitoryBuildingInfo dormitoryBuildingInfo,
 
-        @JsonInclude(JsonInclude.Include.NON_NULL) AgencyReviewInfo agencyReviewInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        AgencyReviewInfo agencyReviewInfo,
 
-        @JsonInclude(JsonInclude.Include.NON_NULL) AgencyBuildingInfo agencyBuildingInfo,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        AgencyBuildingInfo agencyBuildingInfo,
 
         ReviewInfo reviewInfo,
         String image,
@@ -32,8 +38,8 @@ public record InfoDto(
 
     public static InfoDto ofGeneralBuildingInfo(Reviews review, Buildings building, Boolean liked, Integer imageCount) {
         return InfoDto.builder()
-                .generalBuildingInfo(GeneralBuildingInfo.of(building, liked))
-                .reviewInfo(ReviewInfo.ofBuilding(review, building))
+                .generalBuildingInfo(GeneralBuildingInfo.of(building,liked))
+                .reviewInfo(ReviewInfo.ofBuilding(review,building))
                 .image(review != null ? review.getThumbnailImage() : null)
                 .imageCount(imageCount)
                 .build();
@@ -42,7 +48,7 @@ public record InfoDto(
     public static InfoDto ofDormitoryReviewInfo(DormReviews dormReview, Buildings building, String universityName,
             Boolean liked, Integer imageCount) {
         return InfoDto.builder()
-                .dormitoryReviewInfo(DormitoryReviewInfo.of(dormReview, building, universityName, liked))
+                .dormitoryReviewInfo(DormitoryReviewInfo.of(dormReview,building,universityName,liked))
                 .reviewInfo(ReviewInfo.of(dormReview))
                 .image(dormReview.getThumbnailImage())
                 .imageCount(imageCount)
@@ -52,8 +58,8 @@ public record InfoDto(
     public static InfoDto ofDormitoryBuildingInfo(Reviews review, Buildings building, String universityName,
             Boolean liked, Integer imageCount) {
         return InfoDto.builder()
-                .dormitoryBuildingInfo(DormitoryBuildingInfo.of(building, universityName, liked))
-                .reviewInfo(ReviewInfo.ofBuilding(review, building))
+                .dormitoryBuildingInfo(DormitoryBuildingInfo.of(building,universityName,liked))
+                .reviewInfo(ReviewInfo.ofBuilding(review,building))
                 .image(review != null ? review.getThumbnailImage() : null)
                 .imageCount(imageCount)
                 .build();
@@ -61,7 +67,7 @@ public record InfoDto(
 
     public static InfoDto ofAgencyReviewInfo(Reviews review, Agencies agency, Boolean liked, Integer imageCount) {
         return InfoDto.builder()
-                .agencyReviewInfo(AgencyReviewInfo.of(review, agency, liked))
+                .agencyReviewInfo(AgencyReviewInfo.of(review,agency,liked))
                 .reviewInfo(ReviewInfo.of(review))
                 .image(review.getThumbnailImage())
                 .imageCount(imageCount)
@@ -70,8 +76,8 @@ public record InfoDto(
 
     public static InfoDto ofAgencyBuildingInfo(Reviews review, Agencies agency, Boolean liked, Integer imageCount) {
         return InfoDto.builder()
-                .agencyBuildingInfo(AgencyBuildingInfo.of(agency, liked))
-                .reviewInfo(ReviewInfo.ofAgency(review, agency))
+                .agencyBuildingInfo(AgencyBuildingInfo.of(agency,liked))
+                .reviewInfo(ReviewInfo.ofAgency(review,agency))
                 .image(review != null ? review.getThumbnailImage() : null)
                 .imageCount(imageCount)
                 .build();


### PR DESCRIPTION
## 📌 이슈 번호
#290 

## 💬 리뷰 포인트
imageCount를 위한 `getImageCount `추가.

## 🚀 상세 설명
- 관심목록 조회 API
- 마이페이지 조회 API
- 내 주변 찐빵 조회 API
위 3개의 API에서 이미지 갯수를 응답으로 추가하였습니다

## 📸 스크린샷

## 📢 노트
- Notion API 명세서 업데이트 해뒀습니다아