### PR TITLE
[Feat #285] 찐빵 콘텐츠 관리자 기능 개발

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportAdminController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportAdminController.java
@@ -48,4 +48,17 @@ public class ReportAdminController {
         return new ResTemplate<>(HttpStatus.OK, "콘텐츠 수정 성공", null);
     }
 
+    @DeleteMapping("{reportId}")
+    public ResTemplate<?> deleteReport(
+            @PathVariable Long reportId,
+            @AuthenticationPrincipal Users user
+    ) {
+        if (user == null) throw InvalidTokenException.unauthorized();
+
+        // 일반 사용자 접근 시 예외처리
+        if (user.getRole() != UserRole.ADMIN) throw AdminAccessException.accessDenied();
+
+        reportAdminService.deleteReport(reportId);
+        return new ResTemplate<>(HttpStatus.OK, "콘텐츠 삭제 성공", null);
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportAdminController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportAdminController.java
@@ -1,0 +1,36 @@
+package JJinBBang.app.domain.common.controller;
+
+import JJinBBang.app.domain.common.dto.request.ReportRequest;
+import JJinBBang.app.domain.common.exception.AdminAccessException;
+import JJinBBang.app.domain.common.service.ReportAdminService;
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.enums.UserRole;
+import JJinBBang.app.domain.user.exception.InvalidTokenException;
+import JJinBBang.app.global.template.ResTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/report")
+public class ReportAdminController {
+
+    private final ReportAdminService reportAdminService;
+
+    @PostMapping("")
+    public ResTemplate<?> createReport(
+            @AuthenticationPrincipal Users user,
+            @RequestBody ReportRequest req
+    ) {
+        if (user == null) throw InvalidTokenException.unauthorized();
+
+        // 일반 사용자 접근 시 예외처리
+        if (user.getRole() != UserRole.ADMIN) throw AdminAccessException.accessDenied();
+
+        reportAdminService.creatReport(user, req);
+        return new ResTemplate<>(HttpStatus.CREATED, "콘텐츠 작성 성공", null);
+    }
+
+}

--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportAdminController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportAdminController.java
@@ -29,7 +29,7 @@ public class ReportAdminController {
         // 일반 사용자 접근 시 예외처리
         if (user.getRole() != UserRole.ADMIN) throw AdminAccessException.accessDenied();
 
-        reportAdminService.creatReport(req);
+        reportAdminService.createReport(req);
         return new ResTemplate<>(HttpStatus.CREATED, "콘텐츠 작성 성공", null);
     }
 

--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportAdminController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportAdminController.java
@@ -29,8 +29,23 @@ public class ReportAdminController {
         // 일반 사용자 접근 시 예외처리
         if (user.getRole() != UserRole.ADMIN) throw AdminAccessException.accessDenied();
 
-        reportAdminService.creatReport(user, req);
+        reportAdminService.creatReport(req);
         return new ResTemplate<>(HttpStatus.CREATED, "콘텐츠 작성 성공", null);
+    }
+
+    @PutMapping("{reportId}")
+    public ResTemplate<?> updateReport(
+            @PathVariable Long reportId,
+            @AuthenticationPrincipal Users user,
+            @RequestBody ReportRequest req
+    ) {
+        if (user == null) throw InvalidTokenException.unauthorized();
+
+        // 일반 사용자 접근 시 예외처리
+        if (user.getRole() != UserRole.ADMIN) throw AdminAccessException.accessDenied();
+
+        reportAdminService.updateReport(reportId, req);
+        return new ResTemplate<>(HttpStatus.OK, "콘텐츠 수정 성공", null);
     }
 
 }

--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportAdminController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportAdminController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/admin/report")
+@RequestMapping("/api/admin/report")
 public class ReportAdminController {
 
     private final ReportAdminService reportAdminService;

--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
@@ -4,6 +4,7 @@ import JJinBBang.app.domain.common.dto.response.ReportInfoResponse;
 import JJinBBang.app.domain.common.dto.response.ReportListResponse;
 import JJinBBang.app.domain.common.service.ReportService;
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.exception.InvalidTokenException;
 import JJinBBang.app.global.template.ResTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -34,7 +35,7 @@ public class ReportController {
 
     @GetMapping("{reportId}")
     public ResTemplate<ReportInfoResponse> getReportDetail(
-            @AuthenticationPrincipal Users user,
+            @AuthenticationPrincipal Users user, // nullable
             @PathVariable Long reportId
     ) {
         ReportInfoResponse data = reportService.getReportDetail(user, reportId);
@@ -46,6 +47,9 @@ public class ReportController {
             @AuthenticationPrincipal Users user,
             @PathVariable Long reportId
     ) {
+        // 콘텐츠 조회 시 인증 필요 x -> 전역 예외처리 적용 시 제거
+        if (user == null) throw InvalidTokenException.unauthorized();
+
         reportService.addLike(user, reportId);
         return new ResTemplate<>(HttpStatus.OK, "리포트 좋아요 추가 성공", null);
     }
@@ -55,6 +59,9 @@ public class ReportController {
             @AuthenticationPrincipal Users user,
             @PathVariable Long reportId
     ) {
+        // 콘텐츠 조회 시 인증 필요 x -> 전역 예외처리 적용 시 제거
+        if (user == null) throw InvalidTokenException.unauthorized();
+
         reportService.deleteLike(user, reportId);
         return new ResTemplate<>(HttpStatus.OK, "리포트 좋아요 삭제 성공", null);
     }

--- a/src/main/java/JJinBBang/app/domain/common/dto/request/ReportRequest.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/request/ReportRequest.java
@@ -1,0 +1,9 @@
+package JJinBBang.app.domain.common.dto.request;
+
+public record ReportRequest(
+        String category,
+        String coverImage,
+        String title,
+        String content
+) {
+}

--- a/src/main/java/JJinBBang/app/domain/common/dto/request/ReportRequest.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/request/ReportRequest.java
@@ -1,9 +1,11 @@
 package JJinBBang.app.domain.common.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record ReportRequest(
-        String category,
-        String coverImage,
-        String title,
-        String content
+        @NotBlank String category,
+        @NotBlank String coverImage,
+        @NotBlank String title,
+        @NotBlank String content
 ) {
 }

--- a/src/main/java/JJinBBang/app/domain/common/entity/Reports.java
+++ b/src/main/java/JJinBBang/app/domain/common/entity/Reports.java
@@ -69,4 +69,16 @@ public class Reports extends BaseEntity {
         report.content = content;
         return report;
     }
+
+    public void update(
+            ReportCategory category,
+            String coverImage,
+            String title,
+            String content
+    ) {
+        this.category = category;
+        this.coverImage = coverImage;
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/common/entity/Reports.java
+++ b/src/main/java/JJinBBang/app/domain/common/entity/Reports.java
@@ -60,4 +60,13 @@ public class Reports extends BaseEntity {
     public void decreaseLikeCount() {
         if (this.likeCount > 0) this.likeCount--;
     }
+
+    public static Reports create(String coverImage, ReportCategory category, String title, String content) {
+        Reports report = new Reports();
+        report.coverImage = coverImage;
+        report.category = category;
+        report.title = title;
+        report.content = content;
+        return report;
+    }
 }

--- a/src/main/java/JJinBBang/app/domain/common/enums/ReportCategory.java
+++ b/src/main/java/JJinBBang/app/domain/common/enums/ReportCategory.java
@@ -1,17 +1,34 @@
 package JJinBBang.app.domain.common.enums;
 
+import java.util.Arrays;
+
 public enum ReportCategory {
-    REAL_ESTATE, // 부동산
-    TIPS, // 자취 꿀팁
-    CAMPUS_LIFE, // 대학 생활
-    MOVING, // 이사 관련
-    INTERVIEW; // 인터뷰
+    REAL_ESTATE("부동산"), // 부동산
+    TIPS("자취 꿀팁"), // 자취 꿀팁
+    CAMPUS_LIFE("대학 생활"), // 대학 생활
+    MOVING("이사 관련"), // 이사 관련
+    INTERVIEW("인터뷰"); // 인터뷰
+
+    private final String label;
+
+    ReportCategory(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
 
     public static ReportCategory from(String value) {
+        String v = value.trim();
+
         try {
-            return ReportCategory.valueOf(value.trim().toUpperCase());
-        } catch (Exception e) {
-            throw new IllegalArgumentException(e.getMessage());
-        }
+            return ReportCategory.valueOf(v.toUpperCase());
+        } catch (Exception ignore) {}
+
+        return Arrays.stream(values())
+                .filter(category -> category.label.equals(v))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Category: " + v));
     }
 }

--- a/src/main/java/JJinBBang/app/domain/common/enums/ReportCategory.java
+++ b/src/main/java/JJinBBang/app/domain/common/enums/ReportCategory.java
@@ -21,13 +21,8 @@ public enum ReportCategory {
 
     public static ReportCategory from(String value) {
         String v = value.trim();
-
-        try {
-            return ReportCategory.valueOf(v.toUpperCase());
-        } catch (Exception ignore) {}
-
         return Arrays.stream(values())
-                .filter(category -> category.label.equals(v))
+                .filter(category -> category.name().equalsIgnoreCase(v) || category.label.equals(v))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Category: " + v));
     }

--- a/src/main/java/JJinBBang/app/domain/common/exception/AdminAccessException.java
+++ b/src/main/java/JJinBBang/app/domain/common/exception/AdminAccessException.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.domain.common.exception;
+
+import JJinBBang.app.global.error.exception.AccessDeniedGroupException;
+
+public class AdminAccessException extends AccessDeniedGroupException {
+    public AdminAccessException(String message) {
+        super(message);
+    }
+
+    public static AdminAccessException accessDenied() {
+        return new AdminAccessException("관리자 외 접근 불가입니다.");
+    }
+}

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportAdminService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportAdminService.java
@@ -10,4 +10,7 @@ public interface ReportAdminService {
 
     @Transactional
     void updateReport(Long reportId, ReportRequest req);
+
+    @Transactional
+    void deleteReport(Long reportId);
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportAdminService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportAdminService.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.domain.common.service;
+
+import JJinBBang.app.domain.common.dto.request.ReportRequest;
+import JJinBBang.app.domain.user.entity.Users;
+import jakarta.transaction.Transactional;
+
+public interface ReportAdminService {
+
+    @Transactional
+    void creatReport(Users users, ReportRequest req);
+
+
+}

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportAdminService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportAdminService.java
@@ -1,16 +1,12 @@
 package JJinBBang.app.domain.common.service;
 
 import JJinBBang.app.domain.common.dto.request.ReportRequest;
-import jakarta.transaction.Transactional;
 
 public interface ReportAdminService {
 
-    @Transactional
-    void creatReport(ReportRequest req);
+    void createReport(ReportRequest req);
 
-    @Transactional
     void updateReport(Long reportId, ReportRequest req);
 
-    @Transactional
     void deleteReport(Long reportId);
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportAdminService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportAdminService.java
@@ -1,13 +1,13 @@
 package JJinBBang.app.domain.common.service;
 
 import JJinBBang.app.domain.common.dto.request.ReportRequest;
-import JJinBBang.app.domain.user.entity.Users;
 import jakarta.transaction.Transactional;
 
 public interface ReportAdminService {
 
     @Transactional
-    void creatReport(Users users, ReportRequest req);
+    void creatReport(ReportRequest req);
 
-
+    @Transactional
+    void updateReport(Long reportId, ReportRequest req);
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportAdminServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportAdminServiceImpl.java
@@ -1,0 +1,30 @@
+package JJinBBang.app.domain.common.service;
+
+import JJinBBang.app.domain.common.dto.request.ReportRequest;
+import JJinBBang.app.domain.common.entity.Reports;
+import JJinBBang.app.domain.common.enums.ReportCategory;
+import JJinBBang.app.domain.common.repository.ReportRepository;
+import JJinBBang.app.domain.user.entity.Users;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportAdminServiceImpl implements ReportAdminService {
+
+    private final ReportRepository reportRepository;
+
+    @Transactional
+    @Override
+    public void creatReport(Users users, ReportRequest req) {
+        Reports report = Reports.create(
+                req.coverImage(),
+                ReportCategory.from(req.category()),
+                req.title(),
+                req.content()
+        );
+
+        reportRepository.save(report);
+    }
+}

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportAdminServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportAdminServiceImpl.java
@@ -3,8 +3,8 @@ package JJinBBang.app.domain.common.service;
 import JJinBBang.app.domain.common.dto.request.ReportRequest;
 import JJinBBang.app.domain.common.entity.Reports;
 import JJinBBang.app.domain.common.enums.ReportCategory;
+import JJinBBang.app.domain.common.exception.ReportNotFoundGroupException;
 import JJinBBang.app.domain.common.repository.ReportRepository;
-import JJinBBang.app.domain.user.entity.Users;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +17,7 @@ public class ReportAdminServiceImpl implements ReportAdminService {
 
     @Transactional
     @Override
-    public void creatReport(Users users, ReportRequest req) {
+    public void creatReport(ReportRequest req) {
         Reports report = Reports.create(
                 req.coverImage(),
                 ReportCategory.from(req.category()),
@@ -26,5 +26,19 @@ public class ReportAdminServiceImpl implements ReportAdminService {
         );
 
         reportRepository.save(report);
+    }
+
+    @Transactional
+    @Override
+    public void updateReport(Long reportId, ReportRequest req) {
+        Reports report = reportRepository.findById(reportId)
+                .orElseThrow(ReportNotFoundGroupException::reportNotFound);
+
+        report.update(
+                ReportCategory.from(req.category()),
+                req.coverImage(),
+                req.title(),
+                req.content()
+        );
     }
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportAdminServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportAdminServiceImpl.java
@@ -5,19 +5,20 @@ import JJinBBang.app.domain.common.entity.Reports;
 import JJinBBang.app.domain.common.enums.ReportCategory;
 import JJinBBang.app.domain.common.exception.ReportNotFoundGroupException;
 import JJinBBang.app.domain.common.repository.ReportRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReportAdminServiceImpl implements ReportAdminService {
 
     private final ReportRepository reportRepository;
 
     @Transactional
     @Override
-    public void creatReport(ReportRequest req) {
+    public void createReport(ReportRequest req) {
         Reports report = Reports.create(
                 req.coverImage(),
                 ReportCategory.from(req.category()),

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportAdminServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportAdminServiceImpl.java
@@ -41,4 +41,13 @@ public class ReportAdminServiceImpl implements ReportAdminService {
                 req.content()
         );
     }
+
+    @Transactional
+    @Override
+    public void deleteReport(Long reportId) {
+        Reports report = reportRepository.findById(reportId)
+                .orElseThrow(ReportNotFoundGroupException::reportNotFound);
+
+        reportRepository.delete(report);
+    }
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #285 

## 💬 리뷰 포인트
- 찐빵 콘텐츠 관련 관리자 기능 개발 및 사용자 관련 수정사항

## 🚀 상세 설명
찐빵 콘텐츠 관련 관리자 기능 개발 진행하였습니다.
- 콘텐츠 작성 API
  - 콘텐츠 본문은 xml로 저장할 수 있도록 합니다.
- 콘텐츠 수정 API
- 콘텐츠 삭제 API

콘텐츠 접근 관련 수정 내용도 있습니다.
- 기존에는 콘텐츠 접근을 토큰을 갖고 접근 할 수 있도록 했던 내용을 조회는 토큰 없이도 조회 되도록 수정하였습니다.
- 좋아요 관련 기능에서는 토큰이 없는 경우 예외처리 되도록 수정하였습니다.

## 📸 스크린샷

## 📢 노트