### PR TITLE
[BUG] CI 빌드 실패 - searchCampuses() 괄호 문제 해결

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/controller/UniversityController.java
+++ b/src/main/java/JJinBBang/app/domain/common/controller/UniversityController.java
@@ -51,6 +51,7 @@ public class UniversityController {
         }
         UniversityListResponse res = new UniversityListResponse(universityInfos);
         return new ResTemplate<>(HttpStatus.OK, "대학교 리스트 조회 성공", res);
+    }
       
     @Validated
     @GetMapping("/search")


### PR DESCRIPTION
## 📌 이슈 번호
#330 

## 💬 리뷰 포인트
- CI 빌드 실패 원인이 getUniversityListByLocation() 메서드의 } 누락으로 인한 파싱 오류인지 확인
- 로컬 IDE에서는 자동 보정되거나 빌드 통과하지만 CI 빌드 환경에서는 strict parsing으로 실패한 점 재확인

## 🚀 상세 설명
CI에서 Gradle 빌드 실행 시 다음과 같은 Java 컴파일 오류가 발생함:
```
';' expected
<identifier> expected
illegal start of expression
reached end of file while parsing
```

해당 오류는 searchCampuses() 메서드 파라미터/어노테이션 구성 문제가 아니라, 상위 메서드(getUniversityListByLocation)의 마지막 }가 누락되며 발생한 파싱 오류로 확인

이를 해결하기 위해 getUniversityListByLocation()의 누락된 } 블록을 추가하여 자바 컴파일이 정상적으로 종료되도록 수정 완려

## 📸 스크린샷

## 📢 노트