### PR TITLE
[Feat #324] Slack 관련 기능 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,9 @@ dependencies {
 
 	// Swagger (SpringDoc OpenAPI)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+
+	// Slack
+	implementation "com.slack.api:slack-api-client:1.47.0"
 }
 
 // Q 클래스 경로 지정

--- a/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
@@ -104,10 +104,12 @@ public class UsersController {
 
 		slackService.sendOpinionMessage(
 				userId,
-				"\n" +
-						userOpinionRequest.opinion() +
-						"\n\n대상: " + userOpinionRequest.targetId() +
-						"\n유형: " + userOpinionRequest.opinionType()
+				String.format(
+						"\n%s\n\n대상: %s\n유형: %s",
+						userOpinionRequest.opinion(),
+						userOpinionRequest.targetId(),
+						userOpinionRequest.opinionType()
+				)
 		);
 
 		return new ResTemplate<>(HttpStatus.OK, "문의 성공", null);

--- a/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/UsersController.java
@@ -8,6 +8,7 @@ import JJinBBang.app.domain.user.exception.InvalidTokenException;
 import JJinBBang.app.global.sheets.dto.UnregisterReasonDto;
 import JJinBBang.app.global.sheets.dto.UserOpinionDto;
 import JJinBBang.app.global.sheets.service.GoogleSheetsService;
+import JJinBBang.app.global.slack.service.SlackService;
 import JJinBBang.app.global.template.ResTemplate;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,7 @@ public class UsersController {
 
 	private final UsersService usersService;
 	private final GoogleSheetsService googleSheetsService;
+	private final SlackService slackService;
 
 	@GetMapping
 	public ResTemplate<UserInfoResponseDto> getUserInfo(@AuthenticationPrincipal Users user) {
@@ -99,6 +101,14 @@ public class UsersController {
 		);
 
 		googleSheetsService.appendUserOpinion(data, userOpinionRequest.opinionType());
+
+		slackService.sendOpinionMessage(
+				userId,
+				"\n" +
+						userOpinionRequest.opinion() +
+						"\n\n대상: " + userOpinionRequest.targetId() +
+						"\n유형: " + userOpinionRequest.opinionType()
+		);
 
 		return new ResTemplate<>(HttpStatus.OK, "문의 성공", null);
 	}

--- a/src/main/java/JJinBBang/app/global/common/enums/VerificationStatus.java
+++ b/src/main/java/JJinBBang/app/global/common/enums/VerificationStatus.java
@@ -6,7 +6,8 @@ public enum VerificationStatus {
 	ENROLL_STUDENT_VERIFIED("인증완료"), // 재학증명서 인증
 	EMAIL_VERIFIED("인증완료"), // 학교 웹메일 인증
 	PENDING("인증대기"), // 인증대기
-	UNVERIFIED("미인증"); // 미인증
+	UNVERIFIED("미인증"), // 미인증
+	REJECTED("반려"); // 반려
 
 	private final String status;
 

--- a/src/main/java/JJinBBang/app/global/config/SlackConfig.java
+++ b/src/main/java/JJinBBang/app/global/config/SlackConfig.java
@@ -3,17 +3,15 @@ package JJinBBang.app.global.config;
 import JJinBBang.app.global.slack.properties.SlackProperties;
 import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class SlackConfig {
 
     private final SlackProperties slackProperties;
-
-    public SlackConfig(SlackProperties slackProperties) {
-        this.slackProperties = slackProperties;
-    }
 
     @Bean
     public MethodsClient methodsClient() {

--- a/src/main/java/JJinBBang/app/global/config/SlackConfig.java
+++ b/src/main/java/JJinBBang/app/global/config/SlackConfig.java
@@ -1,0 +1,22 @@
+package JJinBBang.app.global.config;
+
+import JJinBBang.app.global.slack.properties.SlackProperties;
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SlackConfig {
+
+    private final SlackProperties slackProperties;
+
+    public SlackConfig(SlackProperties slackProperties) {
+        this.slackProperties = slackProperties;
+    }
+
+    @Bean
+    public MethodsClient methodsClient() {
+        return Slack.getInstance().methods(slackProperties.getBotToken());
+    }
+}

--- a/src/main/java/JJinBBang/app/global/security/exception/SecurityAccessDeniedException.java
+++ b/src/main/java/JJinBBang/app/global/security/exception/SecurityAccessDeniedException.java
@@ -36,6 +36,10 @@ public class SecurityAccessDeniedException extends AccessDeniedException {
         return new SecurityAccessDeniedException("미인증 상태여야 합니다.");
     }
 
+    public static SecurityAccessDeniedException rejectedStatusRequired() {
+        return new SecurityAccessDeniedException("반려 상태여야 합니다.");
+    }
+
     public static SecurityAccessDeniedException existPendingUnivVerifyRequest() {
         return new SecurityAccessDeniedException("대기 중인 학교 인증 요청이 존재합니다.");
     }

--- a/src/main/java/JJinBBang/app/global/security/filter/VerificationStatusFilter.java
+++ b/src/main/java/JJinBBang/app/global/security/filter/VerificationStatusFilter.java
@@ -94,6 +94,10 @@ public class VerificationStatusFilter extends OncePerRequestFilter {
                 // 미인증 상태여야만 하는 경우
                 return SecurityAccessDeniedException.unverifiedStatusRequired();
             }
+            case REJECTED -> {
+                // 반려되지 않은 경우
+                return SecurityAccessDeniedException.rejectedStatusRequired();
+            }
             default -> {
                 return SecurityAccessDeniedException.wrongAccess();
             }
@@ -105,6 +109,10 @@ public class VerificationStatusFilter extends OncePerRequestFilter {
             return userStatus.equals(VerificationStatus.EMAIL_VERIFIED) ||
                 userStatus.equals(VerificationStatus.ENROLL_STUDENT_VERIFIED) ||
                 userStatus.equals(VerificationStatus.NEW_STUDENT_VERIFIED);
+        }
+        if (requiredStatus.equals(VerificationStatus.UNVERIFIED)) {
+            return userStatus.equals(VerificationStatus.UNVERIFIED) ||
+                    userStatus.equals(VerificationStatus.REJECTED);
         }
         return userStatus.equals(requiredStatus);
     }

--- a/src/main/java/JJinBBang/app/global/slack/enums/SlackNotificationType.java
+++ b/src/main/java/JJinBBang/app/global/slack/enums/SlackNotificationType.java
@@ -1,0 +1,16 @@
+package JJinBBang.app.global.slack.enums;
+
+public enum SlackNotificationType {
+    OPINION("[문의 및 신고가 접수되었습니다. - ID: %s] \n%s"),
+    CERTIFICATE("[재학생 인증 요청 - ID: %s] \n관리자 확인이 필요합니다.\n\n📄 <%s|합격증명서 확인하기>");
+
+    private final String template;
+
+    SlackNotificationType(String template) {
+        this.template = template;
+    }
+
+    public String format(Object... args) {
+        return String.format(template, args);
+    }
+}

--- a/src/main/java/JJinBBang/app/global/slack/properties/SlackProperties.java
+++ b/src/main/java/JJinBBang/app/global/slack/properties/SlackProperties.java
@@ -6,10 +6,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
 @Getter
+@Setter
 @Component
 @ConfigurationProperties(prefix = "slack")
 public class SlackProperties {
 
+    private String botToken;
     private Webhook webhook = new Webhook();
     private Security security = new Security();
 

--- a/src/main/java/JJinBBang/app/global/slack/properties/SlackProperties.java
+++ b/src/main/java/JJinBBang/app/global/slack/properties/SlackProperties.java
@@ -16,7 +16,8 @@ public class SlackProperties {
     @Getter
     @Setter
     public static class Webhook {
-        private String url;
+        private String verifyUrl;
+        private String opinionUrl;
     }
 
     @Getter

--- a/src/main/java/JJinBBang/app/global/slack/service/SlackService.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/SlackService.java
@@ -8,4 +8,6 @@ public interface SlackService {
     void sendVerifyMessage(Long userId, String fileLink, boolean needsInput);
 
     String handleInteractivity(String payload) throws JsonProcessingException;
+
+    void sendOpinionMessage(Long userId, String opinion);
 }

--- a/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
@@ -169,7 +169,7 @@ public class SlackServiceImpl implements SlackService {
             // CASE 3. 수동 반려
             certificateService.updateVerificationStatusByCertificate(
                     userId,
-                    String.valueOf(VerificationStatus.UNVERIFIED),
+                    String.valueOf(VerificationStatus.REJECTED),
                     null,
                     null
             );

--- a/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
@@ -13,6 +13,8 @@ import JJinBBang.app.global.slack.service.SlackService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
@@ -36,6 +38,7 @@ public class SlackServiceImpl implements SlackService {
     private final CertificateService certificateService;
     private final UniversitiesRepository universitiesRepository;
     private final UsersRepository usersRepository;
+    private final MethodsClient methodsClient;
 
     private static final String INPUT_BLOCK_ID = "input_university_block";
     private static final String ACTION_ID_INPUT = "university_name";
@@ -103,14 +106,22 @@ public class SlackServiceImpl implements SlackService {
         // 1) Slack이 보낸 JSON 파싱
         JsonNode root = objectMapper.readTree(payload);
 
+        String channelId = root.path("channel").path("id").asText();
+        String threadTs = root.path("message").path("ts").asText();
+
         // 2) 사용자 정보, action 추출
         JsonNode actionsNode = root.path("actions").get(0);
         String actionId = actionsNode.path("action_id").asText();
         String value = actionsNode.path("value").asText();
         Long userId = Long.parseLong(value);
 
+        JsonNode userNode = root.path("user");
+        String adminId = userNode.path("id").asText();
+        String adminTag = "<@" + adminId + ">";
+
         String message = "";
 
+        // 3) 수동 인증 로직
         if (ACTION_ID_APPROVE_WITH_INPUT.equals(actionId)) {
             // CASE 1. 대학교 이름 수동 입력 승인
             String inputUnivName = root.path("state")
@@ -141,7 +152,7 @@ public class SlackServiceImpl implements SlackService {
             );
 
             log.info("관리자 수동 입력 승인: User - {} / University - {}", userId, inputUnivName);
-            message = "✅ 관리자에 의해 승인 처리되었습니다.";
+            message = "✅ 관리자(" + adminTag +")에 의해 승인 처리되었습니다.";
 
         } else if (ACTION_ID_APPROVE.equals(actionId)) {
             // CASE 2. 수동 승인
@@ -152,7 +163,7 @@ public class SlackServiceImpl implements SlackService {
                     null
             );
 
-            message = "✅ 관리자에 의해 승인 처리되었습니다.";
+            message = "✅ 관리자(" + adminTag + ")에 의해 승인 처리되었습니다.";
             log.info("Slack에서 승인 처리 완료: userId - {}", userId);
         } else if (ACTION_ID_REJECT.equals(actionId)) {
             // CASE 3. 수동 반려
@@ -166,7 +177,10 @@ public class SlackServiceImpl implements SlackService {
             log.info("Slack에서 반려 처리 완료: userId - {}", userId);
         }
 
-        return createResponse(true, message);    }
+        // 승인 및 반려 시 스레드 메시지 전송
+        postThreadMessage(channelId, threadTs, message);
+        return createResponse(true, message);
+    }
 
     // 텍스트 섹션 생성하기
     private Map<String, Object> createTextBlock(String content) {
@@ -239,6 +253,22 @@ public class SlackServiceImpl implements SlackService {
         } catch (JsonProcessingException e) {
             log.error("Slack 응답 JSON 생성 실패", e);
             return String.format("{\"replace_original\": \"%b\", \"text\": \"Error processing response\"}", replaceOriginal);
+        }
+    }
+
+    // Slack Thread 메시지 전송
+    public void postThreadMessage(String channelId, String threadTs, String message) {
+        try {
+            ChatPostMessageRequest request = ChatPostMessageRequest.builder()
+                    .channel(channelId)
+                    .threadTs(threadTs)
+                    .text(message)
+                    .build();
+
+            methodsClient.chatPostMessage(request);
+            log.info("Slack 스레드 메시지 전송 완료: {}", threadTs);
+        } catch (Exception e) {
+            log.error("Slack 스레드 메시지 전송 중 오류 발생: {}", e.getMessage());
         }
     }
 

--- a/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.IOException;
 import java.util.*;
 
 @Service
@@ -173,7 +175,7 @@ public class SlackServiceImpl implements SlackService {
                     null,
                     null
             );
-            message = "❌ 관리자에 의해 반려 처리되었습니다.";
+            message = "❌ 관리자에(" + adminTag + ")에 의해 반려 처리되었습니다.";
             log.info("Slack에서 반려 처리 완료: userId - {}", userId);
         }
 
@@ -195,7 +197,7 @@ public class SlackServiceImpl implements SlackService {
         return section;
     }
 
-    public Map<String, Object> createTextBlockByTypes(SlackNotificationType type, Long userId, String data) {
+    private Map<String, Object> createTextBlockByTypes(SlackNotificationType type, Long userId, String data) {
         String formattedMessage = type.format(userId, data);
         return createTextBlock(formattedMessage);
     }
@@ -257,7 +259,7 @@ public class SlackServiceImpl implements SlackService {
     }
 
     // Slack Thread 메시지 전송
-    public void postThreadMessage(String channelId, String threadTs, String message) {
+    private void postThreadMessage(String channelId, String threadTs, String message) {
         try {
             ChatPostMessageRequest request = ChatPostMessageRequest.builder()
                     .channel(channelId)
@@ -267,8 +269,8 @@ public class SlackServiceImpl implements SlackService {
 
             methodsClient.chatPostMessage(request);
             log.info("Slack 스레드 메시지 전송 완료: {}", threadTs);
-        } catch (Exception e) {
-            log.error("Slack 스레드 메시지 전송 중 오류 발생: {}", e.getMessage());
+        } catch (IOException | SlackApiException e) {
+            log.error("Slack 스레드 메시지 전송 중 오류 발생: thread_ts={}", threadTs, e);
         }
     }
 

--- a/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/impl/SlackServiceImpl.java
@@ -7,6 +7,7 @@ import JJinBBang.app.domain.user.exception.UserNotFoundException;
 import JJinBBang.app.domain.user.repository.UsersRepository;
 import JJinBBang.app.domain.user.service.CertificateService;
 import JJinBBang.app.global.common.enums.VerificationStatus;
+import JJinBBang.app.global.slack.enums.SlackNotificationType;
 import JJinBBang.app.global.slack.properties.SlackProperties;
 import JJinBBang.app.global.slack.service.SlackService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -51,7 +52,7 @@ public class SlackServiceImpl implements SlackService {
      */
     @Override
     public void sendVerifyMessage(Long userId, String fileLink, boolean needsInput) {
-        String webhookUrl = slackProperties.getWebhook().getUrl();
+        String webhookUrl = slackProperties.getWebhook().getVerifyUrl();
 
         // 1) 전체 메시지 Payload 생성
         Map<String, Object> payload = new HashMap<>();
@@ -62,13 +63,13 @@ public class SlackServiceImpl implements SlackService {
         if (needsInput) {
             // CASE 1. 재학중인 대학교 추출에 실패한 경우
             payload.put("text", "새로 업로드 된 합격증명서 검증이 필요합니다! (대학교 수동 입력 필요)");
-            blocks.add(createTextBlock(userId, fileLink));
+            blocks.add(createTextBlockByTypes(SlackNotificationType.CERTIFICATE, userId, fileLink));
             blocks.add(createInputBlock());
             blocks.add(createActionBlock(userId, ACTION_ID_APPROVE_WITH_INPUT));
         } else {
             // CASE 2. 재학중인 대학교 추출에 성공한 경우 (다른 검증 과정에서 오류가 발생한 경우)
             payload.put("text", "새로 업로드 된 합격증명서 검증이 필요합니다!");
-            blocks.add(createTextBlock(userId, fileLink));
+            blocks.add(createTextBlockByTypes(SlackNotificationType.CERTIFICATE, userId, fileLink));
             blocks.add(createActionBlock(userId, ACTION_ID_APPROVE));
         }
 
@@ -168,17 +169,21 @@ public class SlackServiceImpl implements SlackService {
         return createResponse(true, message);    }
 
     // 텍스트 섹션 생성하기
-    private Map<String, Object> createTextBlock(Long userId, String fileLink) {
-        Map<String, Object> section = new HashMap<>();
-        section.put("type", "section");
-
+    private Map<String, Object> createTextBlock(String content) {
         Map<String, Object> text = new HashMap<>();
         text.put("type", "mrkdwn");
-        text.put("text", String.format("[재학생 인증 요청 - ID: %s] \n관리자 확인이 필요합니다.\n\n📄 <%s|합격증명서 확인하기>", userId, fileLink));
+        text.put("text", content);
 
+        Map<String, Object> section = new HashMap<>();
+        section.put("type", "section");
         section.put("text", text);
 
         return section;
+    }
+
+    public Map<String, Object> createTextBlockByTypes(SlackNotificationType type, Long userId, String data) {
+        String formattedMessage = type.format(userId, data);
+        return createTextBlock(formattedMessage);
     }
 
     // 의사 버튼 섹션 생성하기 (승인/반려)
@@ -234,6 +239,34 @@ public class SlackServiceImpl implements SlackService {
         } catch (JsonProcessingException e) {
             log.error("Slack 응답 JSON 생성 실패", e);
             return String.format("{\"replace_original\": \"%b\", \"text\": \"Error processing response\"}", replaceOriginal);
+        }
+    }
+
+
+    @Override
+    public void sendOpinionMessage(Long userId, String opinion) {
+        String webhookUrl = slackProperties.getWebhook().getOpinionUrl();
+
+        // 1) 전체 메시지 Payload 생성
+        Map<String, Object> payload = new HashMap<>();
+
+        // 2) Slack 메시지 내용
+        List<Map<String, Object>> blocks = new ArrayList<>();
+        payload.put("text", "유저 문의 및 신고가 접수되었습니다!");
+        blocks.add(createTextBlockByTypes(SlackNotificationType.OPINION, userId, opinion));
+        payload.put("blocks", blocks);
+
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+
+            restTemplate.postForEntity(webhookUrl, request, String.class);
+            log.info("Slack 인증 메시지 전송 완료: ID {}", userId);
+        } catch (RestClientException e) {
+            log.error("Slack API 호출 중 네트워크 오류 발생: {}", e.getMessage(), e);
+        } catch (Exception e) {
+            log.error("Slack 메시지 전송 중 알 수 없는 오류 발생: ", e);
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -203,6 +203,7 @@ google:
       range-template: ${google.spreadsheet.unregister.range-template}
 
 slack:
+  bot-token: ${slack.bot-token}
   webhook:
     verify-url: ${slack.webhook.verify-url}
     opinion-url: ${slack.webhook.opinion-url}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -204,7 +204,8 @@ google:
 
 slack:
   webhook:
-    url: ${slack.webhook.url}
+    verify-url: ${slack.webhook.verify-url}
+    opinion-url: ${slack.webhook.opinion-url}
   security:
     signing-secret: ${slack.security.signing-secret}
 


### PR DESCRIPTION
## 📌 이슈 번호
> #324 

## 💬 리뷰 포인트
> Slack을 활용한 인증 기능을 추가하고 받은 피드백 반영하였습니다.

## 🚀 상세 설명
> 해당 PR에 대해 상세하게 설명해주세요

1. 사용자 문의 및 신고 내용을 Slack으로도 전송한다.
- 기존 Google Sheets에 저장하던 사용자 문의와 신고 데이터를 Slack에 알림으로 띄우도록 기능 추가하였습니다.

<img width="312" height="111" alt="image" src="https://github.com/user-attachments/assets/64fcef70-98e1-4d57-9fdf-b7a7d7bfa8bf" />
 
2. Slack에서 사용자 인증 및 반려에 대해 스레드 메시지를 남긴다.
- 현재는 승인 및 반려 시 ✅와 ❌로 표시하는 방식을 사용중입니다.
- Webhook으로는 단방향으로 접근 가능하기 때문에 채널에 봇을 직접 초대하고 bot token을 활용해서 봇이 양방향으로 데이터를 전달할 수 있도록 수정하였습니다.
- 이번 수정 방식은 승인 및 반려 시 스레드를 열고 메시지를 보내는 방식입니다.  
- application-prod.yml 노션에 반영해 두었습니다.
 
<img width="686" height="365" alt="image" src="https://github.com/user-attachments/assets/eec1cd07-c023-4b1c-b05a-53f8491a4f7d" />
  
3. 반려된 사용자에게는 `REJECTED` 상태를 부여한다.
- REJECTED 상태를 추가하였습니다.
- 또한 원영님께서 가이드해주신대로 VerificationStatusFilter 부분 REJECTED가 생기면서 수정이 필요한 부분 추가하였습니다.
- security-path.yml 도 노션에서 수정했습니다. 
```
ALTER TABLE users 
MODIFY COLUMN verification_status 
ENUM(
    'VERIFIED', 
    'NEW_STUDENT_VERIFIED', 
    'ENROLL_STUDENT_VERIFIED', 
    'EMAIL_VERIFIED', 
    'PENDING', 
    'UNVERIFIED', 
    'REJECTED'
);
``` 
ENUM 설정을 위해 SQL 적용을 해야합니다.

## 📸 스크린샷

## 📢 노트