### PR TITLE
[Feat #316] 대학명 및 캠퍼스명 검색 api 구현

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/repository/CampusesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/building/repository/CampusesRepository.java
@@ -1,9 +1,0 @@
-package JJinBBang.app.domain.building.repository;
-
-import JJinBBang.app.domain.common.entity.Campuses;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository("BuildingCampusesRepository")
-public interface CampusesRepository extends JpaRepository<Campuses, Long> {
-}

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -20,6 +20,7 @@ import JJinBBang.app.domain.building.exception.*;
 import JJinBBang.app.domain.building.repository.*;
 import JJinBBang.app.domain.common.dto.PaginatedResponse;
 import JJinBBang.app.domain.common.entity.Campuses;
+import JJinBBang.app.domain.common.repository.CampusesRepository;
 import JJinBBang.app.domain.common.service.S3Service;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.common.enums.KeywordType;

--- a/src/main/java/JJinBBang/app/domain/common/controller/UniversityController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/UniversityController.java
@@ -1,10 +1,12 @@
 package JJinBBang.app.domain.common.controller;
 
+import JJinBBang.app.domain.common.dto.CampusSearchResponse;
 import JJinBBang.app.domain.common.dto.UniversityResponseDto;
 import JJinBBang.app.domain.common.service.UniversityServiceImpl;
 import JJinBBang.app.global.template.ResTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,6 +33,27 @@ public class UniversityController {
                 HttpStatus.OK,
                 "대학교 리스트 조회 성공",
                 response
+        );
+    }
+
+    @Validated
+    @GetMapping("/search")
+    public ResTemplate<CampusSearchResponse> searchCampuses(
+        @RequestParam
+        String query,
+
+        @RequestParam(defaultValue = "15")
+        int limit,
+
+        @RequestParam(defaultValue = "0")
+        int offset
+    ) {
+        CampusSearchResponse data = universityService.searchCampuses(query, limit, offset);
+
+        return new ResTemplate<>(
+            HttpStatus.OK,
+            "대학교 검색 성공",
+            data
         );
     }
 }

--- a/src/main/java/JJinBBang/app/domain/common/dto/CampusSearchResponse.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/CampusSearchResponse.java
@@ -1,0 +1,53 @@
+package JJinBBang.app.domain.common.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record CampusSearchResponse(
+	List<CampusSearchItem> items,
+	int limit,
+	int offset
+) {
+
+	public static CampusSearchResponse of(
+		List<CampusSearchItem> items,
+		int limit,
+		int offset
+	) {
+		return CampusSearchResponse.builder()
+			.items(items)
+			.limit(limit)
+			.offset(offset)
+			.build();
+	}
+
+	@Builder
+	public record CampusSearchItem (
+		String fullName,
+		String campusAddress,
+		Long campusId,
+		String campusName,
+		Long universityId,
+		String universityName
+	) {
+		public static CampusSearchItem of(
+			String fullName,
+			String campusAddress,
+			Long campusId,
+			String campusName,
+			Long universityId,
+			String universityName
+		) {
+			return CampusSearchItem.builder()
+				.fullName(fullName)
+				.campusAddress(campusAddress)
+				.campusId(campusId)
+				.campusName(campusName)
+				.universityId(universityId)
+				.universityName(universityName)
+				.build();
+		}
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/common/repository/CampusSearchRow.java
+++ b/src/main/java/JJinBBang/app/domain/common/repository/CampusSearchRow.java
@@ -1,0 +1,9 @@
+package JJinBBang.app.domain.common.repository;
+
+public interface CampusSearchRow {
+	Long getCampusId();
+	String getCampusName();
+	String getCampusAddress();
+	Long getUniversityId();
+	String getUniversityName();
+}

--- a/src/main/java/JJinBBang/app/domain/common/repository/CampusesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/common/repository/CampusesRepository.java
@@ -2,6 +2,8 @@ package JJinBBang.app.domain.common.repository;
 
 import JJinBBang.app.domain.common.entity.Campuses;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +11,44 @@ import java.util.List;
 @Repository("CommonCampusesRepository")
 public interface CampusesRepository extends JpaRepository<Campuses, Long> {
     List<Campuses> findByUniversityId(Long universityId);
+
+    @Query(value = """
+        SELECT
+          c.campus_id      AS campusId,
+          c.campus_name    AS campusName,
+          c.campus_address AS campusAddress,
+          u.university_id  AS universityId,
+          u.university_name AS universityName
+        FROM campuses c
+        JOIN universities u ON u.university_id = c.university_id
+        WHERE REPLACE(CONCAT(u.university_name, c.campus_name), ' ', '')
+              LIKE CONCAT('%', :kw, '%')
+        ORDER BY
+          -- 1) 접두사 우선(결합 문자열 기준)
+          CASE
+            WHEN REPLACE(CONCAT(u.university_name, c.campus_name), ' ', '')
+                 LIKE CONCAT(:kw, '%') THEN 0
+            ELSE 1
+          END ASC,
+        
+          -- 2) 키워드가 앞에서 발견될수록
+          LOCATE(
+            :kw,
+            REPLACE(CONCAT(u.university_name, c.campus_name), ' ', '')
+          ) ASC,
+        
+          -- 3) 짧은 것 우선
+          (CHAR_LENGTH(u.university_name) + CHAR_LENGTH(c.campus_name)) ASC,
+        
+          -- 4) 안정 정렬
+          u.university_name ASC,
+          c.campus_name ASC,
+          c.campus_id ASC
+        LIMIT :limit OFFSET :offset;
+        """, nativeQuery = true)
+    List<CampusSearchRow> search(
+        @Param("kw") String kw,
+        @Param("limit") int limit,
+        @Param("offset") int offset
+    );
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/UniversityService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/UniversityService.java
@@ -1,5 +1,6 @@
 package JJinBBang.app.domain.common.service;
 
+import JJinBBang.app.domain.common.dto.CampusSearchResponse;
 import JJinBBang.app.domain.common.dto.UniversityResponseDto;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,4 +11,5 @@ public interface UniversityService {
     @Transactional
     List<UniversityResponseDto> getUniversityList(int offset, int limit);
 
+	CampusSearchResponse searchCampuses(String query, int offset, int limit);
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/UniversityServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/UniversityServiceImpl.java
@@ -1,7 +1,9 @@
 package JJinBBang.app.domain.common.service;
 
+import JJinBBang.app.domain.common.dto.CampusSearchResponse;
 import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.domain.common.dto.UniversityResponseDto;
+import JJinBBang.app.domain.common.repository.CampusesRepository;
 import JJinBBang.app.domain.user.repository.UniversityRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,7 +21,7 @@ import java.util.List;
 public class UniversityServiceImpl implements UniversityService {
 
     private final UniversityRepository universityRepository;
-
+    private final CampusesRepository campusesRepository;
     @Transactional
     @Override
     public List<UniversityResponseDto> getUniversityList(int offset, int limit) {
@@ -30,5 +32,33 @@ public class UniversityServiceImpl implements UniversityService {
         return universityPage.getContent().stream()
                 .map(UniversityResponseDto::of)
                 .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CampusSearchResponse searchCampuses(String query, int limit, int offset) {
+        String kw = query.replaceAll("\\s+", "");
+        limit = Math.min(Math.max(limit, 1), 50);
+        offset = Math.max(offset, 0);
+
+
+        List<CampusSearchResponse.CampusSearchItem> items;
+        if (kw.isEmpty()) {
+            items = List.of();
+        }
+        else {
+            items = campusesRepository.search(kw, limit, offset).stream()
+                .map(r -> CampusSearchResponse.CampusSearchItem.of(
+                    r.getUniversityName() + " " + r.getCampusName(),
+                    r.getCampusAddress(),
+                    r.getCampusId(),
+                    r.getCampusName(),
+                    r.getUniversityId(),
+                    r.getUniversityName()
+                ))
+                .toList();
+        }
+
+        return CampusSearchResponse.of(items, limit, offset);
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호

* #316

## 💬 리뷰 포인트

* 검색 대상이 되는 대학명 캠퍼스명을 하나의 문자열로 붙여서 검색어 구현했습니다.

## 🚀 상세 설명

* 사용자가 입력한 검색어에서 공백을 제거한 뒤 검색에 사용합니다.
  예) `경상국립대 칠암캠퍼스` → `경상국립대칠암캠퍼스`
* DB에서는 **대학명과 캠퍼스명을 이어 붙인 문자열**을 검색 대상으로 삼았습니다.
* 정렬은 아래 우선순위를 적용했습니다.
  1. 접두사 우선: 검색어로 시작하는 결과를 먼저 노출
  2. 키워드 위치 우선: 문자열 안에서 검색어가 더 앞에 있으면 먼저 노출
  3. 짧은 이름 우선: 동일 조건이면 더 짧은 이름 조합을 우선
  4. 마지막은 대학명/캠퍼스명/ID 기준으로 정렬
* `limit/offset` 기반 페이지네이션으로 구현
  * limit은 최소 1, 최대 50으로 고정, 기본값은 15
  * offset은 최소 0으로 고정, 기본값은 0

## 📸 스크린샷

<img width="634" height="728" alt="image" src="https://github.com/user-attachments/assets/bd2df199-cfc2-4587-b56e-59ea4c5ecfca" />
<img width="1147" height="734" alt="image" src="https://github.com/user-attachments/assets/de4a4239-0827-41ab-bd7a-5a11df45c3d6" />

## 📢 노트
