### PR TITLE
:bug: [FIX #333]: 건물 요청 검증 로직 서비스에서 처리

### DIFF
--- a/src/main/java/JJinBBang/app/domain/building/dto/BuildingRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/BuildingRequest.java
@@ -5,23 +5,15 @@ import JJinBBang.app.domain.building.entity.Agencies;
 import JJinBBang.app.domain.building.entity.Buildings;
 import JJinBBang.app.domain.building.enums.BuildingType;
 import JJinBBang.app.domain.common.entity.Campuses;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record BuildingRequest (
-    @NotBlank
     String buildingCode,
-    @NotBlank
     String name,
-    @NotNull
     BuildingType type,
-    @NotBlank
     String address,
-    @NotNull
     Double latitude,
-    @NotNull
     Double longitude
 ){
 	public BuildingRequest updateBuildingCode(String buildingCode) {

--- a/src/main/java/JJinBBang/app/domain/building/dto/ReviewRequest.java
+++ b/src/main/java/JJinBBang/app/domain/building/dto/ReviewRequest.java
@@ -29,7 +29,6 @@ public record ReviewRequest (
 	@NotNull
 	List<@NotBlank String> imageUrls,
 
-	@Valid
 	BuildingRequest buildingRequest,
 
 	@Valid
@@ -45,17 +44,6 @@ public record ReviewRequest (
 	private boolean isDormitoryDetailsProvided() {
 		if (dormitoryReview != null) {
 			return facilities  != null;
-		}
-		return true;
-	}
-
-	@AssertTrue(message = "리뷰 타입에 맞는 건물 유형을 선택해야 합니다")
-	private boolean isProperBuildingType() {
-		if (agencyReview != null) {
-			return buildingRequest.type() == BuildingType.AGENCY;
-		}
-		if (generalReview != null) {
-			return (buildingRequest.type() != BuildingType.AGENCY && buildingRequest.type() != BuildingType.DORMITORY);
 		}
 		return true;
 	}

--- a/src/main/java/JJinBBang/app/domain/building/exception/BuildingInvalidException.java
+++ b/src/main/java/JJinBBang/app/domain/building/exception/BuildingInvalidException.java
@@ -1,0 +1,47 @@
+package JJinBBang.app.domain.building.exception;
+
+import JJinBBang.app.global.error.exception.InvalidGroupException;
+
+public class BuildingInvalidException extends InvalidGroupException {
+	public BuildingInvalidException(String message) {
+		super(message);
+	}
+
+	// 공통
+	public static BuildingInvalidException requiredBuildingRequest() {
+		return new BuildingInvalidException("buildingRequest는 필수입니다.");
+	}
+
+	public static BuildingInvalidException requiredBuildingCode() {
+		return new BuildingInvalidException("buildingCode는 필수입니다.");
+	}
+
+	public static BuildingInvalidException requiredName() {
+		return new BuildingInvalidException("name은 필수입니다.");
+	}
+
+	public static BuildingInvalidException requiredAddress() {
+		return new BuildingInvalidException("address는 필수입니다.");
+	}
+
+	public static BuildingInvalidException requiredType() {
+		return new BuildingInvalidException("type은 필수입니다.");
+	}
+
+	public static BuildingInvalidException requiredLatitude() {
+		return new BuildingInvalidException("latitude는 필수입니다.");
+	}
+
+	public static BuildingInvalidException requiredLongitude() {
+		return new BuildingInvalidException("longitude는 필수입니다.");
+	}
+
+	// 타입 규칙
+	public static BuildingInvalidException agencyMustBeAgencyType() {
+		return new BuildingInvalidException("AGENCY 리뷰는 건물 유형이 AGENCY여야 합니다.");
+	}
+
+	public static BuildingInvalidException generalCannotBeAgencyOrDormitory() {
+		return new BuildingInvalidException("GENERAL 리뷰는 AGENCY/DORMITORY 유형을 선택할 수 없습니다.");
+	}
+}

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -41,7 +41,6 @@ public class ReviewServiceImpl implements ReviewService {
 	private final DormitoryFacilitiesRepository dormitoryFacilitiesRepository;
 	private final BuildingKeywordCountsRepository buildingKeywordCountsRepository;
 	private final S3Service s3Service;
-	private final BuildingCodeResolver buildingCodeResolver;
 
 	/**
      * 특정 건물 또는 공인중개사에 대한 리뷰 목록을 페이징 조회
@@ -125,16 +124,13 @@ public class ReviewServiceImpl implements ReviewService {
                 .orElseThrow(ReviewInternalServerErrorException::missingReviewDetailException);
 
         // 4) 리뷰 타입에 따라 적절한 DTO로 변환
-        if (review instanceof GeneralReviews general) {
-            return ReviewDetailResponse.ofGeneral(general, detail, liked);
-        } else if (review instanceof DormReviews dorm) {
-            return ReviewDetailResponse.ofDormitory(dorm, detail, liked);
-        } else if (review instanceof AgencyReviews agency) {
-            return ReviewDetailResponse.ofAgency(agency, detail, liked);
-        } else {
-            // 지원하지 않는 타입이면 서버 오류
-            throw ReviewInternalServerErrorException.notSupportReviewType();
-        }
+		// 지원하지 않는 타입이면 서버 오류
+		return switch (review) {
+			case GeneralReviews general -> ReviewDetailResponse.ofGeneral(general, detail, liked);
+			case DormReviews dorm -> ReviewDetailResponse.ofDormitory(dorm, detail, liked);
+			case AgencyReviews agency -> ReviewDetailResponse.ofAgency(agency, detail, liked);
+			default -> throw ReviewInternalServerErrorException.notSupportReviewType();
+		};
     }
 
     /**
@@ -258,19 +254,6 @@ public class ReviewServiceImpl implements ReviewService {
 
         return saved.getId();
     }
-
-	private Buildings findOrCreateDormitory(BuildingRequest buildingRequest, Campuses campus) {
-		// 카카오 장소 ID를 건물관리번호로 변환
-		String resolvedCode = buildingCodeResolver.resolve(
-			buildingRequest.longitude(),
-			buildingRequest.latitude(),
-			buildingRequest.buildingCode()
-		);
-
-		BuildingRequest updatedRequest = buildingRequest.updateBuildingCode(resolvedCode);
-
-		return findOrCreateBuilding(updatedRequest, campus);
-	}
 
 	private Buildings findAndValidateDormitoryById(Long dormitoryId) {
 		Buildings building = buildingsRepository.findById(dormitoryId)
@@ -437,16 +420,17 @@ public class ReviewServiceImpl implements ReviewService {
 		}
 
 		// 3) 리뷰 타입별 분기 처리
-		if (review instanceof GeneralReviews general) {
-			validateBuilding(dto);
-			updateGeneralReview(general, dto);
-		} else if (review instanceof DormReviews dorm) {
-			updateDormitoryReview(dorm, dto);
-		} else if (review instanceof AgencyReviews agency) {
-			validateBuilding(dto);
-			updateAgencyReview(agency, dto);
-		} else {
-			throw ReviewNotFoundException.missingReviewType();
+		switch (review) {
+			case GeneralReviews general -> {
+				validateBuilding(dto);
+				updateGeneralReview(general, dto);
+			}
+			case DormReviews dorm -> updateDormitoryReview(dorm, dto);
+			case AgencyReviews agency -> {
+				validateBuilding(dto);
+				updateAgencyReview(agency, dto);
+			}
+			default -> throw ReviewNotFoundException.missingReviewType();
 		}
 	}
 
@@ -679,15 +663,12 @@ public class ReviewServiceImpl implements ReviewService {
         }
 
         // 3) 타입별 삭제 로직 분기
-        if (review instanceof GeneralReviews general) {
-            deleteGeneralReview(general);
-        } else if (review instanceof DormReviews dorm) {
-            deleteDormitoryReview(dorm);
-        } else if (review instanceof AgencyReviews agency) {
-            deleteAgencyReview(agency);
-        } else {
-            throw ReviewInternalServerErrorException.notSupportReviewType();
-        }
+		switch (review) {
+			case GeneralReviews general -> deleteGeneralReview(general);
+			case DormReviews dorm -> deleteDormitoryReview(dorm);
+			case AgencyReviews agency -> deleteAgencyReview(agency);
+			default -> throw ReviewInternalServerErrorException.notSupportReviewType();
+		}
     }
 
     /**
@@ -859,12 +840,8 @@ public class ReviewServiceImpl implements ReviewService {
 	}
 
 	private void validateBuilding(ReviewRequest dto) {
-		// DORM이면 호출 자체를 안 하도록(현재 구조) 이미 처리했으면 이 블록은 없어도 됨
-		if (dto.dormitoryReview() != null) return;
-
 		boolean isGeneral = dto.generalReview() != null;
 		boolean isAgency  = dto.agencyReview() != null;
-		if (!isGeneral && !isAgency) return;
 
 		BuildingRequest br = dto.buildingRequest();
 		if (br == null) throw BuildingInvalidException.requiredBuildingRequest();

--- a/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/building/service/ReviewServiceImpl.java
@@ -18,7 +18,6 @@ import JJinBBang.app.domain.building.exception.*;
 import JJinBBang.app.domain.building.repository.*;
 import JJinBBang.app.domain.common.dto.PaginatedResponse;
 import JJinBBang.app.domain.common.entity.Campuses;
-import JJinBBang.app.domain.common.repository.CampusesRepository;
 import JJinBBang.app.domain.common.service.S3Service;
 import JJinBBang.app.domain.user.entity.Users;
 import JJinBBang.app.global.common.enums.KeywordType;
@@ -155,10 +154,12 @@ public class ReviewServiceImpl implements ReviewService {
     ) {
         // 리뷰 타입에 따라 분기 처리
         if (reviewType == ReviewType.GENERAL) {
-            return CreateReviewResponse.from(createGeneralReview(reviewRequest, user));
+			validateBuilding(reviewRequest);
+			return CreateReviewResponse.from(createGeneralReview(reviewRequest, user));
         } else if (reviewType == ReviewType.DORM) {
             return CreateReviewResponse.from(createDormitoryReview(reviewRequest, user));
         } else if (reviewType == ReviewType.AGENCY) {
+			validateBuilding(reviewRequest);
             return CreateReviewResponse.from(createAgencyReview(reviewRequest, user));
         } else {
             // 미지원 타입 예외
@@ -437,10 +438,12 @@ public class ReviewServiceImpl implements ReviewService {
 
 		// 3) 리뷰 타입별 분기 처리
 		if (review instanceof GeneralReviews general) {
+			validateBuilding(dto);
 			updateGeneralReview(general, dto);
 		} else if (review instanceof DormReviews dorm) {
 			updateDormitoryReview(dorm, dto);
 		} else if (review instanceof AgencyReviews agency) {
+			validateBuilding(dto);
 			updateAgencyReview(agency, dto);
 		} else {
 			throw ReviewNotFoundException.missingReviewType();
@@ -854,4 +857,36 @@ public class ReviewServiceImpl implements ReviewService {
 		imagesToDelete.removeAll(safeNew);
 		imagesToDelete.forEach(s3Service::deleteFile);
 	}
+
+	private void validateBuilding(ReviewRequest dto) {
+		// DORM이면 호출 자체를 안 하도록(현재 구조) 이미 처리했으면 이 블록은 없어도 됨
+		if (dto.dormitoryReview() != null) return;
+
+		boolean isGeneral = dto.generalReview() != null;
+		boolean isAgency  = dto.agencyReview() != null;
+		if (!isGeneral && !isAgency) return;
+
+		BuildingRequest br = dto.buildingRequest();
+		if (br == null) throw BuildingInvalidException.requiredBuildingRequest();
+
+		if (br.buildingCode() == null || br.buildingCode().isBlank())
+			throw BuildingInvalidException.requiredBuildingCode();
+		if (br.name() == null || br.name().isBlank())
+			throw BuildingInvalidException.requiredName();
+		if (br.address() == null || br.address().isBlank())
+			throw BuildingInvalidException.requiredAddress();
+		if (br.type() == null)
+			throw BuildingInvalidException.requiredType();
+		if (br.latitude() == null)
+			throw BuildingInvalidException.requiredLatitude();
+		if (br.longitude() == null)
+			throw BuildingInvalidException.requiredLongitude();
+
+		if (isAgency && br.type() != BuildingType.AGENCY)
+			throw BuildingInvalidException.agencyMustBeAgencyType();
+
+		if (isGeneral && (br.type() == BuildingType.AGENCY || br.type() == BuildingType.DORMITORY))
+			throw BuildingInvalidException.generalCannotBeAgencyOrDormitory();
+	}
+
 }


### PR DESCRIPTION
## 📌 이슈 번호
* #333

## 💬 리뷰 포인트
* `buildingRequest` 검증을 Bean Validation이 아니라 `ReviewServiceImpl.validateBuilding()`에서 처리하도록 변경됨
* GENERAL/AGENCY만 검증하고 DORM은 `buildingRequest` 무시
* `BuildingInvalidException` 정적 팩토리 메시지 사용

## 🚀 상세 설명
* `BuildingRequest`의 `@NotBlank/@NotNull` 등 검증 어노테이션 제거
* 서비스 레벨에서 `validateBuilding()`로 `buildingRequest` 필수/필드값/타입 규칙(AGENCY, GENERAL) 검증 추가
* 검증 실패 시 `BuildingInvalidException` 정적 메서드로 예외 통일

## 📸 스크린샷
<img width="1152" height="730" alt="image" src="https://github.com/user-attachments/assets/76d5ec34-4bc9-4d92-a429-5418b48d2f5c" />
<img width="1147" height="700" alt="image" src="https://github.com/user-attachments/assets/d188615e-9599-4ad7-98aa-2c4af2ea9ee9" />


## 📢 노트
