### PR TITLE
[Fix #307] 콘텐츠 목록에 좋아요 여부 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/ReportController.java
@@ -20,6 +20,7 @@ public class ReportController {
 
     @GetMapping("")
     public ResTemplate<ReportListResponse> getReportList(
+            @AuthenticationPrincipal Users user,
             @RequestParam(name = "category") String category,
             @RequestParam(name = "cursor", required = false) Long cursor,
             @RequestParam(name = "size", required = false) Integer size
@@ -27,7 +28,8 @@ public class ReportController {
         ReportListResponse data = reportService.getReportList(
                 category != null ?category.toUpperCase() : null,
                 cursor,
-                (size != null && size > 0) ? size : 10
+                (size != null && size > 0) ? size : 10,
+                user
         );
 
         return new ResTemplate<>(HttpStatus.OK, "리포트 목록 조회 성공", data);

--- a/src/main/java/JJinBBang/app/domain/common/repository/ReportLikesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/common/repository/ReportLikesRepository.java
@@ -6,6 +6,8 @@ import JJinBBang.app.domain.common.entity.Reports;
 import JJinBBang.app.domain.user.entity.Users;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -14,4 +16,7 @@ public interface ReportLikesRepository extends JpaRepository<ReportLikes, Report
 
     @EntityGraph(attributePaths = {"report"})
     List<ReportLikes> findAllByUser_UserId(Long userId);
+
+    @Query("SELECT rl.report.id FROM ReportLikes rl WHERE rl.user = :user AND rl.report IN :reports")
+    List<Long> findLikedReportIds(@Param("user") Users users, @Param("reports") List<Reports> reports);
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportService.java
@@ -6,7 +6,7 @@ import JJinBBang.app.domain.user.entity.Users;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface ReportService {
-    ReportListResponse getReportList(String category, Long cursor, int size);
+    ReportListResponse getReportList(String category, Long cursor, int size, Users user);
 
     @Transactional
     ReportInfoResponse getReportDetail(Users user, Long reportId);

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
@@ -22,7 +22,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -40,7 +42,7 @@ public class ReportServiceImpl implements ReportService {
      * @return
      */
     @Override
-    public ReportListResponse getReportList(String category, Long cursor, int size) {
+    public ReportListResponse getReportList(String category, Long cursor, int size, Users user) {
 
         if (size <= 0) throw ReportInvalidException.invalidSize();
 
@@ -84,17 +86,29 @@ public class ReportServiceImpl implements ReportService {
         boolean hasNext = resultList.size() > size;
         if (hasNext) resultList = resultList.subList(0, size);
 
+        Set<Long> likedReportIds = new HashSet<>();
+        if (user != null && !resultList.isEmpty()) {
+            List<Long> ids = reportLikesRepository.findLikedReportIds(user, resultList);
+            likedReportIds.addAll(ids);
+        }
+
         // 리포트 데이터 매핑
         List<ReportInfo> reports = resultList.stream()
-                .map(report -> new ReportInfo(
-                        report.getId(),
-                        report.getCoverImage(),
-                        report.getCategory(),
-                        report.getTitle(),
-                        report.getCreatedAt(),
-                        report.getLikeCount(),
-                        report.getViewCount()
-                ))
+                .map(report -> {
+
+                    boolean isLiked = likedReportIds.contains(report.getId());
+
+                    return new ReportInfo(
+                            report.getId(),
+                            report.getCoverImage(),
+                            report.getCategory(),
+                            report.getTitle(),
+                            report.getCreatedAt(),
+                            report.getLikeCount(),
+                            report.getViewCount(),
+                            isLiked
+                    );
+                })
                 .toList();
 
         // pagination 데이터 업데이트 (마지막 요소 id 조회)

--- a/src/main/java/JJinBBang/app/global/common/dto/ReportInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/ReportInfo.java
@@ -11,6 +11,7 @@ public record ReportInfo(
         String title, // 리포트 제목
         LocalDateTime createdAt, // 작성일
         Integer likeCount, // 좋아요 수
-        Integer viewCount // 조회 수
+        Integer viewCount, // 조회 수
+        boolean isLiked // 좋아요 여부
 ) {
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #307 

## 💬 리뷰 포인트
> 찐빵 콘텐츠 목록 조회 시 좋아요 여부 표기하도록 수정

## 🚀 상세 설명
- 지난번 콘텐츠 게시글을 토큰이 없어도 조회를 할 수 있도록 변경함에 따라 콘텐츠 목록에서도 좋아요 여부를 알 수 있도록 수정이 필요하여 수정하였습니다.
  - 헤더에 토큰을 받을 수 있도록 하였고 해당 사용자의 좋아요 여부를 조회하여 응답할 수 있도록 하였습니다.

- 아래와 같은 형식으로 목록 조회 시 각 아이템에 isLiked 항목을 추가하였습니다.

  <img width="268" height="75" alt="image" src="https://github.com/user-attachments/assets/461e4c4e-1877-4988-b8aa-d008843b007c" />

- N+1 문제는 Fetch Batching 쿼리 방식으로 해결하였습니다.

  <img width="797" height="51" alt="image" src="https://github.com/user-attachments/assets/7874eee0-38e3-43ef-ac9c-c1502da9e1c2" />

## 📢 노트