### PR TITLE
[Refactor #322] 위치 기반 대학 조회 기능

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/controller/UniversityController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/UniversityController.java
@@ -1,7 +1,9 @@
 package JJinBBang.app.domain.common.controller;
 
 import JJinBBang.app.domain.common.dto.UniversityResponseDto;
-import JJinBBang.app.domain.common.service.UniversityServiceImpl;
+import JJinBBang.app.domain.common.dto.response.UniversityListResponse;
+import JJinBBang.app.domain.common.service.UniversityService;
+import JJinBBang.app.global.common.dto.UniversityInfo;
 import JJinBBang.app.global.template.ResTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,7 +19,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class UniversityController {
 
-    private final UniversityServiceImpl universityService;
+    private final UniversityService universityService;
 
     @GetMapping
     public ResTemplate<?> getUniversityList(
@@ -32,5 +34,20 @@ public class UniversityController {
                 "대학교 리스트 조회 성공",
                 response
         );
+    }
+
+    @GetMapping("/location")
+    public ResTemplate<UniversityListResponse> getUniversityListByLocation(
+            @RequestParam(required = false) Double lat, // 위도
+            @RequestParam(required = false) Double lng // 경도
+    ) {
+        List<UniversityInfo> universityInfos;
+        if (lat != null && lng != null) {
+            universityInfos = universityService.getUniversityListByLocation(lat, lng);
+        } else {
+            universityInfos = universityService.getUniversityListBasic();
+        }
+        UniversityListResponse res = new UniversityListResponse(universityInfos);
+        return new ResTemplate<>(HttpStatus.OK, "대학교 리스트 조회 성공", res);
     }
 }

--- a/src/main/java/JJinBBang/app/domain/common/dto/response/UniversityListResponse.java
+++ b/src/main/java/JJinBBang/app/domain/common/dto/response/UniversityListResponse.java
@@ -1,0 +1,10 @@
+package JJinBBang.app.domain.common.dto.response;
+
+import JJinBBang.app.global.common.dto.UniversityInfo;
+
+import java.util.List;
+
+public record UniversityListResponse(
+        List<UniversityInfo> universityList
+) {
+}

--- a/src/main/java/JJinBBang/app/domain/common/repository/CampusesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/common/repository/CampusesRepository.java
@@ -14,7 +14,8 @@ public interface CampusesRepository extends JpaRepository<Campuses, Long> {
 
     @Query(value = """
         SELECT
-            c.campus_id AS id,
+            c.campus_id AS campusId,
+            u.university_id AS universityId,
             c.campus_name AS campusName,
             c.campus_address AS campusAddress,
             c.campus_lat AS campusLat,
@@ -26,12 +27,15 @@ public interface CampusesRepository extends JpaRepository<Campuses, Long> {
             sin(radians(:lat)) * sin(radians(c.campus_lat)))) AS distance
         FROM campuses c
         JOIN universities u ON c.university_id = u.university_id
-        ORDER BY distance ASC LIMIT 10""", nativeQuery = true)
+        ORDER BY distance ASC 
+        LIMIT 10
+        """, nativeQuery = true)
     List<Object[]> findNearestCampuses(@Param("lat") double lat, @Param("lng") double lng);
 
     @Query(value = """
         SELECT 
-            c.campus_id AS id,
+            c.campus_id AS campusId,
+            u.university_id AS universityId,
             c.campus_name AS campusName,
             c.campus_address AS campusAddress,
             c.campus_lat AS campusLat,
@@ -48,7 +52,7 @@ public interface CampusesRepository extends JpaRepository<Campuses, Long> {
             FROM campuses sub_c
             WHERE sub_c.university_id = u.university_id
         )
-        GROUP BY c.campus_id, c.campus_name, c.campus_address, c.campus_lat, c.campus_lot, c.image, u.university_name, u.university_logo
+        GROUP BY c.campus_id, u.university_id, c.campus_name, c.campus_address, c.campus_lat, c.campus_lot, c.image, u.university_name, u.university_logo
         ORDER BY userCount DESC
         LIMIT 10
         """, nativeQuery = true)

--- a/src/main/java/JJinBBang/app/domain/common/repository/CampusesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/common/repository/CampusesRepository.java
@@ -10,6 +10,9 @@ import java.util.List;
 
 @Repository("CommonCampusesRepository")
 public interface CampusesRepository extends JpaRepository<Campuses, Long> {
+
+    double EARTH_RADIUS = 6371.0;
+
     List<Campuses> findByUniversityId(Long universityId);
 
     @Query(value = """
@@ -23,14 +26,19 @@ public interface CampusesRepository extends JpaRepository<Campuses, Long> {
             c.image AS image,
             u.university_name AS universityName,
             u.university_logo AS universityLogo,
-            (6371 * acos(cos(radians(:lat)) * cos(radians(c.campus_lat)) * cos(radians(c.campus_lot) - radians(:lng)) +
+            (:earthRadius * acos(cos(radians(:lat)) * cos(radians(c.campus_lat)) * cos(radians(c.campus_lot) - radians(:lng)) +
             sin(radians(:lat)) * sin(radians(c.campus_lat)))) AS distance
         FROM campuses c
         JOIN universities u ON c.university_id = u.university_id
         ORDER BY distance ASC 
-        LIMIT 10
+        LIMIT :limitCount
         """, nativeQuery = true)
-    List<Object[]> findNearestCampuses(@Param("lat") double lat, @Param("lng") double lng);
+    List<Object[]> findNearestCampuses(
+            @Param("lat") double lat,
+            @Param("lng") double lng,
+            @Param("earthRadius") double earthRadius,
+            @Param("limitCount") int limitCount
+    );
 
     @Query(value = """
         SELECT 
@@ -54,7 +62,7 @@ public interface CampusesRepository extends JpaRepository<Campuses, Long> {
         )
         GROUP BY c.campus_id, u.university_id, c.campus_name, c.campus_address, c.campus_lat, c.campus_lot, c.image, u.university_name, u.university_logo
         ORDER BY userCount DESC
-        LIMIT 10
+        LIMIT :limitCount
         """, nativeQuery = true)
-    List<Object[]> findTop10PopularUniversities();
+    List<Object[]> findTopPopularUniversities(@Param("limitCount") int limitCount);
 }

--- a/src/main/java/JJinBBang/app/domain/common/repository/CampusesRepository.java
+++ b/src/main/java/JJinBBang/app/domain/common/repository/CampusesRepository.java
@@ -2,6 +2,8 @@ package JJinBBang.app.domain.common.repository;
 
 import JJinBBang.app.domain.common.entity.Campuses;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +11,46 @@ import java.util.List;
 @Repository("CommonCampusesRepository")
 public interface CampusesRepository extends JpaRepository<Campuses, Long> {
     List<Campuses> findByUniversityId(Long universityId);
+
+    @Query(value = """
+        SELECT
+            c.campus_id AS id,
+            c.campus_name AS campusName,
+            c.campus_address AS campusAddress,
+            c.campus_lat AS campusLat,
+            c.campus_lot AS campusLot,
+            c.image AS image,
+            u.university_name AS universityName,
+            u.university_logo AS universityLogo,
+            (6371 * acos(cos(radians(:lat)) * cos(radians(c.campus_lat)) * cos(radians(c.campus_lot) - radians(:lng)) +
+            sin(radians(:lat)) * sin(radians(c.campus_lat)))) AS distance
+        FROM campuses c
+        JOIN universities u ON c.university_id = u.university_id
+        ORDER BY distance ASC LIMIT 10""", nativeQuery = true)
+    List<Object[]> findNearestCampuses(@Param("lat") double lat, @Param("lng") double lng);
+
+    @Query(value = """
+        SELECT 
+            c.campus_id AS id,
+            c.campus_name AS campusName,
+            c.campus_address AS campusAddress,
+            c.campus_lat AS campusLat,
+            c.campus_lot AS campusLot,
+            c.image AS image,
+            u.university_name AS universityName,
+            u.university_logo AS universityLogo,
+            COUNT(usr.user_id) AS userCount
+        FROM universities u
+        JOIN campuses c ON u.university_id = c.university_id
+        LEFT JOIN users usr ON u.university_id = usr.university_id
+        WHERE c.campus_id = (
+            SELECT MIN(sub_c.campus_id)
+            FROM campuses sub_c
+            WHERE sub_c.university_id = u.university_id
+        )
+        GROUP BY c.campus_id, c.campus_name, c.campus_address, c.campus_lat, c.campus_lot, c.image, u.university_name, u.university_logo
+        ORDER BY userCount DESC
+        LIMIT 10
+        """, nativeQuery = true)
+    List<Object[]> findTop10PopularUniversities();
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/UniversityService.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/UniversityService.java
@@ -1,13 +1,15 @@
 package JJinBBang.app.domain.common.service;
 
 import JJinBBang.app.domain.common.dto.UniversityResponseDto;
-import org.springframework.transaction.annotation.Transactional;
+import JJinBBang.app.global.common.dto.UniversityInfo;
 
 import java.util.List;
 
 public interface UniversityService {
 
-    @Transactional
     List<UniversityResponseDto> getUniversityList(int offset, int limit);
 
+    List<UniversityInfo> getUniversityListByLocation(Double lat, Double lng);
+
+    List<UniversityInfo> getUniversityListBasic();
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/UniversityServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/UniversityServiceImpl.java
@@ -21,6 +21,8 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class UniversityServiceImpl implements UniversityService {
 
+    private static final int SEARCH_LIMIT_COUNT = 10;
+
     private final UniversitiesRepository universitiesRepository;
     private final CampusesRepository campusesRepository;
 
@@ -37,13 +39,15 @@ public class UniversityServiceImpl implements UniversityService {
 
     @Override
     public List<UniversityInfo> getUniversityListByLocation(Double lat, Double lng) {
-        List<Object[]> results = campusesRepository.findNearestCampuses(lat, lng);
+        List<Object[]> results = campusesRepository.findNearestCampuses(
+                lat, lng, CampusesRepository.EARTH_RADIUS, SEARCH_LIMIT_COUNT
+        );
         return results.stream().map(this::mapToDto).toList();
     }
 
     @Override
     public List<UniversityInfo> getUniversityListBasic() {
-        List<Object[]> results = campusesRepository.findTop10PopularUniversities();
+        List<Object[]> results = campusesRepository.findTopPopularUniversities(SEARCH_LIMIT_COUNT);
         return results.stream().map(this::mapToDto).toList();
     }
 

--- a/src/main/java/JJinBBang/app/domain/common/service/UniversityServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/UniversityServiceImpl.java
@@ -1,8 +1,12 @@
 package JJinBBang.app.domain.common.service;
 
+import JJinBBang.app.domain.common.entity.Campuses;
 import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.domain.common.dto.UniversityResponseDto;
-import JJinBBang.app.domain.user.repository.UniversityRepository;
+import JJinBBang.app.domain.common.repository.CampusesRepository;
+import JJinBBang.app.domain.common.repository.UniversitiesRepository;
+import JJinBBang.app.global.common.dto.CampusInfo;
+import JJinBBang.app.global.common.dto.UniversityInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -18,17 +22,52 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class UniversityServiceImpl implements UniversityService {
 
-    private final UniversityRepository universityRepository;
+    private final UniversitiesRepository universitiesRepository;
+    private final CampusesRepository campusesRepository;
 
-    @Transactional
     @Override
     public List<UniversityResponseDto> getUniversityList(int offset, int limit) {
         Pageable pageable = PageRequest.of(offset / limit, limit, Sort.by("id").ascending());
 
-        Page<Universities> universityPage = universityRepository.findAll(pageable);
+        Page<Universities> universityPage = universitiesRepository.findAll(pageable);
 
         return universityPage.getContent().stream()
                 .map(UniversityResponseDto::of)
                 .toList();
+    }
+
+    @Override
+    public List<UniversityInfo> getUniversityListByLocation(Double lat, Double lng) {
+        List<Object[]> results = campusesRepository.findNearestCampuses(lat, lng);
+
+        return results.stream()
+                .map(this::mapToDto)
+                .toList();
+    }
+
+    @Override
+    public List<UniversityInfo> getUniversityListBasic() {
+        List<Object[]> results = campusesRepository.findTop10PopularUniversities();
+
+        return results.stream()
+                .map(this::mapToDto)
+                .toList();
+    }
+
+    private UniversityInfo mapToDto(Object[] row) {
+        Long id = ((Number) row[0]).longValue();
+        String campusName = (String) row[1];
+        String campusAddress = (String) row[2];
+        Double campusLat = ((Number) row[3]).doubleValue();
+        Double campusLot = ((Number) row[4]).doubleValue();
+        String image = (String) row[5];
+        String univName = (String) row[6];
+        String univLogo = (String) row[7];
+
+        CampusInfo campusInfo = new CampusInfo(
+                id, campusName, image, campusAddress, campusLat, campusLot
+        );
+
+        return new UniversityInfo(id, univName, univLogo, campusInfo);
     }
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/UniversityServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/UniversityServiceImpl.java
@@ -1,6 +1,5 @@
 package JJinBBang.app.domain.common.service;
 
-import JJinBBang.app.domain.common.entity.Campuses;
 import JJinBBang.app.domain.common.entity.Universities;
 import JJinBBang.app.domain.common.dto.UniversityResponseDto;
 import JJinBBang.app.domain.common.repository.CampusesRepository;
@@ -39,35 +38,33 @@ public class UniversityServiceImpl implements UniversityService {
     @Override
     public List<UniversityInfo> getUniversityListByLocation(Double lat, Double lng) {
         List<Object[]> results = campusesRepository.findNearestCampuses(lat, lng);
-
-        return results.stream()
-                .map(this::mapToDto)
-                .toList();
+        return results.stream().map(this::mapToDto).toList();
     }
 
     @Override
     public List<UniversityInfo> getUniversityListBasic() {
         List<Object[]> results = campusesRepository.findTop10PopularUniversities();
-
-        return results.stream()
-                .map(this::mapToDto)
-                .toList();
+        return results.stream().map(this::mapToDto).toList();
     }
 
     private UniversityInfo mapToDto(Object[] row) {
-        Long id = ((Number) row[0]).longValue();
-        String campusName = (String) row[1];
-        String campusAddress = (String) row[2];
-        Double campusLat = ((Number) row[3]).doubleValue();
-        Double campusLot = ((Number) row[4]).doubleValue();
-        String image = (String) row[5];
-        String univName = (String) row[6];
-        String univLogo = (String) row[7];
+        Long campusId = ((Number) row[0]).longValue();
+        Long universityId = ((Number) row[1]).longValue();
+
+        String campusName = (String) row[2];
+        String campusAddress = (String) row[3];
+        Double campusLat = ((Number) row[4]).doubleValue();
+        Double campusLot = ((Number) row[5]).doubleValue();
+        String image = (String) row[6];
+        String univName = (String) row[7];
+        String univLogo = (String) row[8];
 
         CampusInfo campusInfo = new CampusInfo(
-                id, campusName, image, campusAddress, campusLat, campusLot
+                campusId, campusName, image, campusAddress, campusLat, campusLot
         );
 
-        return new UniversityInfo(id, univName, univLogo, campusInfo);
+        return new UniversityInfo(
+                universityId, univName, univLogo, campusInfo
+        );
     }
 }

--- a/src/main/java/JJinBBang/app/global/common/dto/CampusInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/CampusInfo.java
@@ -1,0 +1,11 @@
+package JJinBBang.app.global.common.dto;
+
+public record CampusInfo(
+        Long id,
+        String campusName,
+        String logoImageUrl,
+        String campusAddress,
+        Double latitude,
+        Double longitude
+) {
+}

--- a/src/main/java/JJinBBang/app/global/common/dto/UniversityInfo.java
+++ b/src/main/java/JJinBBang/app/global/common/dto/UniversityInfo.java
@@ -1,0 +1,9 @@
+package JJinBBang.app.global.common.dto;
+
+public record UniversityInfo(
+        Long id,
+        String universityName,
+        String logoImageUrl,
+        CampusInfo campusInfo
+) {
+}


### PR DESCRIPTION
## 📌 이슈 번호
> #322 

## 💬 리뷰 포인트
> 해당 PR의 핵심 포인트만 간략히 요약해주세요

- 기존의 대학 조회 API를 대학 확장을 하게 되면서 여러 대학을 조회해야 하는 상황이 발생하여 기능 업데이트 진행하였습니다.

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

- 사용자 위경도를 받도록 하였고, 위치 권한을 허용하지 않는 경우를 고려하여 Nullable로 두었습니다.
- 권한 허용 O
  - 10개의 대학만 추가되기 때문에 테이블 전체에 접근해서 최단거리 조회를 할 수 있도록 하였습니다.
  - 우선 대학 확장을 위해서는 급하게 필요하다고 판단하여 현재는 다음과 같이 진행하였고, 배포 즉시 최적화 진행하겠습니다.
- 권한 허용 X
  - 허용하지 않는 경우 사용자 수가 가장 많은 대학의 대표 캠퍼스(현재는 가장 낮은 수의 ID를 가진 캠퍼스로 설정) 최대 10개를 불러올 수 있도록 하였습니다.
  - 마찬가지로 배포 즉시 최적화 진행하겠습니다.

## 📸 스크린샷
<img width="694" height="726" alt="image" src="https://github.com/user-attachments/assets/9a0f9562-bc1f-466d-86ac-60ba76445e32" />

기존 응답 포맷과 다르며 기존 API는 임시로 두었다가 프론트엔드쪽에서 연결되면 제거하도록 하겠습니다.

## 📢 노트