### PR TITLE
[Refactor #320] Request에 address 항목 추가

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/dto/request/EventReview.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/request/EventReview.java
@@ -11,6 +11,9 @@ public record EventReview(
         @NotBlank(message = "재학 중인 대학교를 입력해주세요.")
         String university,
 
+        @NotBlank(message = "주소를 입력해주세요.")
+        String address,
+
         @NotBlank(message = "계약 형태를 입력해주세요.")
         String contractType,  // 계약 형태
 

--- a/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
@@ -121,7 +121,8 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
                     req.review().content(),
                     req.hasAgreedToMarketing(),
                     req.hasAgreedToPrivacy(),
-                    java.time.LocalDateTime.now().format(DATE_TIME_FORMATTER)
+                    java.time.LocalDateTime.now().format(DATE_TIME_FORMATTER),
+                    req.review().address()
             );
 
             appendRowToGoogleSheets(sheet, "review-event", row);


### PR DESCRIPTION
## 📌 이슈 번호
> #320 

## 💬 리뷰 포인트
> 리뷰이벤트에서 원룸 주소 요소가 빠져서 추가하였습니다.

## 🚀 상세 설명
- dto에 address 추가 및 sheets에 저장 시 함께 넘겨주도록 간단한 수정 작업 진행하였습니다.
- application-prod.yml에 sheets column 추가 관련 변경사항 있습니다! (노션 업데이트 완료)

## 📸 스크린샷
<img width="472" height="53" alt="image" src="https://github.com/user-attachments/assets/1b69ac03-5db1-4ad7-afd9-71c51a1e8947" />

## 📢 노트