### PR TITLE
🐛 Fix: OCI Object Storage 이미지 삭제 경로 보정

### DIFF
--- a/src/main/java/JJinBBang/app/domain/common/service/S3Service.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/S3Service.java
@@ -162,13 +162,19 @@ public class S3Service {
 		if (url == null || url.isBlank()) {
 			throw new IllegalArgumentException("빈 URL입니다.");
 		}
+		int queryStart = url.indexOf('?');
+		String urlWithoutQuery = queryStart >= 0 ? url.substring(0, queryStart) : url;
+		String cdnBase = "https://" + cdnDomain.replaceAll("^https?://", "").replaceAll("/+$", "");
+		if (urlWithoutQuery.startsWith(cdnBase + "/")) {
+			return URLDecoder.decode(urlWithoutQuery.substring(cdnBase.length() + 1), StandardCharsets.UTF_8);
+		}
+
 		int schemeEnd = url.indexOf("://");
 		int pathStart = url.indexOf('/', (schemeEnd >= 0 ? schemeEnd + 3 : 0));
 		if (pathStart < 0 || pathStart == url.length() - 1) {
 			throw new IllegalArgumentException("경로가 없는 URL입니다: " + url);
 		}
-		int q = url.indexOf('?', pathStart);
-		String path = (q >= 0) ? url.substring(pathStart + 1, q) : url.substring(pathStart + 1);
+		String path = (queryStart >= 0) ? url.substring(pathStart + 1, queryStart) : url.substring(pathStart + 1);
 		return URLDecoder.decode(path, StandardCharsets.UTF_8);
 	}
 }

--- a/src/test/java/JJinBBang/app/domain/common/service/S3ServiceTest.java
+++ b/src/test/java/JJinBBang/app/domain/common/service/S3ServiceTest.java
@@ -1,0 +1,47 @@
+package JJinBBang.app.domain.common.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+	@Mock
+	private S3Presigner s3Presigner;
+
+	@Mock
+	private S3Client s3;
+
+	private S3Service s3Service;
+
+	@BeforeEach
+	void setUp() {
+		s3Service = new S3Service(s3Presigner, s3);
+		ReflectionTestUtils.setField(s3Service, "cdnDomain",
+			"objectstorage.ap-chuncheon-1.oraclecloud.com/n/example/b/review-images/o");
+		ReflectionTestUtils.setField(s3Service, "bucket", "review-images");
+	}
+
+	@Test
+	void deleteFileStripsConfiguredCdnBasePathFromObjectKey() {
+		s3Service.deleteFile(
+			"https://objectstorage.ap-chuncheon-1.oraclecloud.com/n/example/b/review-images/o/review/image.jpg");
+
+		ArgumentCaptor<DeleteObjectRequest> request = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+		verify(s3).deleteObject(request.capture());
+		assertThat(request.getValue().key()).isEqualTo("review/image.jpg");
+	}
+}


### PR DESCRIPTION
## 원인
OCI Object Storage public URL은 bucket 경로가 CDN base에 포함되는데, 기존 삭제 로직은 URL 전체 경로를 object key로 사용했습니다.

## 변경
- 설정된 CDN base 경로를 먼저 제거한 뒤 실제 object key만 전달
- OCI 경로형 public URL 회귀 테스트 추가

## 검증
- 회귀 테스트 RED: 예상 review/image.jpg, 실제 n/.../o/review/image.jpg
- 수정 후 targeted test 통과
- Gradle bootJar 통과
- actionlint, gitleaks, diff whitespace 검사 통과
- 전체 테스트 20개 중 기존 10개 실패 유지

## 배포 경계
- develop만 갱신하고 AWS release/CodeDeploy는 실행하지 않음
