### PR TITLE
🚀 Release: AWS 병행 유지 및 OCI 레거시 배포 구성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.gradle
+.idea
+build
+docs
+outputs
+
+# Runtime secrets must never enter the image build context.
+src/main/resources/application-dev.yml
+src/main/resources/application-prod.yml
+src/main/resources/gcp_iam_key.json
+src/main/resources/security-path.yml

--- a/.github/workflows/deploy-oci.yml
+++ b/.github/workflows/deploy-oci.yml
@@ -1,0 +1,186 @@
+name: Build private API image for OCI
+
+on:
+  push:
+    branches:
+      - develop
+      - release
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment environment
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+          - legacy
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: oci-api-${{ github.ref_name }}
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/jjinbbang-web/jjinbbang-api
+
+jobs:
+  build-and-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Resolve and validate deployment target
+        id: target
+        env:
+          REQUESTED_ENVIRONMENT: ${{ github.event_name == 'workflow_dispatch' && inputs.environment || '' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]]; then
+            environment="$REQUESTED_ENVIRONMENT"
+          elif [[ "$GITHUB_REF_NAME" == release ]]; then
+            environment=prod
+          else
+            environment=dev
+          fi
+
+          case "$environment" in
+            dev)
+              expected_ref=develop
+              ;;
+            prod|legacy)
+              expected_ref=release
+              ;;
+            *)
+              echo "unsupported environment: $environment" >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ "$GITHUB_REF_NAME" != "$expected_ref" ]]; then
+            echo "environment/source ref mismatch: $environment/$GITHUB_REF_NAME" >&2
+            exit 1
+          fi
+
+          echo "environment=$environment" >> "$GITHUB_OUTPUT"
+
+      - name: Verify existing package is not anonymously readable
+        run: |
+          set -euo pipefail
+          response="$(curl --silent --show-error --write-out '\n%{http_code}' \
+            'https://ghcr.io/token?service=ghcr.io&scope=repository:jjinbbang-web/jjinbbang-api:pull')"
+          token_status="${response##*$'\n'}"
+
+          if [[ "$token_status" == 200 ]]; then
+            echo 'GHCR grants anonymous pull access; private visibility is required.' >&2
+            exit 1
+          elif [[ "$token_status" != 401 && "$token_status" != 403 ]]; then
+            echo "unable to verify anonymous GHCR access (HTTP $token_status)" >&2
+            exit 1
+          fi
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish ARM64 image
+        id: image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ${{ env.IMAGE }}:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
+
+      - name: Verify published private ARM64 image
+        env:
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          [[ "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+          response="$(curl --silent --show-error --write-out '\n%{http_code}' \
+            'https://ghcr.io/token?service=ghcr.io&scope=repository:jjinbbang-web/jjinbbang-api:pull')"
+          token_status="${response##*$'\n'}"
+
+          if [[ "$token_status" == 200 ]]; then
+            echo 'GHCR grants anonymous pull access; private visibility is required.' >&2
+            exit 1
+          elif [[ "$token_status" != 401 && "$token_status" != 403 ]]; then
+            echo "unable to verify anonymous GHCR access (HTTP $token_status)" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools inspect "$IMAGE@$IMAGE_DIGEST" \
+            --raw |
+            jq -e 'any(.manifests[]?; .platform.os == "linux" and .platform.architecture == "arm64")' >/dev/null
+
+      - name: Check GitOps dispatch credentials
+        id: gitops
+        env:
+          GITOPS_APP_ID: ${{ secrets.GITOPS_APP_ID }}
+          GITOPS_APP_PRIVATE_KEY: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+        run: |
+          if [[ -n "$GITOPS_APP_ID" && -n "$GITOPS_APP_PRIVATE_KEY" ]]; then
+            echo 'enabled=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'enabled=false' >> "$GITHUB_OUTPUT"
+            echo '::notice::Private image was published, but GitOps dispatch is disabled until GitHub App credentials are configured.'
+          fi
+
+      - name: Create GitHub App token for GitOps dispatch
+        if: steps.gitops.outputs.enabled == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.GITOPS_APP_ID }}
+          private-key: ${{ secrets.GITOPS_APP_PRIVATE_KEY }}
+          owner: JJinBBang-web
+          repositories: jjinbbang-lab
+
+      - name: Dispatch immutable image to GitOps
+        if: steps.gitops.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DEPLOY_ENVIRONMENT: ${{ steps.target.outputs.environment }}
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          curl --fail --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header 'Accept: application/vnd.github+json' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            https://api.github.com/repos/JJinBBang-web/jjinbbang-lab/dispatches \
+            --data @- <<EOF
+          {
+            "event_type": "api-image-built",
+            "client_payload": {
+              "component": "api",
+              "environment": "$DEPLOY_ENVIRONMENT",
+              "image": "$IMAGE",
+              "tag": "$GITHUB_SHA",
+              "image_digest": "$IMAGE_DIGEST",
+              "source_repository": "$GITHUB_REPOSITORY",
+              "source_ref": "$GITHUB_REF_NAME",
+              "source_sha": "$GITHUB_SHA"
+            }
+          }
+          EOF

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,7 @@
 name: Build and Deploy to EC2
 
-# 워크플로우가 언제 실행될 것인지 조건 명시
 on:
-  push:
-    branches:
-      - release
-  # pull_request:
-  #   branches:
-  #     - release
+  workflow_dispatch:
 
 # AWS 관련 값 변수로 설정
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-jammy@sha256:ce5767b7222312d42395f5bab033cd91f09e44032a2f21bdfd7b5b912dbe1e77 AS build
+
+WORKDIR /workspace
+
+COPY gradlew build.gradle settings.gradle ./
+COPY gradle ./gradle
+RUN chmod +x gradlew
+
+COPY src ./src
+RUN ./gradlew clean bootJar -x test --no-daemon \
+    && find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' \
+       -exec cp '{}' /workspace/app.jar \;
+
+FROM eclipse-temurin:21-jre-jammy@sha256:eebd356ad7358b7094758e5787a6726f332917cfd56feab6457c56dab895cdbf
+
+WORKDIR /app
+COPY --from=build --chown=65532:65532 /workspace/app.jar /app/app.jar
+
+USER 65532:65532
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/src/main/java/JJinBBang/app/domain/common/config/S3Config.java
+++ b/src/main/java/JJinBBang/app/domain/common/config/S3Config.java
@@ -1,5 +1,7 @@
 package JJinBBang.app.domain.common.config;
 
+import java.net.URI;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +12,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -24,10 +27,17 @@ public class S3Config {
 	@Value("${cloud.aws.credentials.secret-key:}")
 	private String secretKey;
 
+	@Value("${cloud.aws.s3.endpoint:}")
+	private String endpoint;
+
+	@Value("${cloud.aws.s3.path-style-access-enabled:false}")
+	private boolean pathStyleAccessEnabled;
+
 	@Bean
 	public S3Presigner s3Presigner() {
 		S3Presigner.Builder builder = S3Presigner.builder()
 			.region(Region.of(region));
+		configureEndpoint(builder);
 
 		if (!accessKey.isBlank() && !secretKey.isBlank()) {
 			builder.credentialsProvider(StaticCredentialsProvider.create(
@@ -43,6 +53,7 @@ public class S3Config {
 	public S3Client s3() {
 		S3ClientBuilder builder = S3Client.builder()
 			.region(Region.of(region));
+		configureEndpoint(builder);
 
 		if (!accessKey.isEmpty() && !secretKey.isEmpty()) {
 			builder.credentialsProvider(StaticCredentialsProvider.create(
@@ -52,5 +63,21 @@ public class S3Config {
 		}
 
 		return builder.build();
+	}
+
+	private void configureEndpoint(S3Presigner.Builder builder) {
+		if (!endpoint.isBlank()) {
+			builder.endpointOverride(URI.create(endpoint))
+				.serviceConfiguration(S3Configuration.builder()
+					.pathStyleAccessEnabled(pathStyleAccessEnabled)
+					.build());
+		}
+	}
+
+	private void configureEndpoint(S3ClientBuilder builder) {
+		if (!endpoint.isBlank()) {
+			builder.endpointOverride(URI.create(endpoint))
+				.forcePathStyle(pathStyleAccessEnabled);
+		}
 	}
 }

--- a/src/main/java/JJinBBang/app/domain/common/service/S3Service.java
+++ b/src/main/java/JJinBBang/app/domain/common/service/S3Service.java
@@ -162,13 +162,19 @@ public class S3Service {
 		if (url == null || url.isBlank()) {
 			throw new IllegalArgumentException("빈 URL입니다.");
 		}
+		int queryStart = url.indexOf('?');
+		String urlWithoutQuery = queryStart >= 0 ? url.substring(0, queryStart) : url;
+		String cdnBase = "https://" + cdnDomain.replaceAll("^https?://", "").replaceAll("/+$", "");
+		if (urlWithoutQuery.startsWith(cdnBase + "/")) {
+			return URLDecoder.decode(urlWithoutQuery.substring(cdnBase.length() + 1), StandardCharsets.UTF_8);
+		}
+
 		int schemeEnd = url.indexOf("://");
 		int pathStart = url.indexOf('/', (schemeEnd >= 0 ? schemeEnd + 3 : 0));
 		if (pathStart < 0 || pathStart == url.length() - 1) {
 			throw new IllegalArgumentException("경로가 없는 URL입니다: " + url);
 		}
-		int q = url.indexOf('?', pathStart);
-		String path = (q >= 0) ? url.substring(pathStart + 1, q) : url.substring(pathStart + 1);
+		String path = (queryStart >= 0) ? url.substring(pathStart + 1, queryStart) : url.substring(pathStart + 1);
 		return URLDecoder.decode(path, StandardCharsets.UTF_8);
 	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   config:
-    import: classpath:security-path.yml
+    import: ${SECURITY_PATH_CONFIG:classpath:security-path.yml}
 
   profiles:
     active: prod
@@ -178,7 +178,7 @@ vworld:
 
 google:
   credentials:
-    path: "classpath:gcp_iam_key.json"
+    path: ${GOOGLE_CREDENTIALS_PATH:classpath:gcp_iam_key.json}
   drive:
     folders:
       admission: ${google.drive.folders.admission}

--- a/src/test/java/JJinBBang/app/domain/common/service/S3ServiceTest.java
+++ b/src/test/java/JJinBBang/app/domain/common/service/S3ServiceTest.java
@@ -1,0 +1,47 @@
+package JJinBBang.app.domain.common.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+	@Mock
+	private S3Presigner s3Presigner;
+
+	@Mock
+	private S3Client s3;
+
+	private S3Service s3Service;
+
+	@BeforeEach
+	void setUp() {
+		s3Service = new S3Service(s3Presigner, s3);
+		ReflectionTestUtils.setField(s3Service, "cdnDomain",
+			"objectstorage.ap-chuncheon-1.oraclecloud.com/n/example/b/review-images/o");
+		ReflectionTestUtils.setField(s3Service, "bucket", "review-images");
+	}
+
+	@Test
+	void deleteFileStripsConfiguredCdnBasePathFromObjectKey() {
+		s3Service.deleteFile(
+			"https://objectstorage.ap-chuncheon-1.oraclecloud.com/n/example/b/review-images/o/review/image.jpg");
+
+		ArgumentCaptor<DeleteObjectRequest> request = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+		verify(s3).deleteObject(request.capture());
+		assertThat(request.getValue().key()).isEqualTo("review/image.jpg");
+	}
+}

--- a/src/test/java/JJinBBang/app/global/mail/MailAuthServiceImplTest.java
+++ b/src/test/java/JJinBBang/app/global/mail/MailAuthServiceImplTest.java
@@ -1,7 +1,9 @@
 package JJinBBang.app.global.mail;
 
+import JJinBBang.app.domain.user.repository.UniversityRepository;
 import JJinBBang.app.global.mail.dto.EmailAuthInfo;
 import JJinBBang.app.global.mail.exception.MailInvalidException;
+import JJinBBang.app.global.mail.exception.MailNotFoundException;
 import JJinBBang.app.global.mail.properties.MailAuthProperties;
 import JJinBBang.app.global.mail.repository.EmailAuthCodeRepository;
 import JJinBBang.app.global.mail.service.MailSendService;
@@ -33,6 +35,8 @@ class MailAuthServiceImplTest {
 	EmailAuthCodeRepository repo;
 	@Mock
 	MailSendService mailSender;
+	@Mock
+	UniversityRepository universityRepository;
 
 	@InjectMocks
 	MailAuthServiceImpl service;
@@ -46,6 +50,7 @@ class MailAuthServiceImplTest {
 		when(props.getBodyText()).thenReturn("코드: %s (유효:%s분)");
 		// 5분 = 300,000 밀리초
 		when(props.getExpirationTime()).thenReturn(300_000L);
+		when(universityRepository.existsByDomainMatching("gnu.ac.kr")).thenReturn(true);
 	}
 
 	@Test
@@ -112,8 +117,7 @@ class MailAuthServiceImplTest {
 		when(repo.findEmailAndAuthCodeByUserId(userId))
 				.thenReturn(Optional.empty());
 
-		// x@gnu.ac.kr 으로 인증코드 검사 수행 시 MailInvalidException 발생해야 함
-		assertThrows(MailInvalidException.class,
+		assertThrows(MailNotFoundException.class,
 				() -> service.verifyAuthCode(userId, "x@gnu.ac.kr", "0000"));
 	}
 }


### PR DESCRIPTION
## 변경 사항
- AWS EC2/CodeDeploy 배포 workflow를 삭제하지 않고 수동 실행으로 전환
- appspec.yml과 기존 배포 스크립트를 rollback 용도로 보존
- OCI private GHCR ARM64 이미지 workflow와 Dockerfile 추가
- OCI Object Storage S3 호환 설정 및 삭제 경로 보정 반영
- 최신 메일/S3 단위 테스트 반영

## 검증
- 관련 일반 단위 테스트 13개 통과
- Gradle build -x test 통과
- workflow YAML parse 통과
- 전체 20개 중 prod-profile integration 7개는 외부 ignore 설정 부재로 기존과 동일하게 실패

## 안전 경계
- AWS 리소스, EC2, CodeDeploy, S3, DNS, Cloudflare에는 접근하지 않음
- release 병합 시 기존 AWS workflow는 자동 실행되지 않음
- AWS 서버와 rollback 파일은 그대로 유지