### PR TITLE
[Refactor #341] 콘텐츠 조회 및 문의하기 리팩토링

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/enums/ReportCategory.java
+++ b/src/main/java/JJinBBang/app/domain/common/enums/ReportCategory.java
@@ -1,7 +1,10 @@
 package JJinBBang.app.domain.common.enums;
 
+import lombok.Getter;
+
 import java.util.Arrays;
 
+@Getter
 public enum ReportCategory {
     REAL_ESTATE("부동산"), // 부동산
     TIPS("자취 꿀팁"), // 자취 꿀팁
@@ -13,10 +16,6 @@ public enum ReportCategory {
 
     ReportCategory(String label) {
         this.label = label;
-    }
-
-    public String getLabel() {
-        return label;
     }
 
     public static ReportCategory from(String value) {

--- a/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/ReportServiceImpl.java
@@ -52,7 +52,7 @@ public class ReportServiceImpl implements ReportService {
 
         // category 검증
         final ReportCategory reportCategory;
-        if (category == null || category.isBlank()) {
+        if (category == null || category.isBlank() || category.equalsIgnoreCase("ALL")) {
             reportCategory = null;
         } else {
             try {
@@ -95,9 +95,6 @@ public class ReportServiceImpl implements ReportService {
         // 리포트 데이터 매핑
         List<ReportInfo> reports = resultList.stream()
                 .map(report -> {
-
-                    boolean isLiked = likedReportIds.contains(report.getId());
-
                     return new ReportInfo(
                             report.getId(),
                             report.getCoverImage(),
@@ -106,7 +103,7 @@ public class ReportServiceImpl implements ReportService {
                             report.getCreatedAt(),
                             report.getLikeCount(),
                             report.getViewCount(),
-                            isLiked
+                            likedReportIds.contains(report.getId())
                     );
                 })
                 .toList();

--- a/src/main/java/JJinBBang/app/domain/user/dto/request/UserOpinionRequest.java
+++ b/src/main/java/JJinBBang/app/domain/user/dto/request/UserOpinionRequest.java
@@ -1,11 +1,17 @@
 package JJinBBang.app.domain.user.dto.request;
 
 import JJinBBang.app.global.sheets.enums.OpinionType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 // 문의하기(신고하기) - 신고내용
 public record UserOpinionRequest(
+        @NotBlank
         String opinion,
+
+        @NotNull
         OpinionType opinionType, // 문의 타입
-        Long targetId // 신고 대상 (리뷰, 빌딩)
+
+        Long targetId // 신고 대상 (리뷰, 빌딩) - null의 경우 일반 문의
 ) {
 }

--- a/src/main/java/JJinBBang/app/global/sheets/enums/OpinionType.java
+++ b/src/main/java/JJinBBang/app/global/sheets/enums/OpinionType.java
@@ -2,5 +2,6 @@ package JJinBBang.app.global.sheets.enums;
 
 public enum OpinionType {
     REVIEW_REPORT, // 리뷰 신고
-    BUILDING_REPORT // 건물 신고
+    BUILDING_REPORT, // 건물 신고
+    GENERAL, // 일반 문의
 }

--- a/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
+++ b/src/main/java/JJinBBang/app/global/sheets/service/impl/GoogleSheetsServiceImpl.java
@@ -80,7 +80,7 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
 
         List<Object> row = List.of(
                 userOpinionDto.userId(),
-                userOpinionDto.targetId(),
+                userOpinionDto.targetId() == null ? "-" : userOpinionDto.targetId(),
                 userOpinionDto.opinion(),
                 userOpinionDto.timestamp().format(DATE_TIME_FORMATTER)
         );
@@ -95,6 +95,7 @@ public class GoogleSheetsServiceImpl implements GoogleSheetsService {
         return switch (opinionType) {
             case BUILDING_REPORT -> "user-building-opinion";
             case REVIEW_REPORT ->  "user-review-opinion";
+            case GENERAL -> "user-general-opinion";
         };
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -195,6 +195,7 @@ google:
       sheets:
         user-review-opinion: ${google.spreadsheet.opinion.sheets.user-review-opinion}
         user-building-opinion: ${google.spreadsheet.opinion.sheets.user-building-opinion}
+        user-general-opinion: ${google.spreadsheet.opinion.sheets.user-general-opinion}
       range-template: ${google.spreadsheet.opinion.range-template}
     unregister:
       id: ${google.spreadsheet.unregister.id}


### PR DESCRIPTION
## 📌 이슈 번호
> #341 

## 💬 리뷰 포인트
> 콘텐츠 조회 및 문의하기 리팩토링 진행했습니다.

## 🚀 상세 설명
1. 콘텐츠 조회 시 전체 카테고리에 대한 조회 추가
- 카테고리를 비우거나 ALL을 입력하는 경우 전체 데이터가 조회되도록 수정하였습니다.
2. 문의하기 일반 문의 추가
- 기존 방식은 빌딩이나 리뷰 ID 등 신고 대상이 존재하는 기능이었고, 일반 카테고리를 추가해서 문의하기가 가능하도록 하였습니다.

## 📢 노트