### PR TITLE
[Refactor #318] 기숙사 조회 로직을 캠퍼스 ID 기반으로 수정 및 예외 처리 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/controller/BuildingController.java
+++ b/src/main/java/JJinBBang/app/domain/building/controller/BuildingController.java
@@ -57,8 +57,8 @@ public class BuildingController {
 	}
 
 	@GetMapping("/dormitory")
-	public ResTemplate<DormitoryListResponse> getDormitoryList(@RequestParam Long universityId) {
-		DormitoryListResponse data = buildingService.getDormitoryList(universityId);
+	public ResTemplate<DormitoryListResponse> getDormitoryList(@RequestParam Long campusId) {
+		DormitoryListResponse data = buildingService.getDormitoryList(campusId);
 		return new ResTemplate<>(HttpStatus.OK, "기숙사 목록 조회 성공", data);
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/exception/BuildingNotFoundException.java
+++ b/src/main/java/JJinBBang/app/domain/building/exception/BuildingNotFoundException.java
@@ -14,4 +14,8 @@ public class BuildingNotFoundException extends NotFoundGroupException {
 	public static BuildingNotFoundException missingDormitory() {
 		return new BuildingNotFoundException("기숙사 정보가 존재하지 않습니다");
 	}
+
+	public static RuntimeException missingCampus() {
+		return new BuildingNotFoundException("캠퍼스 정보가 존재하지 않습니다");
+	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/exception/BuildingNotFoundException.java
+++ b/src/main/java/JJinBBang/app/domain/building/exception/BuildingNotFoundException.java
@@ -15,7 +15,7 @@ public class BuildingNotFoundException extends NotFoundGroupException {
 		return new BuildingNotFoundException("기숙사 정보가 존재하지 않습니다");
 	}
 
-	public static RuntimeException missingCampus() {
+	public static BuildingNotFoundException missingCampus() {
 		return new BuildingNotFoundException("캠퍼스 정보가 존재하지 않습니다");
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/building/repository/BuildingsRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/BuildingsRepository.java
@@ -26,6 +26,6 @@ public interface BuildingsRepository extends JpaRepository<Buildings, Long>, Bui
     @Query("UPDATE Buildings r SET r.likeCount = r.likeCount - 1 WHERE r.id = :buildingId")
     void decrementLikeCount(@Param("buildingId") Long buildingId);
 
-    // 캠퍼스목록과 건물 유형으로 건물 리스트 조회
-    List<Buildings> findByCampusInAndBuildingTypeOrderByCampus_CampusNameAscBuildingNameAsc(List<Campuses> campuses, String buildingType);
+    // 캠퍼스와 건물 유형으로 건물 리스트 조회
+    List<Buildings> findByCampusAndBuildingTypeOrderByBuildingNameAsc(Campuses campus, String buildingType);
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/BuildingService.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BuildingService.java
@@ -7,5 +7,5 @@ import JJinBBang.app.domain.user.entity.Users;
 public interface BuildingService {
 	BuildingDetailResponse getBuildingDetail(Long buildingId, Users user);
 
-	DormitoryListResponse getDormitoryList(Long universityId);
+	DormitoryListResponse getDormitoryList(Long campusId);
 }

--- a/src/main/java/JJinBBang/app/domain/building/service/BuildingServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/BuildingServiceImpl.java
@@ -12,14 +12,13 @@ import org.springframework.transaction.annotation.Transactional;
 import JJinBBang.app.domain.building.dto.BuildingDetailResponse;
 import JJinBBang.app.domain.building.dto.KeywordCount;
 import JJinBBang.app.domain.building.entity.Buildings;
+import JJinBBang.app.domain.building.exception.BuildingNotFoundException;
 import JJinBBang.app.domain.building.exception.BuildingNullException;
 import JJinBBang.app.domain.building.repository.BuildingKeywordCountsRepository;
 import JJinBBang.app.domain.building.repository.BuildingsRepository;
 import JJinBBang.app.domain.common.entity.Campuses;
-import JJinBBang.app.domain.common.entity.Universities;
+import JJinBBang.app.domain.common.repository.CampusesRepository;
 import JJinBBang.app.domain.user.entity.Users;
-import JJinBBang.app.domain.user.exception.UniversityNotFoundException;
-import JJinBBang.app.domain.user.repository.UniversityRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -27,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class BuildingServiceImpl implements BuildingService {
 	private final BuildingsRepository buildingsRepository;
 	private final BuildingKeywordCountsRepository buildingKeywordCountRepository;
-	private final UniversityRepository universityRepository;
+	private final CampusesRepository campusesRepository;
 
 	@Override
 	@Transactional(readOnly = true)
@@ -71,14 +70,10 @@ public class BuildingServiceImpl implements BuildingService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public DormitoryListResponse getDormitoryList(Long universityId) {
-		Universities university = universityRepository.findById(universityId).orElseThrow(UniversityNotFoundException::missingUniversity);
-		List<Campuses> campuses = university.getCampuses();
-if (campuses.isEmpty()) {
-			return DormitoryListResponse.of(List.of());
-		}
+	public DormitoryListResponse getDormitoryList(Long campusId) {
+		Campuses campus = campusesRepository.findById(campusId).orElseThrow(BuildingNotFoundException::missingCampus);
 
-		List<Buildings> dormitories = buildingsRepository.findByCampusInAndBuildingTypeOrderByCampus_CampusNameAscBuildingNameAsc(campuses, BuildingType.DORMITORY.name());
+		List<Buildings> dormitories = buildingsRepository.findByCampusAndBuildingTypeOrderByBuildingNameAsc(campus, BuildingType.DORMITORY.name());
 
 		List<DormitoryItem> items = dormitories.stream()
 			.map(building -> DormitoryItem.of(


### PR DESCRIPTION
## 📌 이슈 번호

* #318 

## 💬 리뷰 포인트

* 기숙사 목록 조회가 `universityId` → `campusId` 기준으로 변경
* 캠퍼스 없을 때 예외(`missingCampus`) 처리 

## 🚀 상세 설명

* `GET /dormitory` 요청 파라미터를 `universityId`에서 `campusId`로 변경
* 서비스/레포지토리도 캠퍼스 단건 기준 조회로 수정
* 캠퍼스 미존재 케이스 예외 추가

## 📸 스크린샷

## 📢 노트

* 클라이언트 호출 파라미터도 `campusId`로 수정 필요
