### PR TITLE
Feat[#294]: 대학교 웹메일 주소에 서브도메인 및 와일드카드 기능 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/repository/UniversityRepository.java
+++ b/src/main/java/JJinBBang/app/domain/user/repository/UniversityRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -18,4 +20,53 @@ public interface UniversityRepository extends JpaRepository<Universities, Long> 
 
     Optional<Universities> findUniversitiesByUniversityDomain(String universityDomain);
     boolean existsByUniversityDomain(String universityDomain);
+
+    /**
+     * 입력된 도메인이 대학교 도메인과 매칭되는지 확인 (와일드카드 패턴 지원)
+     * 
+     * 매칭 규칙:
+     * 1. 정확한 매칭: universityDomain = inputDomain
+     * 2. 와일드카드 매칭: universityDomain이 '*.xxx' 형태이고 inputDomain이 'xxx' 또는 '*.xxx'로 끝나는 경우
+     * 3. 서브도메인 매칭: inputDomain이 universityDomain으로 끝나는 경우 (예: mail.gnu.ac.kr → gnu.ac.kr)
+     * 
+     * @param inputDomain 입력된 도메인 (예: "mail.gnu.ac.kr")
+     * @return 매칭되는 대학교 (우선순위: 정확한 매칭 > 와일드카드 > 서브도메인)
+     */
+    @Query(value = """
+        SELECT u.* FROM universities u
+        WHERE u.university_domain IS NOT NULL
+        AND (
+            u.university_domain = :inputDomain
+			-- 서브도메인 매칭
+            OR (:inputDomain LIKE CONCAT('%.', u.university_domain))
+			-- 와일드카드 매칭
+            OR (u.university_domain LIKE '*.%' AND :inputDomain LIKE CONCAT('%.', SUBSTRING(u.university_domain, 3)))
+        )
+        ORDER BY 
+            CASE 
+                WHEN u.university_domain = :inputDomain THEN 1
+                WHEN u.university_domain LIKE '*.%' THEN 2
+                ELSE 3
+            END
+        LIMIT 1
+        """, nativeQuery = true)
+    Optional<Universities> findFirstByDomainMatching(@Param("inputDomain") String inputDomain);
+
+    /**
+     * 입력된 도메인이 대학교 도메인과 매칭되는지 확인 (와일드카드 패턴 지원)
+     * 
+     * @param inputDomain 입력된 도메인 (예: "mail.gnu.ac.kr")
+     * @return 매칭 여부
+     */
+    @Query("""
+        SELECT COUNT(u) > 0
+        FROM Universities u
+        WHERE u.universityDomain IS NOT NULL
+        AND (
+            u.universityDomain = :inputDomain
+            OR (:inputDomain LIKE CONCAT('%.', u.universityDomain))
+            OR (u.universityDomain LIKE '*.%' AND :inputDomain LIKE CONCAT('%.', SUBSTRING(u.universityDomain, 3)))
+        )
+        """)
+    boolean existsByDomainMatching(@Param("inputDomain") String inputDomain);
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/UsersServiceImpl.java
@@ -144,9 +144,13 @@ public class UsersServiceImpl implements UsersService {
 		user.updateVerificationStatus(VerificationStatus.EMAIL_VERIFIED);
 
 		// 유저의 학교 정보 업데이트
-		String domain = extractDomain(universityEmail);
-		Universities authenticatedUniversity = universityRepository.findUniversitiesByUniversityDomain(domain)
-				.orElseThrow(() -> UniversityNotFoundException.universityNotFound(domain));
+		String inputDomain = extractDomain(universityEmail);
+		
+		// SQL 쿼리로 도메인 매칭 (정확한 매칭 + 와일드카드 패턴 + 서브도메인 매칭)
+		Universities authenticatedUniversity = universityRepository
+				.findFirstByDomainMatching(inputDomain)
+				.orElseThrow(() -> UniversityNotFoundException.universityNotFound(inputDomain));
+
 		user.updateUniversity(authenticatedUniversity);
 
 		return usersRepository.save(user);

--- a/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/mail/service/impl/MailAuthServiceImpl.java
@@ -72,12 +72,15 @@ public class MailAuthServiceImpl implements MailAuthService {
             throw MailInvalidException.invalidEmailFormat();
         }
 
-        // 이메일 도메인 검증
-        // DB에 저장되어있는 이메일 도메인인지 or 환경변수에 설정된 도메인인지 검사
-        if (!universityRepository.existsByUniversityDomain(extractDomain(email)) &&
-                !properties.getAllowedDomain().contains(extractDomain(email))) {
-            throw MailInvalidException.invalidEmailDomain();
+        String inputDomain = extractDomain(email);
+
+        // DB에서 도메인 매칭 확인 (정확한 매칭 + 와일드카드 패턴 + 서브도메인 매칭)
+        if (universityRepository.existsByDomainMatching(inputDomain)) {
+            return;
         }
+
+        // 모든 검증 실패
+        throw MailInvalidException.invalidEmailDomain();
     }
 
     private boolean isValidFormat(String email) {


### PR DESCRIPTION
## 📌 이슈 번호
> #294 

## 💬 리뷰 포인트
1. application-prod의 allowed-domain 기능을 비활성화 했습니다.
2. 대학교 웹메일 도메인에 서브도메인 및 와일드카드를 작성해도 동작하도록 구현하였습니다.

## 🚀 상세 설명
1. allowed-domain 기능 비활성화
기존: application-prod.yml의 mail-auth.allowed-domain과 DB의 universities 테이블을 함께 사용
변경: allowed-domain 설정을 비활성화하고 DB만 사용하도록 전환

2. 서브도메인 및 와일드카드 지원
서브도메인 매칭: mail.gnu.ac.kr → gnu.ac.kr 자동 인식
와일드카드 패턴: *.ac.kr 형태로 여러 서브도메인 일괄 관리 가능
매칭 우선순위: 정확한 매칭 > 와일드카드 > 서브도메인

## 📸 스크린샷

## 📢 노트
와일드카드(*.xxx)와 일반 도메인(xxx)이 중복되지 않도록 관리
서브도메인 매칭은 포함 관계를 고려해 추가 (예: gnu.ac.kr과 ac.kr 중복 주의)
새 도메인 추가 전 기존 도메인 목록을 확인해서 겹치지 않게 추가 부탁드립니다.