### PR TITLE
fix[#297]: Redis 및 Security 설정 개선

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/repository/impl/RedisPendingUserRepository.java
+++ b/src/main/java/JJinBBang/app/domain/user/repository/impl/RedisPendingUserRepository.java
@@ -5,13 +5,13 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import JJinBBang.app.domain.user.entity.PendingUser;
 import JJinBBang.app.domain.user.repository.PendingUserRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -21,10 +21,14 @@ import lombok.extern.slf4j.Slf4j;
 	name = "mode",
 	havingValue = "redis"
 )
-@RequiredArgsConstructor
 public class RedisPendingUserRepository implements PendingUserRepository {
 
-	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisTemplate<String, PendingUser> redisTemplate;
+
+	public RedisPendingUserRepository(
+			@Qualifier("pendingUserRedisTemplate") RedisTemplate<String, PendingUser> redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
 
 	private static final String PREFIX = "pending:user:";
 
@@ -45,7 +49,7 @@ public class RedisPendingUserRepository implements PendingUserRepository {
 	@Override
 	public Optional<PendingUser> findById(String pendingId) {
 		String key = key(pendingId);
-		PendingUser user = (PendingUser) redisTemplate.opsForValue().get(key);
+		PendingUser user = redisTemplate.opsForValue().get(key);
 		return Optional.ofNullable(user);
 	}
 

--- a/src/main/java/JJinBBang/app/global/config/RedisConfig.java
+++ b/src/main/java/JJinBBang/app/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.global.config;
 
+import JJinBBang.app.domain.user.entity.PendingUser;
 import JJinBBang.app.global.mail.dto.EmailAuthInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -23,12 +24,13 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
     @Bean
-    public RedisTemplate<String, EmailAuthInfo> redisTemplate(RedisConnectionFactory factory) {
+    public RedisTemplate<String, EmailAuthInfo> emailAuthRedisTemplate(RedisConnectionFactory factory) {
         RedisTemplate<String, EmailAuthInfo> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);
 
         // key: String serializer
         template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
 
         // value: JSON serializer for EmailAuthInfo
         ObjectMapper om = new ObjectMapper();
@@ -40,6 +42,51 @@ public class RedisConfig {
                 new Jackson2JsonRedisSerializer<>(om, EmailAuthInfo.class);
 
         template.setValueSerializer(ser);
+        template.setHashValueSerializer(ser);
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, PendingUser> pendingUserRedisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, PendingUser> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        // key: String serializer
+        template.setKeySerializer(new StringRedisSerializer());
+
+        // value: JSON serializer for PendingUser
+        ObjectMapper om = new ObjectMapper();
+        om.registerModule(new JavaTimeModule());
+        om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // 생성자 인자로 ObjectMapper와 target Class를 함께 넘김
+        Jackson2JsonRedisSerializer<PendingUser> ser =
+                new Jackson2JsonRedisSerializer<>(om, PendingUser.class);
+
+        template.setValueSerializer(ser);
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        // key: String serializer
+        template.setKeySerializer(new StringRedisSerializer());
+
+        // value: JSON serializer for Object (PendingUser 등 일반 객체용)
+        ObjectMapper om = new ObjectMapper();
+        om.registerModule(new JavaTimeModule());
+        om.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        Jackson2JsonRedisSerializer<Object> serializer =
+                new Jackson2JsonRedisSerializer<>(om, Object.class);
+
+        template.setValueSerializer(serializer);
+        template.setHashValueSerializer(serializer);
         template.afterPropertiesSet();
         return template;
     }

--- a/src/main/java/JJinBBang/app/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/JJinBBang/app/global/jwt/JwtAuthenticationFilter.java
@@ -66,8 +66,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 				SecurityContextHolder.getContext().setAuthentication(authentication);
 			} catch (InvalidTokenException e) {
 				authenticationEntryPoint.commence(request, response, e);
+				return;
 			} catch (NotFoundGroupException e) {
 				authenticationEntryPoint.commence(request, response, InvalidTokenException.userNotFound());
+				return;
 			}
 		}
 		filterChain.doFilter(request, response);

--- a/src/main/java/JJinBBang/app/global/mail/repository/RedisEmailAuthCodeRepository.java
+++ b/src/main/java/JJinBBang/app/global/mail/repository/RedisEmailAuthCodeRepository.java
@@ -2,8 +2,8 @@ package JJinBBang.app.global.mail.repository;
 
 import JJinBBang.app.global.mail.dto.EmailAuthInfo;
 import JJinBBang.app.global.mail.properties.MailAuthProperties;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -15,13 +15,19 @@ import java.util.concurrent.TimeUnit;
 @Repository
 @ConditionalOnProperty( // 조건부 빈 등록 (application.yml의 app.storage.mode 속성에 따라 redis 모드일 때만 활성화)
 		prefix = "app.repository", name = "mode", havingValue = "redis")
-@RequiredArgsConstructor
 public class RedisEmailAuthCodeRepository implements EmailAuthCodeRepository {
 
 	private static final String KEY_PREFIX = "emailAuth:";
 
 	private final RedisTemplate<String, EmailAuthInfo> redisTemplate;
 	private final MailAuthProperties props;
+
+	public RedisEmailAuthCodeRepository(
+			@Qualifier("emailAuthRedisTemplate") RedisTemplate<String, EmailAuthInfo> redisTemplate,
+			MailAuthProperties props) {
+		this.redisTemplate = redisTemplate;
+		this.props = props;
+	}
 
 	private String makeKey(Long userId) {
 		return KEY_PREFIX + userId;
@@ -40,7 +46,8 @@ public class RedisEmailAuthCodeRepository implements EmailAuthCodeRepository {
 	@Override
 	public boolean isExistByUserId(Long userId) {
 		String key = makeKey(userId);
-		return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+		Boolean exists = redisTemplate.hasKey(key);
+		return Boolean.TRUE.equals(exists);
 		// TTL이 지나면 키 자동 삭제
 	}
 

--- a/src/main/java/JJinBBang/app/global/security/SecurityConfig.java
+++ b/src/main/java/JJinBBang/app/global/security/SecurityConfig.java
@@ -57,13 +57,18 @@ public class SecurityConfig {
 	CorsConfigurationSource corsConfigurationSource() {
 
 		CorsConfiguration globalConfig = new CorsConfiguration();
-		globalConfig.setAllowedOrigins(List.of(
+		// setAllowCredentials(true)와 함께 사용할 때는 setAllowedOriginPatterns 사용
+		globalConfig.setAllowedOriginPatterns(List.of(
+				"https://localhost:3000",
 				"http://localhost:3000",
 				"http://localhost:5173",
-				"https://www.jjinbbang.kr"));
+				"https://www.jjinbbang.kr",
+				"https://*.jjinbbang.kr",  // 서브도메인 포함 (test.jjinbbang.kr 등)
+				"https://www.test.jjinbbang.kr"));
 		globalConfig.setAllowedMethods(List.of("GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS", "HEAD"));
 		globalConfig.setAllowedHeaders(List.of("*"));
 		globalConfig.setAllowCredentials(true);
+		globalConfig.setExposedHeaders(List.of("*"));  // 클라이언트에서 접근 가능한 헤더
 
 		CorsConfiguration swaggerConfig = new CorsConfiguration();
 		swaggerConfig.addAllowedOriginPattern("http://localhost:*");


### PR DESCRIPTION
## 📌 이슈 번호
- #297

## 💬 리뷰 포인트
- RedisTemplate 빈 설정 개선으로 의존성 주입 문제 해결
- CORS 설정 개선으로 서브도메인 환경 지원
- JWT 필터 예외 처리 후 필터 체인 중단 로직 추가

## 🚀 상세 설명

### Redis 설정 개선
**문제점:**
- 기존 `redisTemplate` 빈이 `RedisTemplate<String, EmailAuthInfo>` 타입으로 단일 용도로만 사용됨
- `RedisPendingUserRepository`에서 `RedisTemplate<String, Object>` 타입이 필요했으나 빈이 없어 의존성 주입 실패

**해결 방법:**
- `RedisConfig`에서 3개의 RedisTemplate 빈을 명확히 구분하여 생성
  - `emailAuthRedisTemplate`: 이메일 인증 코드 저장용 (`RedisTemplate<String, EmailAuthInfo>`)
  - `pendingUserRedisTemplate`: PendingUser 저장용 (`RedisTemplate<String, PendingUser>`)
  - `redisTemplate`: 범용 객체 저장용 (`RedisTemplate<String, Object>`)
- 각 빈에 `@Qualifier`를 사용하여 명시적 의존성 주입

### CORS 설정 개선
**문제점:**
- `setAllowedOrigins()`와 `setAllowCredentials(true)`를 함께 사용하면 와일드카드 패턴 사용 불가
- 서브도메인 환경(test.jjinbbang.kr 등)에서 CORS 오류 발생
- 클라이언트에서 접근 가능한 헤더가 명시되지 않음

**해결 방법:**
- `setAllowedOriginPatterns()`로 변경하여 와일드카드 패턴 지원
- 서브도메인 패턴 추가: `https://*.jjinbbang.kr`
- `setExposedHeaders(List.of("*"))` 추가로 클라이언트에서 모든 헤더 접근 가능

### JWT 필터 예외 처리 개선
**문제점:**
- `authenticationEntryPoint.commence()` 호출 후에도 필터 체인이 계속 진행됨
- 이미 응답이 커밋된 상태에서 추가 응답 작성 시도로 인한 예외 발생 가능

**해결 방법:**
- 예외 처리 후 `return` 추가하여 필터 체인 중단

## 📸 스크린샷

## 📢 노트
test 브랜치에서 배포 중 발견된 오류들을 수정하여 현재 브랜치에 적용했습니다.