### PR TITLE
[Feat #309]  리뷰이벤트 리뷰 수집 API

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/controller/EventController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/EventController.java
@@ -1,0 +1,38 @@
+package JJinBBang.app.domain.common.controller;
+
+import JJinBBang.app.domain.common.dto.request.ReviewEventRequest;
+import JJinBBang.app.global.sheets.service.GoogleSheetsService;
+import JJinBBang.app.global.template.ResTemplate;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/v1/event")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final GoogleSheetsService googleSheetsService;
+
+    /**
+     * 리뷰 이벤트 리뷰 수집 API - 지거국 10개 대학 확장 이벤트
+     * Google Sheets 저장
+     *
+     * @param req
+     * @return
+     * @throws IOException
+     */
+    @PostMapping("/review")
+    public ResTemplate<?> addReviewFromEvent(
+            @Valid @RequestBody ReviewEventRequest req
+    ) throws IOException {
+        googleSheetsService.appendReviewFromEvent(req);
+        return new ResTemplate<>(HttpStatus.OK, "리뷰이벤트 후기 업로드 성공", null);
+    }
+}

--- a/src/main/java/JJinBBang/app/domain/common/controller/EventController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/EventController.java
@@ -31,7 +31,7 @@ public class EventController {
     @PostMapping("/review")
     public ResTemplate<?> addReviewFromEvent(
             @Valid @RequestBody ReviewEventRequest req
-    ) throws IOException {
+    ) {
         googleSheetsService.appendReviewFromEvent(req);
         return new ResTemplate<>(HttpStatus.OK, "리뷰이벤트 후기 업로드 성공", null);
     }

--- a/src/main/java/JJinBBang/app/domain/common/dto/request/EventReview.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/request/EventReview.java
@@ -1,0 +1,41 @@
+package JJinBBang.app.domain.common.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record EventReview(
+        @NotBlank(message = "재학 중인 대학교를 입력해주세요.")
+        String university,
+
+        @NotBlank(message = "계약 형태를 입력해주세요.")
+        String contractType,  // 계약 형태
+
+        @PositiveOrZero(message = "보증금의 최소 금액은 0원입니다.")
+        int deposit,  // 보증금
+
+        @PositiveOrZero(message = "월세의 최소 금액은 0원입니다.")
+        int monthlyRent,  // 월세
+
+        @PositiveOrZero(message = "관리비의 최소 금액은 0원입니다.")
+        int administrationCost,  // 관리비
+
+        @NotNull
+        @Size(min = 3, message = "장점은 최소 3개 이상 선택해야 합니다.")
+        List<String> positiveKeywords,
+
+        @NotNull
+        @Size(min = 3, message = "단점은 최소 3개 이상 선택해야 합니다.")
+        List<String> negativeKeywords,
+
+        @Size(max = 3, message = "이미지는 최대 3장까지 업로드 가능합니다.")
+        List<String> images,
+
+        @NotBlank
+        @Size(min = 20, message = "리뷰는 최소 20자 이상 작성해야 합니다.")
+        String content
+) {
+}

--- a/src/main/java/JJinBBang/app/domain/common/dto/request/ReviewEventRequest.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/request/ReviewEventRequest.java
@@ -1,0 +1,22 @@
+package JJinBBang.app.domain.common.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record ReviewEventRequest(
+        @Valid
+        @NotNull
+        EventReview review,
+
+        @NotBlank(message = "전화번호를 입력하지 않으면 이벤트 참여가 어렵습니다.")
+        String phoneNumber,
+
+        @AssertTrue(message = "이벤트 참여 및 마케팅에 동의해야 합니다.")
+        boolean hasAgreedToMarketing,  // 마케팅 동의
+
+        @AssertTrue(message = "개인정보 수집에 동의해야 합니다.")
+        boolean hasAgreedToPrivacy  // 개인정보 동의
+) {
+}

--- a/src/main/java/JJinBBang/app/global/sheets/GoogleInternalException.java
+++ b/src/main/java/JJinBBang/app/global/sheets/GoogleInternalException.java
@@ -1,0 +1,13 @@
+package JJinBBang.app.global.sheets;
+
+import JJinBBang.app.global.ocr.exception.OcrInternalException;
+
+public class GoogleInternalException extends RuntimeException {
+    public GoogleInternalException(String message) {
+        super(message);
+    }
+
+    public static OcrInternalException apiError() {
+        return new OcrInternalException("Google Sheets 업로드 중 오류가 발생했습니다.");
+    }
+}

--- a/src/main/java/JJinBBang/app/global/sheets/properties/GoogleProperties.java
+++ b/src/main/java/JJinBBang/app/global/sheets/properties/GoogleProperties.java
@@ -30,6 +30,7 @@ public class GoogleProperties {
         private SheetConfig certificates = new SheetConfig();
         private SheetConfig opinion = new SheetConfig();
         private SheetConfig unregister = new SheetConfig();
+        private SheetConfig reviewEvent = new SheetConfig();
     }
 
     @Setter

--- a/src/main/java/JJinBBang/app/global/sheets/service/GoogleSheetsService.java
+++ b/src/main/java/JJinBBang/app/global/sheets/service/GoogleSheetsService.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.global.sheets.service;
 
+import JJinBBang.app.domain.common.dto.request.ReviewEventRequest;
 import JJinBBang.app.global.sheets.dto.UnregisterReasonDto;
 import JJinBBang.app.global.sheets.dto.UserOpinionDto;
 import JJinBBang.app.global.sheets.enums.OpinionType;
@@ -19,4 +20,7 @@ public interface GoogleSheetsService {
             UserOpinionDto userOpinionDto,
             OpinionType opinionType
     ) throws IOException;
+
+    // 리뷰 저장 (지거국 확장 이벤트)
+    void appendReviewFromEvent(ReviewEventRequest req);
 }

--- a/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
@@ -1,6 +1,7 @@
 package JJinBBang.app.global.sheets.service.impl;
 
 import JJinBBang.app.domain.common.dto.request.ReviewEventRequest;
+import JJinBBang.app.global.sheets.GoogleInternalException;
 import JJinBBang.app.global.sheets.dto.UnregisterReasonDto;
 import JJinBBang.app.global.sheets.dto.UserOpinionDto;
 import JJinBBang.app.global.sheets.enums.OpinionType;
@@ -103,8 +104,8 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
         try {
             var sheet = googleProperties.getSpreadsheet().getReviewEvent();
 
-            String posKeywords = req.review().positiveKeywords() != null ? String.join(", ", req.review().positiveKeywords()) : "";
-            String negKeywords = req.review().negativeKeywords() != null ? String.join(", ", req.review().negativeKeywords()) : "";
+            String posKeywords = String.join(", ", req.review().positiveKeywords());
+            String negKeywords = String.join(", ", req.review().negativeKeywords());
             String imageLinks = req.review().images() != null ? String.join("\n", req.review().images()) : "";
 
             List<Object> row = List.of(
@@ -125,8 +126,8 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
 
             appendRowToGoogleSheets(sheet, "review-event", row);
         } catch (IOException e) {
-            log.error("리뷰이벤트 후기를 저장에 실패했습니다.: {} (전화번호: {})", e.getMessage(), req.phoneNumber());
-            throw new RuntimeException("리뷰 저장 중 오류가 발생했습니다.");
+            log.error("리뷰이벤트 후기를 저장에 실패했습니다.: {}", e.getMessage());
+            throw GoogleInternalException.apiError();
         }
     }
 }

--- a/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.global.sheets.service.impl;
 
+import JJinBBang.app.domain.common.dto.request.ReviewEventRequest;
 import JJinBBang.app.global.sheets.dto.UnregisterReasonDto;
 import JJinBBang.app.global.sheets.dto.UserOpinionDto;
 import JJinBBang.app.global.sheets.enums.OpinionType;
@@ -94,5 +95,38 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
             case BUILDING_REPORT -> "user-building-opinion";
             case REVIEW_REPORT ->  "user-review-opinion";
         };
+    }
+
+    // 리뷰 저장 (지거국 확장 이벤트)
+    @Override
+    public void appendReviewFromEvent(ReviewEventRequest req) {
+        try {
+            var sheet = googleProperties.getSpreadsheet().getReviewEvent();
+
+            String posKeywords = req.review().positiveKeywords() != null ? String.join(", ", req.review().positiveKeywords()) : "";
+            String negKeywords = req.review().negativeKeywords() != null ? String.join(", ", req.review().negativeKeywords()) : "";
+            String imageLinks = req.review().images() != null ? String.join("\n", req.review().images()) : "";
+
+            List<Object> row = List.of(
+                    req.phoneNumber(),
+                    req.review().university(),
+                    req.review().contractType(),
+                    req.review().deposit(),
+                    req.review().monthlyRent(),
+                    req.review().administrationCost(),
+                    posKeywords,
+                    negKeywords,
+                    imageLinks,
+                    req.review().content(),
+                    req.hasAgreedToMarketing(),
+                    req.hasAgreedToPrivacy(),
+                    java.time.LocalDateTime.now().format(DATE_TIME_FORMATTER)
+            );
+
+            appendRowToGoogleSheets(sheet, "review-event", row);
+        } catch (IOException e) {
+            log.error("리뷰이벤트 후기를 저장에 실패했습니다.: {} (전화번호: {})", e.getMessage(), req.phoneNumber());
+            throw new RuntimeException("리뷰 저장 중 오류가 발생했습니다.");
+        }
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
> #309 

## 💬 리뷰 포인트
> 지거국 10개 대학 확장을 하면서 진행하게 될 리뷰이벤트 API를 개발하였습니다.

## 🚀 상세 설명
- 인증 없이 작성 가능하며 이미지를 제외한 모든 문항 입력할 수 있도록 하였습니다.
- 업로드 시 Google Sheets에 저장될 수 있도록 하였으며 저장되는 항목은 아래와 같습니다.
  - 대학교 / 계약유형 / 보증금 / 월세 / 관리비 / 장점 / 단점 / 이미지 / 본문 / 마케팅 동의 / 개인정보 수집 동의 / 전화번호

## 📢 노트