### PR TITLE
🚀 Feat: OCI private GHCR 이미지 배포 구성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.gradle
+.idea
+build
+docs
+outputs
+
+# Runtime secrets must never enter the image build context.
+src/main/resources/application-dev.yml
+src/main/resources/application-prod.yml
+src/main/resources/gcp_iam_key.json
+src/main/resources/security-path.yml

--- a/.github/workflows/deploy-oci.yml
+++ b/.github/workflows/deploy-oci.yml
@@ -1,0 +1,195 @@
+name: Build private API image for OCI
+
+on:
+  push:
+    branches:
+      - develop
+      - release
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment environment
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+          - legacy
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: oci-api-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/jjinbbang-web/jjinbbang-api
+  PACKAGE_API: https://api.github.com/orgs/JJinBBang-web/packages/container/jjinbbang-api
+
+jobs:
+  build-and-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Resolve and validate deployment target
+        id: target
+        env:
+          REQUESTED_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || '' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]]; then
+            environment="$REQUESTED_ENVIRONMENT"
+          elif [[ "$GITHUB_REF_NAME" == release ]]; then
+            environment=prod
+          else
+            environment=dev
+          fi
+
+          case "$environment" in
+            dev)
+              expected_ref=develop
+              ;;
+            prod|legacy)
+              expected_ref=release
+              ;;
+            *)
+              echo "unsupported environment: $environment" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ "$GITHUB_REF_NAME" != "$expected_ref" ]]; then
+            echo "environment/source ref mismatch: $environment/$GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+
+          echo "environment=$environment" >> "$GITHUB_OUTPUT"
+
+      - name: Verify existing package is private
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          response_file="$RUNNER_TEMP/ghcr-package.json"
+          status="$(curl --silent --show-error \
+            --output "$response_file" \
+            --write-out '%{http_code}' \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "$PACKAGE_API")"
+
+          case "$status" in
+            200)
+              jq -e '.visibility == "private"' "$response_file" >/dev/null
+              ;;
+            404)
+              echo 'GHCR package does not exist yet; the first workflow publish creates it as private.'
+              ;;
+            *)
+              echo "unable to verify GHCR package visibility (HTTP $status)" >&2
+              exit 1
+              ;;
+          esac
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish ARM64 image
+        id: image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Verify published image and package visibility
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          [[ "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+          curl --fail --silent --show-error \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "$PACKAGE_API" |
+            jq -e '.visibility == "private"' >/dev/null
+
+          docker buildx imagetools inspect "$IMAGE@$IMAGE_DIGEST" \
+            --format '{{json .Image}}' |
+            jq -e 'has("linux/arm64")' >/dev/null
+
+      - name: Check GitOps dispatch credentials
+        id: gitops
+        env:
+          GITOPS_APP_ID: ${{ secrets.GITOPS_APP_ID }}
+          GITOPS_APP_PRIVATE_KEY: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+        run: |
+          if [[ -n "$GITOPS_APP_ID" && -n "$GITOPS_APP_PRIVATE_KEY" ]]; then
+            echo 'enabled=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'enabled=false' >> "$GITHUB_OUTPUT"
+            echo '::notice::Private image was published, but GitOps dispatch is disabled until GitHub App credentials are configured.'
+          fi
+
+      - name: Create GitHub App token for GitOps dispatch
+        if: steps.gitops.outputs.enabled == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.GITOPS_APP_ID }}
+          private-key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+          owner: JJinBBang-web
+          repositories: jjinbbang-lab
+
+      - name: Dispatch immutable image to GitOps
+        if: steps.gitops.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DEPLOY_ENVIRONMENT: ${{ steps.target.outputs.environment }}
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            https://api.github.com/repos/JJinBBang-web/jjinbbang-lab/dispatches \
+            --data @- <<EOF
+          {
+            "event_type": "api-image-built",
+            "client_payload": {
+              "component": "api",
+              "environment": "$DEPLOY_ENVIRONMENT",
+              "image": "$IMAGE",
+              "tag": "$GITHUB_SHA",
+              "image_digest": "$IMAGE_DIGEST",
+              "source_repository": "$GITHUB_REPOSITORY",
+              "source_ref": "$GITHUB_REF_NAME",
+              "source_sha": "$GITHUB_SHA"
+            }
+          }
+          EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-jammy@sha256:ce5767b7222312d42395f5bab033cd91f09e44032a2f21bdfd7b5b912dbe1e77 AS build
+
+WORKDIR /workspace
+
+COPY gradlew build.gradle settings.gradle ./
+COPY gradle ./gradle
+RUN chmod +x gradlew
+
+COPY src ./src
+RUN ./gradlew clean bootJar -x test --no-daemon \
+    && find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' \
+       -exec cp '{}' /workspace/app.jar \;
+
+FROM eclipse-temurin:21-jre-jammy@sha256:eebd356ad7358b7094758e5787a6726f332917cfd56feab6457c56dab895cdbf
+
+WORKDIR /app
+COPY --from=build --chown=65532:65532 /workspace/app.jar /app/app.jar
+
+USER 65532:65532
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/src/main/java/JJinBBang/app/domain/common/config/S3Config.java
+++ b/src/main/java/JJinBBang/app/domain/common/config/S3Config.java
@@ -1,5 +1,7 @@
 package JJinBBang.app.domain.common.config;
 
+import java.net.URI;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +12,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -24,10 +27,17 @@ public class S3Config {
 	@Value("${cloud.aws.credentials.secret-key:}")
 	private String secretKey;
 
+	@Value("${cloud.aws.s3.endpoint:}")
+	private String endpoint;
+
+	@Value("${cloud.aws.s3.path-style-access-enabled:false}")
+	private boolean pathStyleAccessEnabled;
+
 	@Bean
 	public S3Presigner s3Presigner() {
 		S3Presigner.Builder builder = S3Presigner.builder()
 			.region(Region.of(region));
+		configureEndpoint(builder);
 
 		if (!accessKey.isBlank() && !secretKey.isBlank()) {
 			builder.credentialsProvider(StaticCredentialsProvider.create(
@@ -43,6 +53,7 @@ public class S3Config {
 	public S3Client s3() {
 		S3ClientBuilder builder = S3Client.builder()
 			.region(Region.of(region));
+		configureEndpoint(builder);
 
 		if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
 			builder.credentialsProvider(StaticCredentialsProvider.create(
@@ -52,5 +63,21 @@ public class S3Config {
 		}
 
 		return builder.build();
+	}
+
+	private void configureEndpoint(S3Presigner.Builder builder) {
+		if (!endpoint.isBlank()) {
+			builder.endpointOverride(URI.create(endpoint))
+				.serviceConfiguration(S3Configuration.builder()
+					.pathStyleAccessEnabled(pathStyleAccessEnabled)
+					.build());
+		}
+	}
+
+	private void configureEndpoint(S3ClientBuilder builder) {
+		if (!endpoint.isBlank()) {
+			builder.endpointOverride(URI.create(endpoint))
+				.forcePathStyle(pathStyleAccessEnabled);
+		}
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: classpath:security-path.yml
+    import: ${SECURITY_PATH_CONFIG:classpath:security-path.yml}
 
   profiles:
     active: prod
@@ -178,7 +178,7 @@ vworld:
 
 google:
   credentials:
-    path: "classpath:gcp_iam_key.json"
+    path: ${GOOGLE_CREDENTIALS_PATH:classpath:gcp_iam_key.json}
   drive:
     folders:
       admission: ${google.drive.folders.admission}


### PR DESCRIPTION
## 변경 범위
- 레거시 Spring Boot 애플리케이션용 ARM64 non-root 이미지 추가
- private GHCR 빌드 및 패키지 가시성 검증 워크플로 추가
- OCI Object Storage S3 호환 endpoint 및 외부 Secret 파일 경로 지원
- 운영 비밀 파일을 이미지 빌드 컨텍스트에서 제외

## 검증
- Gradle bootJar 빌드 통과
- actionlint, hadolint, gitleaks 통과
- diff whitespace 검사 통과
- 전체 테스트: 19개 중 10개 실패
  - 기존 테스트용 security-path.yml 미제공
  - 기존 Mail/Token 테스트 컨텍스트 문제
  - 실패를 우회하거나 테스트를 비활성화하지 않음

## 배포 경계
- 이 PR은 develop만 대상으로 하며 AWS release/CodeDeploy를 실행하지 않음
- 생성된 GHCR digest는 jjinbbang-lab legacy overlay에서 별도 고정
