### PR TITLE
[Feat #281] 신입생 인증 자동화 및 Slack 연결

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/controller/AdminUserController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AdminUserController.java
@@ -1,7 +1,5 @@
 package JJinBBang.app.domain.user.controller;
 
-import JJinBBang.app.domain.user.dto.request.UpdateVerificationStatusDto;
-import JJinBBang.app.domain.user.service.CertificateService;
 import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.slack.service.SlackService;
 import JJinBBang.app.global.template.ResTemplate;
@@ -15,31 +13,8 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AdminUserController {
 
-    private final CertificateService certificateService;
     private final UsersService usersService;
     private final SlackService slackService;
-
-    /**
-     * Admin Controller
-     * 사용자 인증 상태 변경
-     */
-    @PatchMapping("/verification/updateStatus")
-    public ResTemplate<?> updateVerificationStatus(
-            @RequestBody UpdateVerificationStatusDto updateVerificationStatus
-    ){
-
-        certificateService.updateVerificationStatusByCertificate(
-                updateVerificationStatus.userId(),
-                updateVerificationStatus.verificationStatus(),
-                null
-        );
-
-        return new ResTemplate<>(
-                HttpStatus.OK,
-                "증명서 인증 상태 변경",
-                null
-        );
-    }
 
     @PostMapping("/slack/verification")
     public ResTemplate<?> handleInteraction(

--- a/src/main/java/JJinBBang/app/domain/user/controller/AdminUserController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AdminUserController.java
@@ -3,7 +3,9 @@ package JJinBBang.app.domain.user.controller;
 import JJinBBang.app.domain.user.dto.request.UpdateVerificationStatusDto;
 import JJinBBang.app.domain.user.service.CertificateService;
 import JJinBBang.app.domain.user.service.UsersService;
+import JJinBBang.app.global.slack.service.SlackService;
 import JJinBBang.app.global.template.ResTemplate;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,7 @@ public class AdminUserController {
 
     private final CertificateService certificateService;
     private final UsersService usersService;
+    private final SlackService slackService;
 
     /**
      * Admin Controller
@@ -27,7 +30,8 @@ public class AdminUserController {
 
         certificateService.updateVerificationStatusByCertificate(
                 updateVerificationStatus.userId(),
-                updateVerificationStatus.verificationStatus()
+                updateVerificationStatus.verificationStatus(),
+                null
         );
 
         return new ResTemplate<>(
@@ -35,6 +39,13 @@ public class AdminUserController {
                 "증명서 인증 상태 변경",
                 null
         );
+    }
+
+    @PostMapping("/slack/verification")
+    public ResTemplate<?> handleInteraction(
+            @RequestParam("payload") String payload
+    ) throws JsonProcessingException {
+        return new ResTemplate<>(HttpStatus.OK, slackService.handleInteractivity(payload), null);
     }
 
     @DeleteMapping("/deletedUsers/executeDeletion")

--- a/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
@@ -26,52 +26,6 @@ public class CertificateController {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    // 재학증명서 업로드
-    @PostMapping("/enrollment/verify")
-    public ResTemplate<?> uploadEnrollmentCertificate(
-            @AuthenticationPrincipal Users principal,
-            @RequestPart("file") MultipartFile file
-    ) {
-        if (principal == null || principal.getProviderId() == null) {
-            throw new RuntimeException("사용자 인증 정보가 유효하지 않습니다.");
-        }
-        try {
-            Users user = usersService.findWithUniversity(principal.getProviderId());
-
-            // 폴더 이름으로 타겟 폴더 지정
-            String folderName = googleProps.getDrive().getFolders().get("enrollment-target");
-
-            // 구글 드라이브에 업로드 및 링크 반환
-            String fileLink = certificateService.uploadEnrollmentFileToDrive(file, folderName);
-
-            // 스프레드 시트에 row로 업로드 (userId, universityId, 파일링크, 업로드 시간)
-            certificateService.appendEnrollmentFileToSheets(
-                    user.getUserId().intValue(),
-                    file.getOriginalFilename(),
-                    fileLink
-            );
-
-            // 미인증 -> 인증대기
-            certificateService.updateVerificationStatusByCertificate(
-                    user.getUserId(),
-                    String.valueOf(VerificationStatus.PENDING),
-                    fileLink,
-                    file.getOriginalFilename()
-            );
-
-            return new ResTemplate<>(HttpStatus.OK,
-                    "업로드 성공",
-                    null);
-
-        } catch (Exception e) {
-            return new ResTemplate<>(
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "업로드 중 문제가 발생했습니다.",
-                    null
-            );
-        }
-    }
-
     // 합격증명서 업로드
     @PostMapping("/admission/verify")
     public ResTemplate<?> uploadAdmissionCertificate(

--- a/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
@@ -1,12 +1,16 @@
 package JJinBBang.app.domain.user.controller;
 
+import JJinBBang.app.domain.user.event.CertificateUploadEvent;
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.exception.UserAuthException;
 import JJinBBang.app.domain.user.service.CertificateService;
 import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.common.enums.VerificationStatus;
 import JJinBBang.app.global.sheets.properties.GoogleProperties;
+import JJinBBang.app.global.slack.service.SlackService;
 import JJinBBang.app.global.template.ResTemplate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +24,10 @@ public class CertificateController {
     private final CertificateService certificateService;
     private final UsersService usersService;
     private final GoogleProperties googleProps;
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    private final SlackService slackService;
 
     // 재학증명서 업로드
     @PostMapping("/enrollment/verify")
@@ -49,7 +57,8 @@ public class CertificateController {
             // 미인증 -> 인증대기
             certificateService.updateVerificationStatusByCertificate(
                     user.getUserId(),
-                    String.valueOf(VerificationStatus.PENDING)
+                    String.valueOf(VerificationStatus.PENDING),
+                    fileLink
             );
 
             return new ResTemplate<>(HttpStatus.OK,
@@ -71,43 +80,40 @@ public class CertificateController {
             @AuthenticationPrincipal Users principal,
             @RequestPart("file") MultipartFile file
     ) {
-        if (principal == null || principal.getProviderId() == null) {
-            throw new RuntimeException("사용자 인증 정보가 유효하지 않습니다.");
-        }
+        if (principal == null || principal.getProviderId() == null)
+            throw UserAuthException.InvalidToken();
 
         try {
             Users user = usersService.findWithUniversity(principal.getProviderId());
-
-            // 구글 드라이브에 업로드 및 링크 반환
             String folderName = googleProps.getDrive().getFolders().get("admission-target");
 
-            // 구글 드라이브에 업로드 및 링크 반환
+            // 1) 구글 드라이브에 업로드 및 링크 반환
             String fileLink = certificateService.uploadAdmissionFileToDrive(file, folderName);
 
-            // 스프레드 시트에 row로 업로드 (userId, universityId, 파일링크, 업로드 시간)
+            // 2) 스프레드 시트에 row로 업로드 (userId, universityId, 파일링크, 업로드 시간)
             certificateService.appendAdmissionFileToSheets(
                     user.getUserId().intValue(),
                     file.getOriginalFilename(),
                     fileLink
             );
 
-            // 미인증 -> 인증대기
+            // 3) 미인증 -> 인증대기
             certificateService.updateVerificationStatusByCertificate(
                     user.getUserId(),
-                    String.valueOf(VerificationStatus.PENDING)
+                    String.valueOf(VerificationStatus.PENDING),
+                    fileLink
             );
 
-            return new ResTemplate<>(
-                    HttpStatus.OK,
-                    "업로드 성공",
-                    null
-            );
+            // 4) 비동기 트리거 (OCR 및 검증 로직)
+            eventPublisher.publishEvent(new CertificateUploadEvent(
+                    user.getUserId(),
+                    fileLink
+            ));
+
+            return new ResTemplate<>(HttpStatus.OK, "업로드 성공", null);
+
         }  catch (Exception e) {
-            return new ResTemplate<>(
-                    HttpStatus.INTERNAL_SERVER_ERROR,
-                    "업로드 중 문제가 발생했습니다.",
-                    null
-            );
+            return new ResTemplate<>(HttpStatus.INTERNAL_SERVER_ERROR, "업로드 중 문제가 발생했습니다.", null);
         }
     }
 }

--- a/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
@@ -49,20 +49,13 @@ public class CertificateController {
                     fileLink
             );
 
-            // 3) 미인증 -> 인증대기
+            // 3) 미인증 -> 인증대기 (비동기 검증 이벤트 발행)
             certificateService.updateVerificationStatusByCertificate(
                     user.getUserId(),
                     String.valueOf(VerificationStatus.PENDING),
                     fileLink,
                     file.getOriginalFilename()
             );
-
-            // 4) 비동기 트리거 (OCR 및 검증 로직)
-            eventPublisher.publishEvent(new CertificateUploadEvent(
-                    user.getUserId(),
-                    fileLink,
-                    file.getOriginalFilename()
-            ));
 
             return new ResTemplate<>(HttpStatus.OK, "업로드 성공", null);
 

--- a/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
@@ -1,6 +1,5 @@
 package JJinBBang.app.domain.user.controller;
 
-import JJinBBang.app.domain.user.event.CertificateUploadEvent;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.domain.user.exception.UserAuthException;
 import JJinBBang.app.domain.user.service.CertificateService;

--- a/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/CertificateController.java
@@ -7,7 +7,6 @@ import JJinBBang.app.domain.user.service.CertificateService;
 import JJinBBang.app.domain.user.service.UsersService;
 import JJinBBang.app.global.common.enums.VerificationStatus;
 import JJinBBang.app.global.sheets.properties.GoogleProperties;
-import JJinBBang.app.global.slack.service.SlackService;
 import JJinBBang.app.global.template.ResTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -26,8 +25,6 @@ public class CertificateController {
     private final GoogleProperties googleProps;
 
     private final ApplicationEventPublisher eventPublisher;
-
-    private final SlackService slackService;
 
     // 재학증명서 업로드
     @PostMapping("/enrollment/verify")
@@ -58,7 +55,8 @@ public class CertificateController {
             certificateService.updateVerificationStatusByCertificate(
                     user.getUserId(),
                     String.valueOf(VerificationStatus.PENDING),
-                    fileLink
+                    fileLink,
+                    file.getOriginalFilename()
             );
 
             return new ResTemplate<>(HttpStatus.OK,
@@ -101,13 +99,15 @@ public class CertificateController {
             certificateService.updateVerificationStatusByCertificate(
                     user.getUserId(),
                     String.valueOf(VerificationStatus.PENDING),
-                    fileLink
+                    fileLink,
+                    file.getOriginalFilename()
             );
 
             // 4) 비동기 트리거 (OCR 및 검증 로직)
             eventPublisher.publishEvent(new CertificateUploadEvent(
                     user.getUserId(),
-                    fileLink
+                    fileLink,
+                    file.getOriginalFilename()
             ));
 
             return new ResTemplate<>(HttpStatus.OK, "업로드 성공", null);

--- a/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
+++ b/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
@@ -42,6 +42,8 @@ public class CertificateEventListener {
     private List<Universities> universityCache;
 
     private static final double CONFIDENCE_THRESHOLD = 0.9; // 신뢰도 기준값
+    private static final String[] ADMISSION_KEYWORDS = {"합격", "입학", "admission"};
+    private static final String[] AUTHORITY_KEYWORDS = {"총장", "학장", "처장", "직인"};
 
     @PostConstruct
     public void initUniversityCache() {
@@ -131,13 +133,13 @@ public class CertificateEventListener {
         }
 
         // 2) 키워드 검사 (합격이나 입학에 관련된 서류인가?)
-        if (!hasKeyword(text, new String[]{"합격", "입학", "admission"})) {
+        if (!hasKeyword(text, ADMISSION_KEYWORDS)) {
             log.warn("검증 실패 [2/4]: 합격 관련 키워드가 존재하지 않음");
             return false;
         }
 
         // 3) 공문서 검사 (총장 혹은 입학처장 등으로 부터 발급된 서류인가?
-        if (!hasKeyword(text, new String[]{"총장", "학장", "처장", "직인"})) {
+        if (!hasKeyword(text, AUTHORITY_KEYWORDS)) {
             log.warn("검증 실패 [3/4]: 발급 주체가 존재하지 않음");
             return false;
         }

--- a/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
+++ b/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
@@ -11,6 +11,7 @@ import JJinBBang.app.global.ocr.dto.response.OcrResult;
 import JJinBBang.app.global.ocr.service.OcrService;
 import JJinBBang.app.global.openai.service.OpenaiVerificationService;
 import JJinBBang.app.global.slack.service.SlackService;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -20,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,8 +39,15 @@ public class CertificateEventListener {
     private final UsersRepository usersRepository;
     private final OpenaiVerificationService openaiVerificationService;
 
+    private List<Universities> universityCache;
+
     private static final double CONFIDENCE_THRESHOLD = 0.9; // 신뢰도 기준값
-    private static final Pattern UNIV_PATTERN = Pattern.compile("([가-힣]+대(학교|학))");
+
+    @PostConstruct
+    public void initUniversityCache() {
+        this.universityCache = universitiesRepository.findAll();
+        this.universityCache.sort(Comparator.comparing((Universities u) -> u.getUniversityName().length()).reversed());
+    }
 
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -58,7 +68,8 @@ public class CertificateEventListener {
             String cleanText = extractedText.replaceAll("\\s+", "").toLowerCase();
 
             // 2) 대학교 조회
-            Optional<Universities> university = findUniversityFromText(cleanText);
+//            Optional<Universities> university = findUniversityFromText(cleanText);
+            Optional<Universities> university = findUniversityFromTextInMemory(cleanText);
             
             if (university.isEmpty()) {
                 // CASE 1. 자동 검증 실패 - 대학교 조회에 실패한 경우
@@ -103,6 +114,12 @@ public class CertificateEventListener {
         }
     }
 
+    private Optional<Universities> findUniversityFromTextInMemory(String text) {
+        return universityCache.stream()
+                .filter(univ -> text.contains(univ.getUniversityName()))
+                .findFirst();
+    }
+
 
     private boolean performOcrResultVerification(String text, String fileLink, double confidence) {
         if (text == null || text.isBlank()) return false;
@@ -143,30 +160,5 @@ public class CertificateEventListener {
             if (text.contains(k)) return true;
         }
         return false;
-    }
-
-    // 대학명 찾기
-    private Optional<Universities> findUniversityFromText(String cleanText) {
-        Matcher matcher = UNIV_PATTERN.matcher(cleanText);
-
-        while (matcher.find()) {
-            String candidate = matcher.group(1);
-            log.debug("학교명 후보 추출: {}", candidate);
-
-            Optional<Universities> univeristy = findValidUniversityFromCandidate(candidate);
-            if (univeristy.isPresent()) return univeristy;
-        }
-
-        return Optional.empty();
-    }
-
-    private Optional<Universities> findValidUniversityFromCandidate(String candidate) {
-        for (int i = 0; i < candidate.length() - 2; i++) {
-            String subString = candidate.substring(i);
-
-            Optional<Universities> university = universitiesRepository.findByUniversityName(subString);
-            if (university.isPresent()) return university;
-        }
-        return Optional.empty();
     }
 }

--- a/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
+++ b/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
@@ -9,6 +9,7 @@ import JJinBBang.app.domain.user.service.CertificateService;
 import JJinBBang.app.global.common.enums.VerificationStatus;
 import JJinBBang.app.global.ocr.dto.response.OcrResult;
 import JJinBBang.app.global.ocr.service.OcrService;
+import JJinBBang.app.global.openai.service.OpenaiVerificationService;
 import JJinBBang.app.global.slack.service.SlackService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +34,7 @@ public class CertificateEventListener {
     private final OcrService ocrService;
     private final UniversitiesRepository universitiesRepository;
     private final UsersRepository usersRepository;
+    private final OpenaiVerificationService openaiVerificationService;
 
     private static final double CONFIDENCE_THRESHOLD = 0.9; // 신뢰도 기준값
     private static final Pattern UNIV_PATTERN = Pattern.compile("([가-힣]+대(학교|학))");
@@ -72,7 +74,7 @@ public class CertificateEventListener {
             Users user = usersRepository.findByUserId(event.userId()).orElseThrow(UserNotFoundException::notFound);
             user.updateUniversity(univ);
 
-            boolean isVerified = performOcrResultVerification(cleanText, confidence);
+            boolean isVerified = performOcrResultVerification(cleanText, event.fileLink(), confidence);
 
             if (isVerified) {
                 // CASE 2) 자동 검증 성공 -> 신입생 인증으로 변경
@@ -102,7 +104,7 @@ public class CertificateEventListener {
     }
 
 
-    private boolean performOcrResultVerification(String text, double confidence) {
+    private boolean performOcrResultVerification(String text, String fileLink, double confidence) {
         if (text == null || text.isBlank()) return false;
 
         // 1) 신뢰도 검사 (OCR 품질 검증)
@@ -124,6 +126,11 @@ public class CertificateEventListener {
         }
 
         // 4) OPENAI 문서 신뢰도 점검
+        boolean isAiVerified = openaiVerificationService.verifyCertificatesImage(fileLink);
+        if (!isAiVerified) {
+            log.warn("검증 실패 [4/4]: LLM이 비정상 문서로 판정함");
+            return false;
+        }
 
         log.info("🔎 검증 통과!");
         log.info("OCR 신뢰도: {}", confidence);

--- a/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
+++ b/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
@@ -2,6 +2,7 @@ package JJinBBang.app.domain.user.event;
 
 import JJinBBang.app.domain.user.service.CertificateService;
 import JJinBBang.app.global.common.enums.VerificationStatus;
+import JJinBBang.app.global.ocr.service.OcrService;
 import JJinBBang.app.global.slack.service.SlackService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ public class CertificateEventListener {
 
     private final SlackService slackService;
     private final CertificateService certificateService;
+    private final OcrService ocrService;
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 트랜잭선 커밋 후 실행
@@ -25,15 +27,19 @@ public class CertificateEventListener {
 
         try {
             // TODO: OCR & 검증 작업
+            String extractedText = ocrService.extractTextFromGoogleDrive(event.fileLink(), event.fileName());
 
-            boolean isAutoVerified = false;
+            log.info("✨ [OCR 결과] : {}", extractedText);
+
+            boolean isAutoVerified = true;
 
             if (isAutoVerified) {
                 // CASE 1) 자동 검증 성공 -> 신입생 인증으로 변경
                 certificateService.updateVerificationStatusByCertificate(
                         event.userId(),
                         String.valueOf(VerificationStatus.NEW_STUDENT_VERIFIED),
-                        null
+                        null,
+                        event.fileName()
                 );
             } else {
                 // CASE 2) 자동 검증 실패 -> Slack 알림 전송 (관리자 수동 검증 필요)
@@ -45,7 +51,8 @@ public class CertificateEventListener {
             certificateService.updateVerificationStatusByCertificate(
                     event.userId(),
                     String.valueOf(VerificationStatus.UNVERIFIED),
-                    null
+                    null,
+                    event.fileName()
             );
         }
     }

--- a/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
+++ b/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
@@ -1,0 +1,52 @@
+package JJinBBang.app.domain.user.event;
+
+import JJinBBang.app.domain.user.service.CertificateService;
+import JJinBBang.app.global.common.enums.VerificationStatus;
+import JJinBBang.app.global.slack.service.SlackService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CertificateEventListener {
+
+    private final SlackService slackService;
+    private final CertificateService certificateService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 트랜잭선 커밋 후 실행
+    public void handleCertificateVerificationEvent(CertificateUploadEvent event) {
+        log.info("합격증명서 검증 프로세스 시작: USER {}", event.userId());
+
+        try {
+            // TODO: OCR & 검증 작업
+
+            boolean isAutoVerified = false;
+
+            if (isAutoVerified) {
+                // CASE 1) 자동 검증 성공 -> 신입생 인증으로 변경
+                certificateService.updateVerificationStatusByCertificate(
+                        event.userId(),
+                        String.valueOf(VerificationStatus.NEW_STUDENT_VERIFIED),
+                        null
+                );
+            } else {
+                // CASE 2) 자동 검증 실패 -> Slack 알림 전송 (관리자 수동 검증 필요)
+                log.info("승인 실패 - Slack에서 관리자 수동 인증을 진행합니다.");
+                slackService.sendVerifyMessage(event.userId(), event.fileLink());
+            }
+        } catch (Exception e) {
+            log.error("검증 처리 중 오류 발생", e);
+            certificateService.updateVerificationStatusByCertificate(
+                    event.userId(),
+                    String.valueOf(VerificationStatus.UNVERIFIED),
+                    null
+            );
+        }
+    }
+}

--- a/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
+++ b/src/main/java/JJinBBang/app/domain/user/event/CertificateEventListener.java
@@ -1,15 +1,27 @@
 package JJinBBang.app.domain.user.event;
 
+import JJinBBang.app.domain.common.entity.Universities;
+import JJinBBang.app.domain.common.repository.UniversitiesRepository;
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.exception.UserNotFoundException;
+import JJinBBang.app.domain.user.repository.UsersRepository;
 import JJinBBang.app.domain.user.service.CertificateService;
 import JJinBBang.app.global.common.enums.VerificationStatus;
+import JJinBBang.app.global.ocr.dto.response.OcrResult;
 import JJinBBang.app.global.ocr.service.OcrService;
 import JJinBBang.app.global.slack.service.SlackService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Component
 @RequiredArgsConstructor
@@ -19,32 +31,61 @@ public class CertificateEventListener {
     private final SlackService slackService;
     private final CertificateService certificateService;
     private final OcrService ocrService;
+    private final UniversitiesRepository universitiesRepository;
+    private final UsersRepository usersRepository;
+
+    private static final double CONFIDENCE_THRESHOLD = 0.9; // 신뢰도 기준값
+    private static final Pattern UNIV_PATTERN = Pattern.compile("([가-힣]+대(학교|학))");
 
     @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT) // 트랜잭선 커밋 후 실행
     public void handleCertificateVerificationEvent(CertificateUploadEvent event) {
         log.info("합격증명서 검증 프로세스 시작: USER {}", event.userId());
 
         try {
-            // TODO: OCR & 검증 작업
-            String extractedText = ocrService.extractTextFromGoogleDrive(event.fileLink(), event.fileName());
+            // 1) execute OCR
+            OcrResult ocrResult = ocrService.extractTextFromGoogleDrive(event.fileLink(), event.fileName());
+            String extractedText = ocrResult.text();
+            double confidence = ocrResult.confidence();
 
-            log.info("✨ [OCR 결과] : {}", extractedText);
+            log.info("✨ OCR 결과 : {}", extractedText);
+            log.info("✨ OCR 결과 신뢰도: {}", confidence);
 
-            boolean isAutoVerified = true;
+            // 1) OCR 결과 전처리
+            String cleanText = extractedText.replaceAll("\\s+", "").toLowerCase();
 
-            if (isAutoVerified) {
-                // CASE 1) 자동 검증 성공 -> 신입생 인증으로 변경
+            // 2) 대학교 조회
+            Optional<Universities> university = findUniversityFromText(cleanText);
+            
+            if (university.isEmpty()) {
+                // CASE 1. 자동 검증 실패 - 대학교 조회에 실패한 경우
+                log.warn("❌ 소속 대학을 조회할 수 없음");
+                slackService.sendVerifyMessage(event.userId(), event.fileLink(), true);
+                return;
+            }
+
+            Universities univ = university.get();
+            log.info("소속 대학교: {}", univ.getUniversityName());
+
+            // 3) 대학교 정보 업데이트
+            Users user = usersRepository.findByUserId(event.userId()).orElseThrow(UserNotFoundException::notFound);
+            user.updateUniversity(univ);
+
+            boolean isVerified = performOcrResultVerification(cleanText, confidence);
+
+            if (isVerified) {
+                // CASE 2) 자동 검증 성공 -> 신입생 인증으로 변경
                 certificateService.updateVerificationStatusByCertificate(
                         event.userId(),
                         String.valueOf(VerificationStatus.NEW_STUDENT_VERIFIED),
                         null,
-                        event.fileName()
+                        null
                 );
             } else {
-                // CASE 2) 자동 검증 실패 -> Slack 알림 전송 (관리자 수동 검증 필요)
+                // CASE 3) 자동 검증 실패 -> Slack 알림 전송 (관리자 수동 검증 필요)
                 log.info("승인 실패 - Slack에서 관리자 수동 인증을 진행합니다.");
-                slackService.sendVerifyMessage(event.userId(), event.fileLink());
+                slackService.sendVerifyMessage(event.userId(), event.fileLink(), false);
             }
         } catch (Exception e) {
             log.error("검증 처리 중 오류 발생", e);
@@ -54,6 +95,71 @@ public class CertificateEventListener {
                     null,
                     event.fileName()
             );
+
+            // 에러 발생 시 Slack 알림 전송
+            slackService.sendVerifyMessage(event.userId(), event.fileLink(), false);
         }
+    }
+
+
+    private boolean performOcrResultVerification(String text, double confidence) {
+        if (text == null || text.isBlank()) return false;
+
+        // 1) 신뢰도 검사 (OCR 품질 검증)
+        if (confidence < CONFIDENCE_THRESHOLD) {
+            log.warn("검증 실패 [1/4]: 추출된 내용의 신뢰도 낮음 ({})", confidence);
+            return false;
+        }
+
+        // 2) 키워드 검사 (합격이나 입학에 관련된 서류인가?)
+        if (!hasKeyword(text, new String[]{"합격", "입학", "admission"})) {
+            log.warn("검증 실패 [2/4]: 합격 관련 키워드가 존재하지 않음");
+            return false;
+        }
+
+        // 3) 공문서 검사 (총장 혹은 입학처장 등으로 부터 발급된 서류인가?
+        if (!hasKeyword(text, new String[]{"총장", "학장", "처장", "직인"})) {
+            log.warn("검증 실패 [3/4]: 발급 주체가 존재하지 않음");
+            return false;
+        }
+
+        // 4) OPENAI 문서 신뢰도 점검
+
+        log.info("🔎 검증 통과!");
+        log.info("OCR 신뢰도: {}", confidence);
+        return true;
+    }
+
+    // 키워드 검사
+    private boolean hasKeyword(String text, String[] keywords) {
+        for (String k : keywords) {
+            if (text.contains(k)) return true;
+        }
+        return false;
+    }
+
+    // 대학명 찾기
+    private Optional<Universities> findUniversityFromText(String cleanText) {
+        Matcher matcher = UNIV_PATTERN.matcher(cleanText);
+
+        while (matcher.find()) {
+            String candidate = matcher.group(1);
+            log.debug("학교명 후보 추출: {}", candidate);
+
+            Optional<Universities> univeristy = findValidUniversityFromCandidate(candidate);
+            if (univeristy.isPresent()) return univeristy;
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<Universities> findValidUniversityFromCandidate(String candidate) {
+        for (int i = 0; i < candidate.length() - 2; i++) {
+            String subString = candidate.substring(i);
+
+            Optional<Universities> university = universitiesRepository.findByUniversityName(subString);
+            if (university.isPresent()) return university;
+        }
+        return Optional.empty();
     }
 }

--- a/src/main/java/JJinBBang/app/domain/user/event/CertificateUploadEvent.java
+++ b/src/main/java/JJinBBang/app/domain/user/event/CertificateUploadEvent.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.domain.user.event;
+
+public record CertificateUploadEvent(
+        Long userId,
+        String fileLink // Google Drive URL
+) {
+}

--- a/src/main/java/JJinBBang/app/domain/user/event/CertificateUploadEvent.java
+++ b/src/main/java/JJinBBang/app/domain/user/event/CertificateUploadEvent.java
@@ -2,6 +2,7 @@ package JJinBBang.app.domain.user.event;
 
 public record CertificateUploadEvent(
         Long userId,
-        String fileLink // Google Drive URL
+        String fileLink, // Google Drive URL
+        String fileName
 ) {
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/CertificateService.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/CertificateService.java
@@ -9,5 +9,5 @@ public interface CertificateService {
     void appendEnrollmentFileToSheets(int userId, String fileName, String fileLink);
     void appendAdmissionFileToSheets(int userId, String fileName, String fileLink);
 
-    void updateVerificationStatusByCertificate(Long userId, String status, String fileLink);
+    void updateVerificationStatusByCertificate(Long userId, String status, String fileLink, String fileName);
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/CertificateService.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/CertificateService.java
@@ -9,5 +9,5 @@ public interface CertificateService {
     void appendEnrollmentFileToSheets(int userId, String fileName, String fileLink);
     void appendAdmissionFileToSheets(int userId, String fileName, String fileLink);
 
-    void updateVerificationStatusByCertificate(Long userId, String status);
+    void updateVerificationStatusByCertificate(Long userId, String status, String fileLink);
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/CertificateService.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/CertificateService.java
@@ -3,10 +3,8 @@ package JJinBBang.app.domain.user.service;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface CertificateService {
-    String uploadEnrollmentFileToDrive(MultipartFile file, String folderName);
     String uploadAdmissionFileToDrive(MultipartFile file, String folderName);
 
-    void appendEnrollmentFileToSheets(int userId, String fileName, String fileLink);
     void appendAdmissionFileToSheets(int userId, String fileName, String fileLink);
 
     void updateVerificationStatusByCertificate(Long userId, String status, String fileLink, String fileName);

--- a/src/main/java/JJinBBang/app/domain/user/service/CertificateServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/CertificateServiceImpl.java
@@ -39,18 +39,6 @@ public class CertificateServiceImpl implements CertificateService {
     private final UsersService usersService;
     private final ApplicationEventPublisher eventPublisher;
 
-    // 재학증명서 -> 구글 드라이브 업로드
-    @Override
-    public String uploadEnrollmentFileToDrive(MultipartFile file, String folderName) {
-        try {
-            String rootFolderId = googleProps.getDrive().getFolders().get("enrollment");
-            String targetFolderId = findTargetFolderId(rootFolderId, folderName);
-            return uploadFile(file, targetFolderId);
-        } catch (IOException e) {
-            throw new RuntimeException("구글 드라이브 타겟 폴더 탐색 실패");
-        }
-    }
-
     // 합격증명서 -> 구글 드라이브 업로드
     @Override
     public String uploadAdmissionFileToDrive(MultipartFile file, String folderName) {
@@ -61,12 +49,6 @@ public class CertificateServiceImpl implements CertificateService {
         } catch (IOException e) {
             throw new RuntimeException("구글 드라이브 타겟 폴더 탐색 실패");
         }
-    }
-
-    // 재학증명서 업로드 -> 스프레드시트 추가
-    @Override
-    public void appendEnrollmentFileToSheets(int userId, String fileName, String fileLink) {
-        appendSheets("enrollment", userId, fileName, fileLink);
     }
 
     // 합격증명서 업로드 -> 스프레드시트 추가

--- a/src/main/java/JJinBBang/app/domain/user/service/CertificateServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/CertificateServiceImpl.java
@@ -223,7 +223,7 @@ public class CertificateServiceImpl implements CertificateService {
      */
     @Override
     @Transactional
-    public void updateVerificationStatusByCertificate(Long userId, String status, String fileLink) {
+    public void updateVerificationStatusByCertificate(Long userId, String status, String fileLink, String fileName) {
         if (!VerificationStatus.isValid(status))
             throw VerificatoinStatusException.InvalidVerificationStatusException();
 
@@ -232,7 +232,7 @@ public class CertificateServiceImpl implements CertificateService {
         usersRepository.save(user);
 
         if (VerificationStatus.valueOf(status) == VerificationStatus.PENDING) {
-            eventPublisher.publishEvent(new CertificateUploadEvent(userId, fileLink));
+            eventPublisher.publishEvent(new CertificateUploadEvent(userId, fileLink, fileName));
         }
     }
 }

--- a/src/main/java/JJinBBang/app/domain/user/service/CertificateServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/CertificateServiceImpl.java
@@ -185,10 +185,10 @@ public class CertificateServiceImpl implements CertificateService {
             String fileName,
             String fileLink
     ) {
-        String spreadsheetId = googleProps.getSpreadsheetCertificate().getId(); // 스프레드시트
-        String sheetName = googleProps.getSpreadsheetCertificate().getSheets().get(type); // 스프레드시트의 탭
-        String range = String.format(googleProps.getSpreadsheetCertificate().getRangeTemplate(), sheetName); // 시트 범위 포맷팅
-        String hyperlinkFormula = String.format("=HYPERLINK(\"%s\",\"%s\")", fileLink, fileName); // url 포뮬러
+        String spreadsheetId = googleProps.getSpreadsheet().getCertificates().getId();
+        String sheetName = googleProps.getSpreadsheet().getCertificates().getSheets().get(type);
+        String range = String.format(googleProps.getSpreadsheet().getCertificates().getRangeTemplate(), sheetName);
+        String hyperlinkFormula = String.format("=HYPERLINK(\"%s\",\"%s\")", fileLink, fileName);
 
         List<Object> row = List.of(
                 userId,

--- a/src/main/java/JJinBBang/app/domain/user/service/CertificateServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/user/service/CertificateServiceImpl.java
@@ -1,6 +1,7 @@
 package JJinBBang.app.domain.user.service;
 
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.event.CertificateUploadEvent;
 import JJinBBang.app.domain.user.exception.*;
 import JJinBBang.app.domain.user.repository.UsersRepository;
 import JJinBBang.app.global.common.enums.VerificationStatus;
@@ -15,6 +16,7 @@ import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -35,6 +37,7 @@ public class CertificateServiceImpl implements CertificateService {
     private final Sheets sheets;
     private final UsersRepository usersRepository;
     private final UsersService usersService;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 재학증명서 -> 구글 드라이브 업로드
     @Override
@@ -220,12 +223,16 @@ public class CertificateServiceImpl implements CertificateService {
      */
     @Override
     @Transactional
-    public void updateVerificationStatusByCertificate(Long userId, String status) {
-        if (!VerificationStatus.isValid(status)) {
+    public void updateVerificationStatusByCertificate(Long userId, String status, String fileLink) {
+        if (!VerificationStatus.isValid(status))
             throw VerificatoinStatusException.InvalidVerificationStatusException();
-        }
+
         Users user = usersService.findByUserId(userId);
         user.updateVerificationStatus(VerificationStatus.valueOf(status));
         usersRepository.save(user);
+
+        if (VerificationStatus.valueOf(status) == VerificationStatus.PENDING) {
+            eventPublisher.publishEvent(new CertificateUploadEvent(userId, fileLink));
+        }
     }
 }

--- a/src/main/java/JJinBBang/app/global/config/AsyncConfig.java
+++ b/src/main/java/JJinBBang/app/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package JJinBBang.app.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3); // 기본 스레드 수
+        executor.setMaxPoolSize(10); // 최대 스레드 수
+        executor.setQueueCapacity(20); // 대기 큐 사이즈
+        executor.setThreadNamePrefix("CertificatesAsync-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/JJinBBang/app/global/config/HttpConfig.java
+++ b/src/main/java/JJinBBang/app/global/config/HttpConfig.java
@@ -1,0 +1,14 @@
+package JJinBBang.app.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class HttpConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/JJinBBang/app/global/ocr/dto/request/ClovaImage.java
+++ b/src/main/java/JJinBBang/app/global/ocr/dto/request/ClovaImage.java
@@ -1,0 +1,8 @@
+package JJinBBang.app.global.ocr.dto.request;
+
+public record ClovaImage(
+        String format, // 이미지 형식
+        String name, // 이미지 이름
+        String url // 이미지 URL (직접 이미지를 불러올 경우 Base64 인코딩 된 data 사용)
+) {
+}

--- a/src/main/java/JJinBBang/app/global/ocr/dto/request/ClovaOcrRequest.java
+++ b/src/main/java/JJinBBang/app/global/ocr/dto/request/ClovaOcrRequest.java
@@ -1,0 +1,12 @@
+package JJinBBang.app.global.ocr.dto.request;
+
+import java.util.List;
+
+// Google Drive에 저장된 이미지를 불러오기 때문에 아래 포맷으로 진행
+public record ClovaOcrRequest(
+        String version,
+        String requestId,
+        long timestamp,
+        List<ClovaImage> images
+) {
+}

--- a/src/main/java/JJinBBang/app/global/ocr/dto/response/ClovaField.java
+++ b/src/main/java/JJinBBang/app/global/ocr/dto/response/ClovaField.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.global.ocr.dto.response;
+
+public record ClovaField(
+        String inferText, // 인식된 텍스트
+        double inferConfidence // 인식된 텍스트의 신뢰도 (0~1)
+) {
+}

--- a/src/main/java/JJinBBang/app/global/ocr/dto/response/ClovaImageResult.java
+++ b/src/main/java/JJinBBang/app/global/ocr/dto/response/ClovaImageResult.java
@@ -1,0 +1,11 @@
+package JJinBBang.app.global.ocr.dto.response;
+
+import java.util.List;
+
+public record ClovaImageResult(
+        String uid,
+        String name,
+        String inferResult, // 이미지 인식 결과 (SUCCESS | FAILURE | ERROR)
+        List<ClovaField> fields
+) {
+}

--- a/src/main/java/JJinBBang/app/global/ocr/dto/response/ClovaOcrResponse.java
+++ b/src/main/java/JJinBBang/app/global/ocr/dto/response/ClovaOcrResponse.java
@@ -1,0 +1,11 @@
+package JJinBBang.app.global.ocr.dto.response;
+
+import java.util.List;
+
+public record ClovaOcrResponse(
+        String version,
+        String requestId,
+        long timestamp,
+        List<ClovaImageResult> images
+) {
+}

--- a/src/main/java/JJinBBang/app/global/ocr/dto/response/OcrResult.java
+++ b/src/main/java/JJinBBang/app/global/ocr/dto/response/OcrResult.java
@@ -1,0 +1,7 @@
+package JJinBBang.app.global.ocr.dto.response;
+
+public record OcrResult(
+        String text,
+        double confidence
+) {
+}

--- a/src/main/java/JJinBBang/app/global/ocr/exception/OcrInternalException.java
+++ b/src/main/java/JJinBBang/app/global/ocr/exception/OcrInternalException.java
@@ -1,0 +1,17 @@
+package JJinBBang.app.global.ocr.exception;
+
+import JJinBBang.app.global.error.exception.InternalServerErrorGroupException;
+
+public class OcrInternalException extends InternalServerErrorGroupException {
+    public OcrInternalException(String message) {
+        super(message);
+    }
+
+    public static OcrInternalException apiError() {
+        return new OcrInternalException("OCR API 연동 과정에서 오류가 발생했습니다.");
+    }
+
+    public static OcrInternalException ocrFail() {
+        return new OcrInternalException("OCR 처리 과정에서 오류가 발생했습니다.");
+    }
+}

--- a/src/main/java/JJinBBang/app/global/ocr/exception/OcrInvalidException.java
+++ b/src/main/java/JJinBBang/app/global/ocr/exception/OcrInvalidException.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.global.ocr.exception;
+
+import JJinBBang.app.global.error.exception.InvalidGroupException;
+
+public class OcrInvalidException extends InvalidGroupException {
+    public OcrInvalidException(String message) {
+        super(message);
+    }
+
+    public static OcrInvalidException invalidRequest() {
+        return new OcrInvalidException("잘못된 형식의 요청입니다.");
+    }
+}

--- a/src/main/java/JJinBBang/app/global/ocr/properties/OcrProperties.java
+++ b/src/main/java/JJinBBang/app/global/ocr/properties/OcrProperties.java
@@ -1,0 +1,21 @@
+package JJinBBang.app.global.ocr.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@ConfigurationProperties(prefix = "ocr")
+public class OcrProperties {
+
+    private Clova clova = new Clova();
+
+    @Getter
+    @Setter
+    public static class Clova {
+        private String apiUrl;
+        private String secretKey;
+    }
+}

--- a/src/main/java/JJinBBang/app/global/ocr/service/OcrService.java
+++ b/src/main/java/JJinBBang/app/global/ocr/service/OcrService.java
@@ -1,5 +1,7 @@
 package JJinBBang.app.global.ocr.service;
 
+import JJinBBang.app.global.ocr.dto.response.OcrResult;
+
 public interface OcrService {
-    String extractTextFromGoogleDrive(String imageUrl, String fileName);
+    OcrResult extractTextFromGoogleDrive(String imageUrl, String fileName);
 }

--- a/src/main/java/JJinBBang/app/global/ocr/service/OcrService.java
+++ b/src/main/java/JJinBBang/app/global/ocr/service/OcrService.java
@@ -1,0 +1,5 @@
+package JJinBBang.app.global.ocr.service;
+
+public interface OcrService {
+    String extractTextFromGoogleDrive(String imageUrl, String fileName);
+}

--- a/src/main/java/JJinBBang/app/global/ocr/service/impl/OcrServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/ocr/service/impl/OcrServiceImpl.java
@@ -6,6 +6,8 @@ import JJinBBang.app.global.ocr.dto.response.ClovaField;
 import JJinBBang.app.global.ocr.dto.response.ClovaImageResult;
 import JJinBBang.app.global.ocr.dto.response.ClovaOcrResponse;
 import JJinBBang.app.global.ocr.dto.response.OcrResult;
+import JJinBBang.app.global.ocr.exception.OcrInternalException;
+import JJinBBang.app.global.ocr.exception.OcrInvalidException;
 import JJinBBang.app.global.ocr.properties.OcrProperties;
 import JJinBBang.app.global.ocr.service.OcrService;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
@@ -82,8 +85,15 @@ public class OcrServiceImpl implements OcrService {
 
             return new OcrResult(result.toString().trim(), avgConfidence);
 
+        } catch (RestClientException e) {
+            log.error("Clova OCR API 호출 중 오류 발생: url={}, error={}", imageUrl, e.getMessage(), e);
+            throw OcrInternalException.apiError();
+        } catch (IllegalArgumentException e) {
+            log.error("잘못된 입력값 오류: {}", e.getMessage(), e);
+            throw OcrInvalidException.invalidRequest();
         } catch (Exception e) {
-            throw new RuntimeException("OCR 처리 실패");
+            log.error("OCR 처리 중 알 수 없는 오류 발생", e);
+            throw OcrInternalException.ocrFail();
         }
     }
 

--- a/src/main/java/JJinBBang/app/global/ocr/service/impl/OcrServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/ocr/service/impl/OcrServiceImpl.java
@@ -1,0 +1,105 @@
+package JJinBBang.app.global.ocr.service.impl;
+
+import JJinBBang.app.global.ocr.dto.request.ClovaImage;
+import JJinBBang.app.global.ocr.dto.request.ClovaOcrRequest;
+import JJinBBang.app.global.ocr.dto.response.ClovaField;
+import JJinBBang.app.global.ocr.dto.response.ClovaImageResult;
+import JJinBBang.app.global.ocr.dto.response.ClovaOcrResponse;
+import JJinBBang.app.global.ocr.properties.OcrProperties;
+import JJinBBang.app.global.ocr.service.OcrService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OcrServiceImpl implements OcrService {
+
+    private final RestTemplate restTemplate;
+    private final OcrProperties ocrProperties;
+
+    @Override
+    public String extractTextFromGoogleDrive(String imageUrl, String fileName) {
+        try {
+
+            String fileId = extractFileIdFromUrl(imageUrl);
+            String downloadUrl = "https://drive.google.com/uc?export=download&id=" + fileId;
+
+            // 확장자 판별
+            String extension = getExtension(fileName);
+
+            // 1) 헤더 설정
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("X-OCR-SECRET", ocrProperties.getClova().getSecretKey());
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            // 2) Request Body 설정
+            ClovaImage image = new ClovaImage(extension, fileName, downloadUrl);
+
+            ClovaOcrRequest req = new ClovaOcrRequest(
+                    "V2",
+                    UUID.randomUUID().toString(),
+                    System.currentTimeMillis(),
+                    List.of(image)
+            );
+
+            HttpEntity<ClovaOcrRequest> requestEntity = new HttpEntity<>(req, headers);
+            log.info("Clova OCR Request SUCCESS!");
+            log.info("format: {}", extension);
+            log.info("URL: {}", downloadUrl);
+
+            ClovaOcrResponse res = restTemplate.postForObject(ocrProperties.getClova().getApiUrl(), requestEntity, ClovaOcrResponse.class);
+
+            StringBuilder result = new StringBuilder();
+            if (res != null && res.images() != null) {
+                for (ClovaImageResult imageResult : res.images()) {
+                    if (imageResult.fields() != null) {
+                        for (ClovaField field : imageResult.fields()) {
+                            result.append(field.inferText()).append(" ");
+                        }
+                    }
+                }
+            }
+
+            log.info("OCR 추출 완료: {}", result);
+            return result.toString().trim();
+
+        } catch (Exception e) {
+            throw new RuntimeException("OCR 처리 실패");
+        }
+    }
+
+    private String getExtension(String fileName) {
+        if (fileName == null) return "jpg";
+
+        String lowerName = fileName.toLowerCase();
+        if (lowerName.endsWith("pdf")) return "pdf";
+        if (lowerName.endsWith("png")) return "png";
+        if (lowerName.endsWith("jpeg")) return "jpeg";
+
+        return "jpg";
+    }
+
+    private String extractFileIdFromUrl(String url) {
+        Pattern pattern = Pattern.compile("/file/d/([^/]+)");
+        Matcher matcher = pattern.matcher(url);
+        if (matcher.find()) return matcher.group(1);
+
+        Pattern pattern2 = Pattern.compile("id=([^&]+)");
+        Matcher matcher2 = pattern2.matcher(url);
+        if (matcher2.find()) return matcher2.group(1);
+
+        return null;
+    }
+}

--- a/src/main/java/JJinBBang/app/global/ocr/service/impl/OcrServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/ocr/service/impl/OcrServiceImpl.java
@@ -5,6 +5,7 @@ import JJinBBang.app.global.ocr.dto.request.ClovaOcrRequest;
 import JJinBBang.app.global.ocr.dto.response.ClovaField;
 import JJinBBang.app.global.ocr.dto.response.ClovaImageResult;
 import JJinBBang.app.global.ocr.dto.response.ClovaOcrResponse;
+import JJinBBang.app.global.ocr.dto.response.OcrResult;
 import JJinBBang.app.global.ocr.properties.OcrProperties;
 import JJinBBang.app.global.ocr.service.OcrService;
 import lombok.RequiredArgsConstructor;
@@ -30,13 +31,10 @@ public class OcrServiceImpl implements OcrService {
     private final OcrProperties ocrProperties;
 
     @Override
-    public String extractTextFromGoogleDrive(String imageUrl, String fileName) {
+    public OcrResult extractTextFromGoogleDrive(String imageUrl, String fileName) {
         try {
-
             String fileId = extractFileIdFromUrl(imageUrl);
             String downloadUrl = "https://drive.google.com/uc?export=download&id=" + fileId;
-
-            // 확장자 판별
             String extension = getExtension(fileName);
 
             // 1) 헤더 설정
@@ -44,42 +42,52 @@ public class OcrServiceImpl implements OcrService {
             headers.set("X-OCR-SECRET", ocrProperties.getClova().getSecretKey());
             headers.setContentType(MediaType.APPLICATION_JSON);
 
-            // 2) Request Body 설정
+            // 2) Request 설정
             ClovaImage image = new ClovaImage(extension, fileName, downloadUrl);
-
             ClovaOcrRequest req = new ClovaOcrRequest(
                     "V2",
                     UUID.randomUUID().toString(),
                     System.currentTimeMillis(),
                     List.of(image)
             );
-
             HttpEntity<ClovaOcrRequest> requestEntity = new HttpEntity<>(req, headers);
+
             log.info("Clova OCR Request SUCCESS!");
             log.info("format: {}", extension);
             log.info("URL: {}", downloadUrl);
 
+            // 3) API 호출
             ClovaOcrResponse res = restTemplate.postForObject(ocrProperties.getClova().getApiUrl(), requestEntity, ClovaOcrResponse.class);
 
+            // 4) OCR 결과 파싱
             StringBuilder result = new StringBuilder();
+            double totalConfidence = 0.0;
+            int fieldCount = 0;
+
             if (res != null && res.images() != null) {
                 for (ClovaImageResult imageResult : res.images()) {
                     if (imageResult.fields() != null) {
                         for (ClovaField field : imageResult.fields()) {
                             result.append(field.inferText()).append(" ");
+                            totalConfidence += field.inferConfidence();
+                            fieldCount++;
                         }
                     }
                 }
             }
 
-            log.info("OCR 추출 완료: {}", result);
-            return result.toString().trim();
+            // 5) 평균 신뢰도 계산
+            double avgConfidence = (fieldCount == 0) ? 0.0 : totalConfidence / fieldCount;
+            log.info("OCR 평균 신뢰도: {}", String.format("%.2f", avgConfidence));
+
+            return new OcrResult(result.toString().trim(), avgConfidence);
 
         } catch (Exception e) {
             throw new RuntimeException("OCR 처리 실패");
         }
     }
 
+    // 확장자 추출
     private String getExtension(String fileName) {
         if (fileName == null) return "jpg";
 
@@ -91,6 +99,7 @@ public class OcrServiceImpl implements OcrService {
         return "jpg";
     }
 
+    // 다운로드 url 추출
     private String extractFileIdFromUrl(String url) {
         Pattern pattern = Pattern.compile("/file/d/([^/]+)");
         Matcher matcher = pattern.matcher(url);
@@ -102,4 +111,6 @@ public class OcrServiceImpl implements OcrService {
 
         return null;
     }
+
+
 }

--- a/src/main/java/JJinBBang/app/global/openai/properties/OpenaiProperties.java
+++ b/src/main/java/JJinBBang/app/global/openai/properties/OpenaiProperties.java
@@ -1,0 +1,18 @@
+package JJinBBang.app.global.openai.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "openai")
+public class OpenaiProperties {
+
+    private String apiKey;
+    private String model;
+    private String apiUrl;
+    private String certificatesVerificationPrompt;
+}

--- a/src/main/java/JJinBBang/app/global/openai/service/OpenaiVerificationService.java
+++ b/src/main/java/JJinBBang/app/global/openai/service/OpenaiVerificationService.java
@@ -1,0 +1,5 @@
+package JJinBBang.app.global.openai.service;
+
+public interface OpenaiVerificationService {
+    boolean verifyCertificatesImage(String fileLink);
+}

--- a/src/main/java/JJinBBang/app/global/openai/service/impl/OpenaiVerificationServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/openai/service/impl/OpenaiVerificationServiceImpl.java
@@ -1,0 +1,140 @@
+package JJinBBang.app.global.openai.service.impl;
+
+import JJinBBang.app.global.openai.properties.OpenaiProperties;
+import JJinBBang.app.global.openai.service.OpenaiVerificationService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OpenaiVerificationServiceImpl implements OpenaiVerificationService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final OpenaiProperties openaiProperties;
+
+    private static final Pattern DRIVE_ID_PATTERN = Pattern.compile("/d/([a-zA-Z0-9_-]+)");
+
+    @Override
+    public boolean verifyCertificatesImage(String fileLink) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(openaiProperties.getApiKey());
+
+            // 1) 이미지 로드 및 Base64 인코딩
+            String base64Image = downloadAndEncodeImage(fileLink);
+            if (base64Image == null) {
+                log.error("❌ 이미지 다운로드 실패로 인한 검증 중단");
+                return false;
+            }
+
+            // 2) 프롬프트 생성
+            String promptText = openaiProperties.getCertificatesVerificationPrompt();
+            if (promptText == null || promptText.isBlank()) {
+                promptText = "이 이미지가 유효한 대학 합격증명서인지, 위조된 흔적은 없는지 JSON 형태로 판단해줘.";
+                log.warn("⚠️ 프롬프트 설정이 비어있어 기본 프롬프트를 사용합니다.");
+            }
+
+            // 3) Request body 생성
+            Map<String, Object> req = new HashMap<>();
+            req.put("model", openaiProperties.getModel());
+
+            Map<String, Object> textContent = Map.of("type", "text", "text", promptText);
+            Map<String, Object> imageContent = Map.of(
+                    "type", "image_url",
+                    "image_url", Map.of("url", "data:image/jpeg;base64," + base64Image)
+            );
+
+            req.put("messages", List.of(
+                    Map.of("role", "system", "content", "You are a strict document verification AI. Output JSON only."),
+                    Map.of("role", "user", "content", List.of(textContent, imageContent))
+            ));
+            req.put("response_format", Map.of("type", "json_object"));
+
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(req, headers);
+
+            // 4) API 호출
+            String res = restTemplate.postForObject(openaiProperties.getApiUrl(), request, String.class);
+
+            if (res == null || res.isBlank()) {
+                log.error("🤖 OpenAI API 응답이 비어있습니다.");
+                return false;
+            }
+
+            // 5) 결과 파싱
+            JsonNode root = objectMapper.readTree(res);
+            if (!root.has("choices") || root.path("choices").isEmpty()) {
+                log.error("🤖 OpenAI 응답에 'choices' 필드가 없습니다. 응답 내용: {}", res);
+                return false;
+            }
+
+            String content = root.path("choices").get(0).path("message").path("content").asText();
+            JsonNode resultNode = objectMapper.readTree(content);
+
+            boolean isValid = resultNode.path("isValid").asBoolean();
+            String reason = resultNode.path("reason").asText();
+
+            log.info("🤖 OpenAI 검증 결과: {} (이유: {})", isValid ? "통과" : "실패", reason);
+
+            return isValid;
+        } catch (RestClientException e) {
+            log.error("🤖 OpenAI API 호출 중 네트워크/통신 오류 발생: {}", e.getMessage());
+            return false; // 통신 오류 시 보수적으로 실패 처리
+        } catch (JsonProcessingException e) {
+            log.error("🤖 OpenAI 응답 JSON 파싱 실패", e);
+            return false;
+        } catch (Exception e) {
+            log.error("🤖 LLM 검증 중 알 수 없는 오류 발생", e);
+            return false;
+        }
+    }
+
+
+    private String downloadAndEncodeImage(String fileLink) {
+        try {
+            // 1. 파일 ID 추출
+            Matcher matcher = DRIVE_ID_PATTERN.matcher(fileLink);
+            if (!matcher.find()) {
+                log.error("유효하지 않은 구글 드라이브 링크입니다: {}", fileLink);
+                return null;
+            }
+            String fileId = matcher.group(1);
+
+            // 2. 다운로드 URL 생성 (export=download 사용)
+            String downloadUrl = "https://drive.google.com/uc?export=download&id=" + fileId;
+
+            // 3. 이미지 다운로드 (byte array)
+            byte[] imageBytes = restTemplate.getForObject(downloadUrl, byte[].class);
+
+            if (imageBytes == null || imageBytes.length == 0) {
+                log.error("이미지 데이터가 비어있습니다.");
+                return null;
+            }
+
+            // 4. Base64 인코딩
+            return Base64.getEncoder().encodeToString(imageBytes);
+
+        } catch (Exception e) {
+            log.error("이미지 다운로드 및 인코딩 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/JJinBBang/app/global/sheets/properties/GoogleProperties.java
+++ b/src/main/java/JJinBBang/app/global/sheets/properties/GoogleProperties.java
@@ -5,31 +5,38 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @Getter
+@Setter
 @Component
 @ConfigurationProperties(prefix = "google")
 public class GoogleProperties {
+
     private Drive drive = new Drive();
-
-    private Spreadsheet spreadsheetCertificate = new Spreadsheet(); // 중명서 시트
-
-    private Spreadsheet spreadsheetUnregister = new Spreadsheet(); // 탈퇴 사유 시트
-    private Spreadsheet spreadsheetOpinion = new Spreadsheet(); // 문의(신고) 시트
+    private Spreadsheet spreadsheet = new Spreadsheet();
 
     @Setter
     @Getter
     public static class Drive {
-        private Map<String, String> folders;
+        private Map<String, String> folders = new HashMap<>();
         private String urlTemplate;
+    }
+
+    @Getter
+    @Setter
+    public static class Spreadsheet {
+        private SheetConfig certificates = new SheetConfig();
+        private SheetConfig opinion = new SheetConfig();
+        private SheetConfig unregister = new SheetConfig();
     }
 
     @Setter
     @Getter
-    public static class Spreadsheet {
+    public static class SheetConfig {
         private String id;
-        private Map<String, String> sheets;
+        private Map<String, String> sheets = new HashMap<>();
         private String rangeTemplate;
     }
 }

--- a/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
@@ -29,13 +29,13 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
 
     // 시트 데이터 입력
     private AppendValuesResponse appendRowToGoogleSheets(
-            GoogleProperties.Spreadsheet sheet,
+            GoogleProperties.SheetConfig sheetConfig,
             String sheetKey,
             List<Object> data
     ) throws IOException {
-        String sheetsId = sheet.getId();
-        String name = sheet.getSheets().get(sheetKey);
-        String range = String.format(sheet.getRangeTemplate(), name);
+        String sheetsId = sheetConfig.getId();
+        String name = sheetConfig.getSheets().get(sheetKey);
+        String range = String.format(sheetConfig.getRangeTemplate(), name);
 
         ValueRange row = new ValueRange().setValues(List.of(data));
 
@@ -51,7 +51,7 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
     public void appendUnregisterReason(
             UnregisterReasonDto unregisterReasonDto
     ) throws IOException {
-        var sheet = googleProperties.getSpreadsheetUnregister();
+        var sheet = googleProperties.getSpreadsheet().getUnregister();
 
         List<Object> row = List.of(
                 unregisterReasonDto.userId(),
@@ -73,7 +73,7 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
     ) throws IOException {
         Objects.requireNonNull(userOpinionDto, "userOpinionDto is null");
 
-        var sheet = googleProperties.getSpreadsheetOpinion();
+        var sheet = googleProperties.getSpreadsheet().getOpinion();
         String sheetKey = resolveOpinionSheetKey(opinionType);
 
         List<Object> row = List.of(

--- a/src/main/java/JJinBBang/app/global/slack/properties/SlackProperties.java
+++ b/src/main/java/JJinBBang/app/global/slack/properties/SlackProperties.java
@@ -1,0 +1,27 @@
+package JJinBBang.app.global.slack.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@ConfigurationProperties(prefix = "slack")
+public class SlackProperties {
+
+    private Webhook webhook = new Webhook();
+    private Security security = new Security();
+
+    @Getter
+    @Setter
+    public static class Webhook {
+        private String url;
+    }
+
+    @Getter
+    @Setter
+    public static class Security {
+        private String signingSecret;
+    }
+}

--- a/src/main/java/JJinBBang/app/global/slack/service/SlackService.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/SlackService.java
@@ -1,0 +1,6 @@
+package JJinBBang.app.global.slack.service;
+
+public interface SlackService {
+
+    void sendVerifyMessage(Long userId, String fileLink);
+}

--- a/src/main/java/JJinBBang/app/global/slack/service/SlackService.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/SlackService.java
@@ -5,7 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface SlackService {
 
-    void sendVerifyMessage(Long userId, String fileLink);
+    void sendVerifyMessage(Long userId, String fileLink, boolean needsInput);
 
     String handleInteractivity(String payload) throws JsonProcessingException;
 }

--- a/src/main/java/JJinBBang/app/global/slack/service/SlackService.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/SlackService.java
@@ -1,6 +1,11 @@
 package JJinBBang.app.global.slack.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.transaction.annotation.Transactional;
+
 public interface SlackService {
 
     void sendVerifyMessage(Long userId, String fileLink);
+
+    String handleInteractivity(String payload) throws JsonProcessingException;
 }

--- a/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
@@ -1,13 +1,19 @@
 package JJinBBang.app.global.slack.service.impl;
 
+import JJinBBang.app.domain.user.service.CertificateService;
+import JJinBBang.app.global.common.enums.VerificationStatus;
 import JJinBBang.app.global.slack.properties.SlackProperties;
 import JJinBBang.app.global.slack.service.SlackService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
@@ -22,6 +28,8 @@ public class SlackServiceImpl implements SlackService {
 
     private final SlackProperties slackProperties;
     private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final CertificateService certificateService;
 
     /**
      * Slack #합격증명서-인증 채널에 찐빵 봇을 통한 미승인 합격증명서 인증 메시지 전송
@@ -54,6 +62,43 @@ public class SlackServiceImpl implements SlackService {
         } catch (Exception e) {
             log.error("Slack 메시지 전송 실패: ", e);
         }
+    }
+
+    @Transactional
+    @Override
+    public String handleInteractivity(String payload) throws JsonProcessingException {
+
+        // 1) Slack이 보낸 JSON 파싱
+        JsonNode root = objectMapper.readTree(payload);
+
+        // 2) 사용자 정보, action 추출
+        JsonNode actionsNode = root.path("actions").get(0);
+        String actionId = actionsNode.path("action_id").asText();
+        String value = actionsNode.path("value").asText();
+        Long userId = Long.parseLong(value);
+
+        String message = "";
+
+        if ("approve_student_verification".equals(actionId)) {
+            certificateService.updateVerificationStatusByCertificate(
+                    userId,
+                    String.valueOf(VerificationStatus.NEW_STUDENT_VERIFIED),
+                    null
+            );
+
+            message = "✅ 관리자에 의해 승인 처리되었습니다.";
+            log.info("Slack에서 승인 처리 완료: userId - {}", userId);
+        } else if ("reject_student_verification".equals(actionId)) {
+            certificateService.updateVerificationStatusByCertificate(
+                    userId,
+                    String.valueOf(VerificationStatus.UNVERIFIED),
+                    null
+            );
+            message = "❌ 관리자에 의해 반려 처리되었습니다.";
+            log.info("Slack에서 반려 처리 완료: userId - {}", userId);
+        }
+
+        return createResponseJson(message);
     }
 
     // 텍스트 섹션 생성하기
@@ -94,5 +139,10 @@ public class SlackServiceImpl implements SlackService {
         button.put("value", value);
 
         return button;
+    }
+
+    // Slack 응답 메시지 포맷
+    private String createResponseJson(String text) {
+        return String.format("{\"replace_original\": \"true\", \"text\": \"%s\"}", text);
     }
 }

--- a/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
@@ -1,5 +1,10 @@
 package JJinBBang.app.global.slack.service.impl;
 
+import JJinBBang.app.domain.common.entity.Universities;
+import JJinBBang.app.domain.common.repository.UniversitiesRepository;
+import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.exception.UserNotFoundException;
+import JJinBBang.app.domain.user.repository.UsersRepository;
 import JJinBBang.app.domain.user.service.CertificateService;
 import JJinBBang.app.global.common.enums.VerificationStatus;
 import JJinBBang.app.global.slack.properties.SlackProperties;
@@ -16,10 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -30,25 +32,44 @@ public class SlackServiceImpl implements SlackService {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
     private final CertificateService certificateService;
+    private final UniversitiesRepository universitiesRepository;
+    private final UsersRepository usersRepository;
+
+    private static final String INPUT_BLOCK_ID = "input_university_block";
+    private static final String ACTION_ID_INPUT = "university_name";
+    private static final String ACTION_ID_APPROVE = "approve_student_verification";
+    private static final String ACTION_ID_APPROVE_WITH_INPUT = "approve_student_verification_with_input";
+    private static final String ACTION_ID_REJECT = "reject_student_verification";
 
     /**
      * Slack #합격증명서-인증 채널에 찐빵 봇을 통한 미승인 합격증명서 인증 메시지 전송
      *
      * @param userId
      * @param fileLink 합격증명서가 저장 된 Google Drive URL
+     * @param needsInput OCR 단계에서 대학교 조회가 된 경우 - false / 조회가 되지 않은 경우 - true
      */
     @Override
-    public void sendVerifyMessage(Long userId, String fileLink) {
+    public void sendVerifyMessage(Long userId, String fileLink, boolean needsInput) {
         String webhookUrl = slackProperties.getWebhook().getUrl();
 
         // 1) 전체 메시지 Payload 생성
         Map<String, Object> payload = new HashMap<>();
-        payload.put("text", "새로 업로드 된 합격증명서 검증이 필요합니다!");
 
         // 2) Slack 메시지 내용
         List<Map<String, Object>> blocks = new ArrayList<>();
-        blocks.add(createTextBlock(userId, fileLink)); //텍스트 섹션 생성
-        blocks.add(createActionBlock(userId)); // 의사 버튼 생성
+
+        if (needsInput) {
+            // CASE 1. 재학중인 대학교 추출에 실패한 경우
+            payload.put("text", "새로 업로드 된 합격증명서 검증이 필요합니다! (대학교 수동 입력 필요)");
+            blocks.add(createTextBlock(userId, fileLink));
+            blocks.add(createInputBlock());
+            blocks.add(createActionBlock(userId, ACTION_ID_APPROVE_WITH_INPUT));
+        } else {
+            // CASE 2. 재학중인 대학교 추출에 성공한 경우 (다른 검증 과정에서 오류가 발생한 경우)
+            payload.put("text", "새로 업로드 된 합격증명서 검증이 필요합니다!");
+            blocks.add(createTextBlock(userId, fileLink));
+            blocks.add(createActionBlock(userId, ACTION_ID_APPROVE));
+        }
 
         payload.put("blocks", blocks);
 
@@ -64,6 +85,13 @@ public class SlackServiceImpl implements SlackService {
         }
     }
 
+    /**
+     * Slack에서 전송된 payload를 처리하고 승인/반려 작업 수행
+     *
+     * @param payload Slack에서 넘어온 JSON 형식의 payload
+     * @return 처리 결과
+     * @throws JsonProcessingException JSON 페이로드 파싱 과정에서 발생하는 도중 에러가 발생하는 경우
+     */
     @Transactional
     @Override
     public String handleInteractivity(String payload) throws JsonProcessingException {
@@ -79,7 +107,40 @@ public class SlackServiceImpl implements SlackService {
 
         String message = "";
 
-        if ("approve_student_verification".equals(actionId)) {
+        if (ACTION_ID_APPROVE_WITH_INPUT.equals(actionId)) {
+            // CASE 1. 대학교 이름 수동 입력 승인
+            String inputUnivName = root.path("state")
+                    .path("values")
+                    .path(INPUT_BLOCK_ID)
+                    .path(ACTION_ID_INPUT)
+                    .path("value")
+                    .asText();
+
+            // 대학교 조회 및 업데이트
+            if (inputUnivName == null || inputUnivName.isBlank()) {
+                return createResponse(false, "⚠️ 대학교 이름을 입력해주세요!");
+            }
+
+            Optional<Universities> univ = universitiesRepository.findByUniversityName(inputUnivName.trim());
+            if (univ.isEmpty()) {
+                return createResponse(false, "⚠️ '" + inputUnivName + "' 학교를 DB에서 찾을 수 없습니다.");
+            }
+
+            Users user = usersRepository.findByUserId(userId).orElseThrow(UserNotFoundException::notFound);
+            user.updateUniversity(univ.get());
+
+            certificateService.updateVerificationStatusByCertificate(
+                    userId,
+                    String.valueOf(VerificationStatus.NEW_STUDENT_VERIFIED),
+                    null,
+                    null
+            );
+
+            log.info("관리자 수동 입력 승인: User - {} / University - {}", userId, inputUnivName);
+            message = "✅ 관리자에 의해 승인 처리되었습니다.";
+
+        } else if (ACTION_ID_APPROVE.equals(actionId)) {
+            // CASE 2. 수동 승인
             certificateService.updateVerificationStatusByCertificate(
                     userId,
                     String.valueOf(VerificationStatus.NEW_STUDENT_VERIFIED),
@@ -89,7 +150,8 @@ public class SlackServiceImpl implements SlackService {
 
             message = "✅ 관리자에 의해 승인 처리되었습니다.";
             log.info("Slack에서 승인 처리 완료: userId - {}", userId);
-        } else if ("reject_student_verification".equals(actionId)) {
+        } else if (ACTION_ID_REJECT.equals(actionId)) {
+            // CASE 3. 수동 반려
             certificateService.updateVerificationStatusByCertificate(
                     userId,
                     String.valueOf(VerificationStatus.UNVERIFIED),
@@ -100,8 +162,7 @@ public class SlackServiceImpl implements SlackService {
             log.info("Slack에서 반려 처리 완료: userId - {}", userId);
         }
 
-        return createResponseJson(message);
-    }
+        return createResponse(true, message);    }
 
     // 텍스트 섹션 생성하기
     private Map<String, Object> createTextBlock(Long userId, String fileLink) {
@@ -118,17 +179,33 @@ public class SlackServiceImpl implements SlackService {
     }
 
     // 의사 버튼 섹션 생성하기 (승인/반려)
-    private Map<String, Object> createActionBlock(Long userId) {
+    private Map<String, Object> createActionBlock(Long userId, String approveType) {
         Map<String, Object> actions = new HashMap<>();
         actions.put("type", "actions");
 
         List<Map<String, Object>> elements = new ArrayList<>();
 
-        elements.add(createButton("승인", "primary", "approve_student_verification", String.valueOf(userId)));
-        elements.add(createButton("반려", "danger", "reject_student_verification", String.valueOf(userId)));
+        elements.add(createButton("승인", "primary", approveType, String.valueOf(userId)));
+        elements.add(createButton("반려", "danger", ACTION_ID_REJECT, String.valueOf(userId)));
 
         actions.put("elements", elements);
         return actions;
+    }
+
+    // input block 생성하기
+    private Map<String, Object> createInputBlock() {
+        Map<String, Object> inputBlock = new HashMap<>();
+        inputBlock.put("type", "input");
+        inputBlock.put("block_id", INPUT_BLOCK_ID);
+        inputBlock.put("label", Map.of("type", "plain_text", "text", "대학교 이름 입력"));
+
+        Map<String, Object> element = new HashMap<>();
+        element.put("type", "plain_text_input");
+        element.put("action_id", ACTION_ID_INPUT);
+        element.put("placeholder", Map.of("type", "plain_text", "text", "정확한 대학교 이름을 입력해주세요."));
+
+        inputBlock.put("element", element);
+        return inputBlock;
     }
 
     // 버튼 생성하기
@@ -144,7 +221,16 @@ public class SlackServiceImpl implements SlackService {
     }
 
     // Slack 응답 메시지 포맷
-    private String createResponseJson(String text) {
-        return String.format("{\"replace_original\": \"true\", \"text\": \"%s\"}", text);
+    private String createResponse(boolean replaceOriginal, String text) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("replace_original", replaceOriginal);
+        response.put("text", text);
+
+        try {
+            return objectMapper.writeValueAsString(response);
+        } catch (JsonProcessingException e) {
+            log.error("Slack 응답 JSON 생성 실패", e);
+            return String.format("{\"replace_original\": \"%b\", \"text\": \"Error processing response\"}", replaceOriginal);
+        }
     }
 }

--- a/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.*;
@@ -80,8 +81,10 @@ public class SlackServiceImpl implements SlackService {
 
             restTemplate.postForEntity(webhookUrl, request, String.class);
             log.info("Slack 인증 메시지 전송 완료: ID {}", userId);
+        } catch (RestClientException e) {
+            log.error("Slack API 호출 중 네트워크 오류 발생: {}", e.getMessage(), e);
         } catch (Exception e) {
-            log.error("Slack 메시지 전송 실패: ", e);
+            log.error("Slack 메시지 전송 중 알 수 없는 오류 발생: ", e);
         }
     }
 

--- a/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
@@ -1,0 +1,98 @@
+package JJinBBang.app.global.slack.service.impl;
+
+import JJinBBang.app.global.slack.properties.SlackProperties;
+import JJinBBang.app.global.slack.service.SlackService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SlackServiceImpl implements SlackService {
+
+    private final SlackProperties slackProperties;
+    private final RestTemplate restTemplate;
+
+    /**
+     * Slack #합격증명서-인증 채널에 찐빵 봇을 통한 미승인 합격증명서 인증 메시지 전송
+     *
+     * @param userId
+     * @param fileLink 합격증명서가 저장 된 Google Drive URL
+     */
+    @Override
+    public void sendVerifyMessage(Long userId, String fileLink) {
+        String webhookUrl = slackProperties.getWebhook().getUrl();
+
+        // 1) 전체 메시지 Payload 생성
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("text", "새로 업로드 된 합격증명서 검증이 필요합니다!");
+
+        // 2) Slack 메시지 내용
+        List<Map<String, Object>> blocks = new ArrayList<>();
+        blocks.add(createTextBlock(userId, fileLink)); //텍스트 섹션 생성
+        blocks.add(createActionBlock(userId)); // 의사 버튼 생성
+
+        payload.put("blocks", blocks);
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+
+            restTemplate.postForEntity(webhookUrl, request, String.class);
+            log.info("Slack 인증 메시지 전송 완료: ID {}", userId);
+        } catch (Exception e) {
+            log.error("Slack 메시지 전송 실패: ", e);
+        }
+    }
+
+    // 텍스트 섹션 생성하기
+    private Map<String, Object> createTextBlock(Long userId, String fileLink) {
+        Map<String, Object> section = new HashMap<>();
+        section.put("type", "section");
+
+        Map<String, Object> text = new HashMap<>();
+        text.put("type", "mrkdwn");
+        text.put("text", String.format("[재학생 인증 요청 - ID: %s] \n관리자 확인이 필요합니다.\n\n📄 <%s|합격증명서 확인하기>", userId, fileLink));
+
+        section.put("text", text);
+
+        return section;
+    }
+
+    // 의사 버튼 섹션 생성하기 (승인/반려)
+    private Map<String, Object> createActionBlock(Long userId) {
+        Map<String, Object> actions = new HashMap<>();
+        actions.put("type", "actions");
+
+        List<Map<String, Object>> elements = new ArrayList<>();
+
+        elements.add(createButton("승인", "primary", "approve_student_verification", String.valueOf(userId)));
+        elements.add(createButton("반려", "danger", "reject_student_verification", String.valueOf(userId)));
+
+        actions.put("elements", elements);
+        return actions;
+    }
+
+    // 버튼 생성하기
+    private Map<String, Object> createButton(String text, String style, String actionId, String value) {
+        Map<String, Object> button = new HashMap<>();
+        button.put("type", "button");
+        button.put("text", Map.of("type", "plain_text", "text", text));
+        button.put("style", style);
+        button.put("action_id", actionId);
+        button.put("value", value);
+
+        return button;
+    }
+}

--- a/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
@@ -83,6 +83,7 @@ public class SlackServiceImpl implements SlackService {
             certificateService.updateVerificationStatusByCertificate(
                     userId,
                     String.valueOf(VerificationStatus.NEW_STUDENT_VERIFIED),
+                    null,
                     null
             );
 
@@ -92,6 +93,7 @@ public class SlackServiceImpl implements SlackService {
             certificateService.updateVerificationStatusByCertificate(
                     userId,
                     String.valueOf(VerificationStatus.UNVERIFIED),
+                    null,
                     null
             );
             message = "❌ 관리자에 의해 반려 처리되었습니다.";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -182,3 +182,9 @@ ocr:
   clova:
     api-url: ${ocr.clova.api-url}
     secret-key: ${ocr.clova.secret-key}
+
+openai:
+  api-key: ${openai.api-key}
+  model: ${openai.model}
+  api-url: ${openai.api-url}
+  certificates-verification-prompt: ${openai.certificates-verification-prompt}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -166,3 +166,9 @@ vworld:
 google:
   credentials:
     path: "classpath:gcp_iam_key.json"
+
+slack:
+  webhook:
+    url: ${slack.webhook.url}
+  security:
+    signing-secret: ${slack.security.signing-secret}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -171,6 +171,28 @@ vworld:
 google:
   credentials:
     path: "classpath:gcp_iam_key.json"
+  drive:
+    folders:
+      admission: ${google.drive.folders.admission}
+      admission-target: ${google.drive.folders.admission-target}
+    url-template: ${google.drive.url-template}
+  spreadsheet:
+    certificates:
+      id: ${google.spreadsheet.certificates.id}
+      sheets:
+        admission: ${google.spreadsheet.certificates.sheets.admission}
+      range-template: ${google.spreadsheet.certificates.range-template}
+    opinion:
+      id: ${google.spreadsheet.opinion.id}
+      sheets:
+        user-review-opinion: ${google.spreadsheet.opinion.sheets.user-review-opinion}
+        user-building-opinion: ${google.spreadsheet.opinion.sheets.user-building-opinion}
+      range-template: ${google.spreadsheet.opinion.range-template}
+    unregister:
+      id: ${google.spreadsheet.unregister.id}
+      sheets:
+        unregister-reason: ${google.spreadsheet.unregister.sheets.unregister-reason}
+      range-template: ${google.spreadsheet.unregister.range-template}
 
 slack:
   webhook:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,6 +92,11 @@ spring:
     encoding: UTF-8
     basename: ValidationMessages
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 cloud:
   aws:
     region:
@@ -172,3 +177,8 @@ slack:
     url: ${slack.webhook.url}
   security:
     signing-secret: ${slack.security.signing-secret}
+
+ocr:
+  clova:
+    api-url: ${ocr.clova.api-url}
+    secret-key: ${ocr.clova.secret-key}


### PR DESCRIPTION
## 📌 이슈 번호
> #281 

## 💬 리뷰 포인트
> 신입생 합격증명서 자동화 인증 및 Slack 인증 기능을 구현하였습니다.

## 🚀 상세 설명
인증 로직
1. 신입생 합격증명서 업로드 (Google Drive) -> 인증 상태를 PENDING으로 변경
2. 비동기 이벤트 요청 -> 클라이언트에게 업로드 성공 응답
3. 비동기 이벤트 handleCertificateVerificationEvent 진행
  - **OCR로 텍스트 파싱** (NAVER CLOVA OCR 사용)
    - **대학교 조회** -> 사용자의 대학교 정보 업데이트
  - **합격증명서 검증** 단계
    - 신뢰도 검사 (OCR confidence 값 기반 0.9 이상만 통과)
    - 키워드 검사 - 합격에 관련된 키워드, 공문서 관련 키워드 유무
    - OpenAI API 활용한 문서 신뢰도 검증
4. 자동 검증 결과 기반 Slack 전송 판단
  - 자동 검증에 실패한 경우 -> Slack Bot으로 수동 인증 메시지 전송
  - 자동 검증에 성공한 경우 -> NEW_STUDENT_VERIFIED으로 인증 상태 업데이트
5. Slack 인증
  - 승인 -> NEW_STUDENT_VERIFIED로 인증 상태 업데이트
  - 반려 -> UNVERIFIED로 인증 상태 업데이트


LLM 검증 기준
1. 대학 합격 또는 입학을 증명하는 문서인가?
2. 대학교 공식 명칭이 언급되어 있는가?
3. 카카오톡, 대학 입시 사이트 등의 캡쳐 화면이 아닌 문서 형식을 띄는가?
4. 조작된 흔적은 없는가?


- Google Drive 및 Sheets 관련 오류가 발생해서 수정하였습니다.
  - 설정값 application.yml에 입력하였고
  - 관련 properties 형식 수정하였습니다.
  - 사용하지 않는 재학증명서 인증 관련 로직은 삭제하였습니다.


## 📸 스크린샷

- 대학교 이름이 파싱되지 않아 전송되는 Slack 메시지 예시
<img width="690" height="223" alt="image" src="https://github.com/user-attachments/assets/4dc101e1-4af8-41af-bab1-351389757584" />

- 검증 단계에서 검증에 실패하여 전송되는 Slack 메시지 예시
<img width="366" height="225" alt="image" src="https://github.com/user-attachments/assets/10a561f9-02c5-4a4e-a9ad-391e5703d3d9" />

## 📢 노트
- LLM을 추가한 이유는 OCR confidence 값이 텍스트 추출 퀄리티에 대한 값인데,
 실제 합격증명서와 손으로 직접 따라 작성한 이미지 파일의 confidence 값이 거의 차이가 없었습니다.
(실제로 제가 직접 따라 작성한 이미지의 confidence 값이 더 높게 나오는 경우도 있었습니다.)
따라서 텍스트가 아닌 이미지 자체에 대한 검증을 위해 추가하였습니다.
- 현재는 Slack에서 서버로 요청하는 서버 경로가 로컬 서버에서 테스트를 해야하는 상황 때문에 ngrok으로 터널링 된 url을 사용중인데 develop에 합쳐질 때 수정하겠습니다!