### PR TITLE
[FIX] Slack 인증 콜백 처리 오류 수정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/user/controller/AdminUserController.java
+++ b/src/main/java/JJinBBang/app/domain/user/controller/AdminUserController.java
@@ -1,12 +1,19 @@
 package JJinBBang.app.domain.user.controller;
 
 import JJinBBang.app.domain.user.service.UsersService;
+import JJinBBang.app.global.slack.service.SlackRequestVerifier;
 import JJinBBang.app.global.slack.service.SlackService;
 import JJinBBang.app.global.template.ResTemplate;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 @RestController
 @RequestMapping("/api/admin")
@@ -15,12 +22,39 @@ public class AdminUserController {
 
     private final UsersService usersService;
     private final SlackService slackService;
+    private final SlackRequestVerifier slackRequestVerifier;
 
-    @PostMapping("/slack/verification")
-    public ResTemplate<?> handleInteraction(
-            @RequestParam("payload") String payload
+    @PostMapping(
+            value = "/slack/verification",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
+    )
+    public ResponseEntity<String> handleInteraction(
+            @RequestBody String body,
+            @RequestHeader(value = "X-Slack-Request-Timestamp", required = false) String timestamp,
+            @RequestHeader(value = "X-Slack-Signature", required = false) String signature
     ) throws JsonProcessingException {
-        return new ResTemplate<>(HttpStatus.OK, slackService.handleInteractivity(payload), null);
+        if (!slackRequestVerifier.isValid(timestamp, signature, body)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid Slack signature");
+        }
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(slackService.handleInteractivity(extractPayload(body)));
+    }
+
+    private String extractPayload(String body) {
+        for (String pair : body.split("&")) {
+            int separatorIndex = pair.indexOf('=');
+            if (separatorIndex < 0) {
+                continue;
+            }
+
+            String key = URLDecoder.decode(pair.substring(0, separatorIndex), StandardCharsets.UTF_8);
+            if ("payload".equals(key)) {
+                return URLDecoder.decode(pair.substring(separatorIndex + 1), StandardCharsets.UTF_8);
+            }
+        }
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Missing Slack payload");
     }
 
     @DeleteMapping("/deletedUsers/executeDeletion")

--- a/src/main/java/JJinBBang/app/global/config/ClockConfig.java
+++ b/src/main/java/JJinBBang/app/global/config/ClockConfig.java
@@ -1,0 +1,15 @@
+package JJinBBang.app.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
+    }
+}

--- a/src/main/java/JJinBBang/app/global/slack/service/SlackRequestVerifier.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/SlackRequestVerifier.java
@@ -1,0 +1,6 @@
+package JJinBBang.app.global.slack.service;
+
+public interface SlackRequestVerifier {
+
+    boolean isValid(String timestamp, String signature, String body);
+}

--- a/src/main/java/JJinBBang/app/global/slack/service/impl/SlackRequestVerifierImpl.java
+++ b/src/main/java/JJinBBang/app/global/slack/service/impl/SlackRequestVerifierImpl.java
@@ -1,0 +1,80 @@
+package JJinBBang.app.global.slack.service.impl;
+
+import JJinBBang.app.global.slack.properties.SlackProperties;
+import JJinBBang.app.global.slack.service.SlackRequestVerifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.HexFormat;
+
+@Component
+@RequiredArgsConstructor
+public class SlackRequestVerifierImpl implements SlackRequestVerifier {
+
+    private static final String VERSION = "v0";
+    private static final long ALLOWED_CLOCK_SKEW_SECONDS = 60L * 5L;
+
+    private final SlackProperties slackProperties;
+    private final Clock clock;
+
+    @Override
+    public boolean isValid(String timestamp, String signature, String body) {
+        String signingSecret = slackProperties.getSecurity().getSigningSecret();
+        if (signingSecret == null || signingSecret.isBlank()
+                || timestamp == null || signature == null || body == null) {
+            return false;
+        }
+        if (isExpired(timestamp)) {
+            return false;
+        }
+
+        String expectedSignature = VERSION + "=" + hmacSha256(
+                signingSecret,
+                VERSION + ":" + timestamp + ":" + body
+        );
+        return constantTimeEquals(expectedSignature, signature);
+    }
+
+    private boolean isExpired(String timestamp) {
+        try {
+            long requestEpochSeconds = Long.parseLong(timestamp);
+            long nowEpochSeconds = Instant.now(clock).getEpochSecond();
+            return Math.abs(nowEpochSeconds - requestEpochSeconds) > ALLOWED_CLOCK_SKEW_SECONDS;
+        } catch (NumberFormatException e) {
+            return true;
+        }
+    }
+
+    private String hmacSha256(String signingSecret, String data) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(
+                    signingSecret.getBytes(StandardCharsets.UTF_8),
+                    "HmacSHA256"
+            ));
+            return HexFormat.of().formatHex(mac.doFinal(data.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException("Slack request signature verification failed", e);
+        }
+    }
+
+    private boolean constantTimeEquals(String expected, String actual) {
+        byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
+        byte[] actualBytes = actual.getBytes(StandardCharsets.UTF_8);
+
+        if (expectedBytes.length != actualBytes.length) {
+            return false;
+        }
+
+        int result = 0;
+        for (int i = 0; i < expectedBytes.length; i++) {
+            result |= expectedBytes[i] ^ actualBytes[i];
+        }
+        return result == 0;
+    }
+}

--- a/src/test/java/JJinBBang/app/domain/user/controller/AdminUserControllerTest.java
+++ b/src/test/java/JJinBBang/app/domain/user/controller/AdminUserControllerTest.java
@@ -1,0 +1,82 @@
+package JJinBBang.app.domain.user.controller;
+
+import JJinBBang.app.domain.user.service.UsersService;
+import JJinBBang.app.global.slack.service.SlackRequestVerifier;
+import JJinBBang.app.global.slack.service.SlackService;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class AdminUserControllerTest {
+
+    private final UsersService usersService = mock(UsersService.class);
+    private final SlackService slackService = mock(SlackService.class);
+    private final SlackRequestVerifier slackRequestVerifier = mock(SlackRequestVerifier.class);
+    private final MockMvc mockMvc = MockMvcBuilders
+            .standaloneSetup(new AdminUserController(usersService, slackService, slackRequestVerifier))
+            .build();
+
+    @Test
+    void handleInteraction_returnsRawSlackResponseJson() throws Exception {
+        String payload = "{\"type\":\"block_actions\"}";
+        String body = "payload=%7B%22type%22%3A%22block_actions%22%7D";
+        String slackResponse = "{\"replace_original\":true,\"text\":\"승인 처리되었습니다.\"}";
+
+        when(slackRequestVerifier.isValid(eq("1234567890"), eq("v0=signature"), eq(body))).thenReturn(true);
+        when(slackService.handleInteractivity(eq(payload))).thenReturn(slackResponse);
+
+        mockMvc.perform(post("/api/admin/slack/verification")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .header("X-Slack-Request-Timestamp", "1234567890")
+                        .header("X-Slack-Signature", "v0=signature")
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.replace_original").value(true))
+                .andExpect(jsonPath("$.text").value("승인 처리되었습니다."))
+                .andExpect(jsonPath("$.code").doesNotExist())
+                .andExpect(jsonPath("$.message").doesNotExist());
+    }
+
+    @Test
+    void handleInteraction_rejectsInvalidSlackSignature() throws Exception {
+        String body = "payload=%7B%22type%22%3A%22block_actions%22%7D";
+
+        when(slackRequestVerifier.isValid(eq("1234567890"), eq("v0=invalid"), eq(body))).thenReturn(false);
+
+        mockMvc.perform(post("/api/admin/slack/verification")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .header("X-Slack-Request-Timestamp", "1234567890")
+                        .header("X-Slack-Signature", "v0=invalid")
+                        .content(body))
+                .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(slackService);
+    }
+
+    @Test
+    void handleInteraction_rejectsMissingPayload() throws Exception {
+        String body = "not_payload=value";
+
+        when(slackRequestVerifier.isValid(eq("1234567890"), eq("v0=signature"), eq(body))).thenReturn(true);
+
+        mockMvc.perform(post("/api/admin/slack/verification")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .header("X-Slack-Request-Timestamp", "1234567890")
+                        .header("X-Slack-Signature", "v0=signature")
+                        .content(body))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(slackService);
+    }
+}

--- a/src/test/java/JJinBBang/app/global/slack/SlackRequestVerifierImplTest.java
+++ b/src/test/java/JJinBBang/app/global/slack/SlackRequestVerifierImplTest.java
@@ -1,0 +1,79 @@
+package JJinBBang.app.global.slack;
+
+import JJinBBang.app.global.slack.properties.SlackProperties;
+import JJinBBang.app.global.slack.service.impl.SlackRequestVerifierImpl;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SlackRequestVerifierImplTest {
+
+    private static final String SECRET = "test-signing-secret";
+    private static final String TIMESTAMP = "1710000000";
+    private static final String BODY = "payload=%7B%22type%22%3A%22block_actions%22%7D";
+
+    private final SlackRequestVerifierImpl verifier = new SlackRequestVerifierImpl(
+            slackProperties(),
+            Clock.fixed(Instant.ofEpochSecond(1710000000), ZoneOffset.UTC)
+    );
+
+    @Test
+    void isValid_acceptsMatchingSignatureWithinAllowedWindow() {
+        String signature = sign(TIMESTAMP, BODY);
+
+        assertTrue(verifier.isValid(TIMESTAMP, signature, BODY));
+    }
+
+    @Test
+    void isValid_rejectsMismatchedSignature() {
+        assertFalse(verifier.isValid(TIMESTAMP, "v0=invalid", BODY));
+    }
+
+    @Test
+    void isValid_rejectsExpiredTimestamp() {
+        String expiredTimestamp = "1709999000";
+        String signature = sign(expiredTimestamp, BODY);
+
+        assertFalse(verifier.isValid(expiredTimestamp, signature, BODY));
+    }
+
+    @Test
+    void isValid_rejectsMissingSigningSecret() {
+        SlackProperties properties = slackProperties();
+        properties.getSecurity().setSigningSecret(null);
+        SlackRequestVerifierImpl verifier = new SlackRequestVerifierImpl(
+                properties,
+                Clock.fixed(Instant.ofEpochSecond(1710000000), ZoneOffset.UTC)
+        );
+
+        assertFalse(verifier.isValid(TIMESTAMP, sign(TIMESTAMP, BODY), BODY));
+    }
+
+    private SlackProperties slackProperties() {
+        SlackProperties properties = new SlackProperties();
+        SlackProperties.Security security = new SlackProperties.Security();
+        security.setSigningSecret(SECRET);
+        properties.setSecurity(security);
+        return properties;
+    }
+
+    private String sign(String timestamp, String body) {
+        try {
+            String baseString = "v0:" + timestamp + ":" + body;
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return "v0=" + HexFormat.of().formatHex(mac.doFinal(baseString.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
#344 

## 💬 리뷰 포인트
- Slack interactivity 요청을 application/x-www-form-urlencoded 형식에 맞게 처리하도록 수정
- Slack Signature 검증 로직(SlackRequestVerifier) 추가 및 적용
- 기존 ResTemplate 응답 제거 → Slack 요구 스펙에 맞는 raw JSON 응답으로 변경
- payload 파싱 로직 분리 (extractPayload)
- 관련 단위 테스트 추가 (Controller / Verifier)

## 🚀 상세 설명
Slack 재학생 인증 관리자 액션(승인/반려) 처리 시 발생하던 콜백 오류를 수정했습니다.

- Slack interactivity 요청 스펙에 맞게 application/x-www-form-urlencoded 기반의 raw body를 직접 처리하도록 변경
- payload를 URL 디코딩하여 추출하는 로직(extractPayload) 추가
- X-Slack-Request-Timestamp, X-Slack-Signature 헤더 기반으로 Slack 요청 검증 로직 구현
- 검증 실패 시 401 반환, payload 누락 시 400 반환하도록 예외 처리
- Slack 요구사항에 맞게 raw JSON 형태의 응답 반환하도록 수정

추가로, 시간 의존 로직 테스트를 위해 Clock Bean을 도입하고,
SlackRequestVerifier 및 Controller에 대한 단위 테스트를 작성했슴다

## 📸 스크린샷

## 📢 노트