### PR TITLE
[FEAT #310] 기숙사 목록 조회 기능 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/controller/BuildingController.java
+++ b/src/main/java/JJinBBang/app/domain/building/controller/BuildingController.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.domain.building.controller;
 
+import JJinBBang.app.domain.building.dto.DormitoryListResponse;
 import JJinBBang.app.domain.building.service.AgencyService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -53,5 +54,11 @@ public class BuildingController {
 
 		PaginatedResponse<ReviewSummaryResponse> data = reviewService.getReviewList(buildingId, isAgency, user, pageRequest);
 		return new ResTemplate<>(HttpStatus.OK, "조회 성공", data);
+	}
+
+	@GetMapping("/dormitory")
+	public ResTemplate<DormitoryListResponse> getDormitoryList(@RequestParam Long universityId) {
+		DormitoryListResponse data = buildingService.getDormitoryList(universityId);
+		return new ResTemplate<>(HttpStatus.OK, "기숙사 목록 조회 성공", data);
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/dto/DormitoryItem.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/DormitoryItem.java
@@ -1,0 +1,20 @@
+package JJinBBang.app.domain.building.dto;
+
+import lombok.Builder;
+
+@Builder
+public record DormitoryItem(
+	String campusName,
+	Long dormitoryId,
+	String dormitoryName,
+	String dormitoryAddress
+) {
+	public static DormitoryItem of(String campusName, Long dormitoryId, String dormitoryName, String dormitoryAddress) {
+		return DormitoryItem.builder()
+			.campusName(campusName)
+			.dormitoryId(dormitoryId)
+			.dormitoryName(dormitoryName)
+			.dormitoryAddress(dormitoryAddress)
+			.build();
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/dto/DormitoryListResponse.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/DormitoryListResponse.java
@@ -1,0 +1,16 @@
+package JJinBBang.app.domain.building.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record DormitoryListResponse(
+	List<DormitoryItem> dormitories
+) {
+	public static DormitoryListResponse of(List<DormitoryItem> dormitories) {
+		return DormitoryListResponse.builder()
+			.dormitories(dormitories)
+			.build();
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/repository/BuildingsRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/BuildingsRepository.java
@@ -2,8 +2,11 @@ package JJinBBang.app.domain.building.repository;
 
 import JJinBBang.app.domain.building.entity.Buildings;
 import JJinBBang.app.domain.building.repository.custom.BuildingsRepositoryCustom;
+import JJinBBang.app.domain.common.entity.Campuses;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.Modifying;
@@ -22,4 +25,7 @@ public interface BuildingsRepository extends JpaRepository<Buildings, Long>, Bui
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Buildings r SET r.likeCount = r.likeCount - 1 WHERE r.id = :buildingId")
     void decrementLikeCount(@Param("buildingId") Long buildingId);
+
+    // 캠퍼스목록과 건물 유형으로 건물 리스트 조회
+    List<Buildings> findByCampusInAndBuildingTypeOrderByCampus_CampusNameAscBuildingNameAsc(List<Campuses> campuses, String buildingType);
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/BuildingService.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BuildingService.java
@@ -1,8 +1,11 @@
 package JJinBBang.app.domain.building.service;
 
 import JJinBBang.app.domain.building.dto.BuildingDetailResponse;
+import JJinBBang.app.domain.building.dto.DormitoryListResponse;
 import JJinBBang.app.domain.user.entity.Users;
 
 public interface BuildingService {
 	BuildingDetailResponse getBuildingDetail(Long buildingId, Users user);
+
+	DormitoryListResponse getDormitoryList(Long universityId);
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/BuildingServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BuildingServiceImpl.java
@@ -74,7 +74,7 @@ public class BuildingServiceImpl implements BuildingService {
 	public DormitoryListResponse getDormitoryList(Long universityId) {
 		Universities university = universityRepository.findById(universityId).orElseThrow(UniversityNotFoundException::missingUniversity);
 		List<Campuses> campuses = university.getCampuses();
-		if (campuses == null || campuses.isEmpty()) {
+if (campuses.isEmpty()) {
 			return DormitoryListResponse.of(List.of());
 		}
 

--- a/src/main/java/JJinBBang/app/domain/building/service/BuildingServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BuildingServiceImpl.java
@@ -3,6 +3,8 @@ package JJinBBang.app.domain.building.service;
 import java.util.*;
 
 import JJinBBang.app.domain.building.document.BuildingKeywordCounts;
+import JJinBBang.app.domain.building.dto.DormitoryItem;
+import JJinBBang.app.domain.building.dto.DormitoryListResponse;
 import JJinBBang.app.domain.building.enums.BuildingType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,7 +15,11 @@ import JJinBBang.app.domain.building.entity.Buildings;
 import JJinBBang.app.domain.building.exception.BuildingNullException;
 import JJinBBang.app.domain.building.repository.BuildingKeywordCountsRepository;
 import JJinBBang.app.domain.building.repository.BuildingsRepository;
+import JJinBBang.app.domain.common.entity.Campuses;
+import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.domain.user.entity.Users;
+import JJinBBang.app.domain.user.exception.UniversityNotFoundException;
+import JJinBBang.app.domain.user.repository.UniversityRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -21,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class BuildingServiceImpl implements BuildingService {
 	private final BuildingsRepository buildingsRepository;
 	private final BuildingKeywordCountsRepository buildingKeywordCountRepository;
+	private final UniversityRepository universityRepository;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -60,5 +67,28 @@ public class BuildingServiceImpl implements BuildingService {
 		} else {
 			return BuildingDetailResponse.ofGeneral(building, liked, top5Positive);
 		}
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public DormitoryListResponse getDormitoryList(Long universityId) {
+		Universities university = universityRepository.findById(universityId).orElseThrow(UniversityNotFoundException::missingUniversity);
+		List<Campuses> campuses = university.getCampuses();
+		if (campuses == null || campuses.isEmpty()) {
+			return DormitoryListResponse.of(List.of());
+		}
+
+		List<Buildings> dormitories = buildingsRepository.findByCampusInAndBuildingTypeOrderByCampus_CampusNameAscBuildingNameAsc(campuses, BuildingType.DORMITORY.name());
+
+		List<DormitoryItem> items = dormitories.stream()
+			.map(building -> DormitoryItem.of(
+				building.getCampus().getCampusName(),
+				building.getId(),
+				building.getBuildingName(),
+				building.getBuildingAddress()
+			))
+			.toList();
+
+		return DormitoryListResponse.of(items);
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/user/exception/UniversityNotFoundException.java
+++ b/src/main/java/JJinBBang/app/domain/user/exception/UniversityNotFoundException.java
@@ -15,4 +15,7 @@ public class UniversityNotFoundException extends NotFoundGroupException {
         return new UniversityNotFoundException("해당 도메인에 대한 대학교 데이터 없음: " + universityName);
     }
 
+	public static UniversityNotFoundException missingUniversity() {
+        return new UniversityNotFoundException("대학교 정보가 없습니다.");
+	}
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #310 

## 💬 리뷰 포인트

* `universityId`로 해당 대학의 캠퍼스 목록을 가져와 기숙사(BuildingType=DORMITORY) 건물만 조회
* campusName, buildingName  기준으로 정렬

## 🚀 상세 설명
**기숙사 목록 조회 API 추가**
  * `GET /dormitory?universityId=...`
  * `BuildingController`에 엔드포인트 추가

**서비스 로직 추가**
  * `universityId`로 대학 조회(없으면 `UniversityNotFoundException.missingUniversity()` 발생)
  * 대학의 캠퍼스 리스트로 기숙사 건물 조회 후 DTO로 매핑
 
**DTO 추가**
  * `DormitoryItem`, `DormitoryListResponse` 생성

**Repository 메서드 추가**

  * `findByCampusInAndBuildingTypeOrderByCampus_CampusNameAscBuildingNameAsc(...)`

## 📸 스크린샷
<img width="1135" height="1096" alt="image" src="https://github.com/user-attachments/assets/095a95ae-be29-49be-a547-c9f9d7ad4cfc" />

## 📢 노트
